### PR TITLE
Add dockerfile for CLI

### DIFF
--- a/docker/rocketpool-cli-dockerfile
+++ b/docker/rocketpool-cli-dockerfile
@@ -26,7 +26,7 @@ RUN go install ./rocketpool-cli
 FROM ubuntu:20.04
 
 # Install OS dependencies
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates curl
 
 # Copy binary
 COPY --from=builder /go/bin/rocketpool-cli /go/bin/rocketpool-cli

--- a/docker/rocketpool-cli-dockerfile
+++ b/docker/rocketpool-cli-dockerfile
@@ -26,7 +26,7 @@ RUN go install ./rocketpool-cli
 FROM ubuntu:20.04
 
 # Install OS dependencies
-RUN apt-get update && apt-get install -y ca-certificates curl
+RUN apt-get update && apt-get install -y ca-certificates curl tar
 
 # Copy binary
 COPY --from=builder /go/bin/rocketpool-cli /go/bin/rocketpool-cli

--- a/docker/rocketpool-cli-dockerfile
+++ b/docker/rocketpool-cli-dockerfile
@@ -1,0 +1,35 @@
+###
+# Builder
+###
+
+
+# Start from golang image
+FROM golang:latest AS builder
+
+# Copy source files
+ADD ./rocketpool-cli /src/rocketpool-cli
+ADD ./shared /src/shared
+ADD ./go.mod /src/go.mod
+ADD ./go.sum /src/go.sum
+
+# Compile & install
+WORKDIR /src
+RUN go install ./rocketpool-cli
+
+
+###
+# Process
+###
+
+
+# Start from ubuntu image
+FROM ubuntu:20.04
+
+# Install OS dependencies
+RUN apt-get update && apt-get install -y ca-certificates
+
+# Copy binary
+COPY --from=builder /go/bin/rocketpool-cli /go/bin/rocketpool-cli
+
+# Container entry point
+ENTRYPOINT ["/go/bin/rocketpool-cli"]


### PR DESCRIPTION
### Description
In additional to a Docker image for the node service and the ETH1 proxy, this PR adds a Dockerfile definition for the CLI. I find running the CLI very help as part of my broader docker-compose services setup (and where I already have dependencies such as PoW and PoS testnets running in established environments).

### What does this do?
I copied the `rocketpool-dockerfile` file and replaced `rocketpool` with `rocketpool-cli`.

I built the image with:
`docker build --file docker/rocketpool-cli-dockerfile --tag rocketpool/cli:latest .`

### How can I test?
<pre>
<code>
docker run --rm -it rocketpool/cli:latest --help


______           _        _    ______           _ 
| ___ \         | |      | |   | ___ \         | |
| |_/ /___   ___| | _____| |_  | |_/ /__   ___ | |
|    // _ \ / __| |/ / _ \ __| |  __/ _ \ / _ \| |
| |\ \ (_) | (__|   <  __/ |_  | | | (_) | (_) | |
\_| \_\___/ \___|_|\_\___|\__| \_|  \___/ \___/|_|

NAME:
   rocketpool - Rocket Pool CLI

USAGE:
   rocketpool-cli [global options] command [command options] [arguments...]

VERSION:
   0.0.1

AUTHORS:
   David Rugendyke <david@rocketpool.net>
   Jake Pospischil <jake@rocketpool.net>

COMMANDS:
   faucet, f    Withdraw from the Rocket Pool faucet
   minipool, m  Manage the node's minipools
   network, e   Manage Rocket Pool network parameters
   node, n      Manage the node
   queue, q     Manage the Rocket Pool deposit queue
   service, s   Manage Rocket Pool service
   wallet, w    Manage the node wallet
   help, h      Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --host address, -o address  Smart node SSH host address
   --user name, -u name        Smart node SSH user name
   --key file, -k file         Smart node SSH key file
   --help, -h                  show help
   --version, -v               print the version

COPYRIGHT:
   (c) 2020 Rocket Pool Pty Ltd
</code>
</pre>

### Known Issues
N/A