### PR TITLE
Issue #60 command line options for deposit

### DIFF
--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -67,7 +67,21 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
                 Name:      "deposit",
                 Aliases:   []string{"d"},
                 Usage:     "Make a deposit and create a minipool",
-                UsageText: "rocketpool node deposit amount",
+                UsageText: "rocketpool node deposit [options]",
+                Flags: []cli.Flag{
+                    cli.Float64Flag{
+                        Name:  "amount, n",
+                        Usage: "Amount of ETH to deposit (0|16|32)",
+                    },
+                    cli.BoolFlag{
+                        Name:  "autofee, a",
+                        Usage: "Use the suggested fee rate",
+                    },
+                    cli.Float64Flag{
+                        Name:  "fee, f",
+                        Usage: "Minimum node commission rate in % [0-20]",
+                    },
+                },
                 Action: func(c *cli.Context) error {
 
                     // Validate args
@@ -126,4 +140,3 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
         },
     })
 }
-

--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -11,10 +11,6 @@ import (
 )
 
 
-// Config
-const SuggestedNodeFeeDelta = -0.01 // 1% below current
-
-
 func nodeDeposit(c *cli.Context) error {
 
     // Get RP client
@@ -69,7 +65,7 @@ func nodeDeposit(c *cli.Context) error {
         return nil
     }
 
-    var minNodeFee float64 = 0
+    var minNodeFee float64
     if !c.IsSet("fee") && !c.IsSet("autofee") {
         // Get network node fees
         nodeFees, err := rp.NodeFee()
@@ -77,27 +73,15 @@ func nodeDeposit(c *cli.Context) error {
             return err
         }
 
-        // Get suggested minimum node fee
-        suggestedMinNodeFee := nodeFees.NodeFee + SuggestedNodeFeeDelta
-        if suggestedMinNodeFee < nodeFees.MinNodeFee {
-            suggestedMinNodeFee = nodeFees.MinNodeFee
-        }
-
         // Prompt for minimum node fee
-        minNodeFee = promptMinNodeFee(nodeFees.NodeFee, suggestedMinNodeFee)
+        minNodeFee = promptMinNodeFee(nodeFees.NodeFee, nodeFees.SuggestedNodeFee)
     } else if c.IsSet("autofee") {
         // Get network node fees
         nodeFees, err := rp.NodeFee()
         if err != nil {
             return err
         }
-
-        // Get suggested minimum node fee
-        suggestedMinNodeFee := nodeFees.NodeFee + SuggestedNodeFeeDelta
-        if suggestedMinNodeFee < nodeFees.MinNodeFee {
-            suggestedMinNodeFee = nodeFees.MinNodeFee
-        }
-        minNodeFee = suggestedMinNodeFee
+        minNodeFee = nodeFees.SuggestedNodeFee
     } else {
         // fee is set
         minNodeFee = c.Float64("fee") / 100
@@ -105,7 +89,6 @@ func nodeDeposit(c *cli.Context) error {
             return fmt.Errorf("Invalid commission rate: %.5f", minNodeFee)
         }
     }
-
     //fmt.Printf("Amount: %.10f ETH, Fee: %.5f %%\n", eth.WeiToEth(amountWei), minNodeFee * 100)
 
     // Make deposit
@@ -118,5 +101,4 @@ func nodeDeposit(c *cli.Context) error {
     fmt.Printf("The node deposit of %.2f ETH was made successfully.\n", eth.WeiToEth(amountWei))
     fmt.Printf("A new minipool was created at %s.\n", response.MinipoolAddress.Hex())
     return nil
-
 }

--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -28,22 +28,25 @@ func nodeDeposit(c *cli.Context) error {
         return err
     }
 
-    // Get deposit amount options
-    amountOptions := []string{
-        "32 ETH (minipool begins staking immediately)",
-        "16 ETH (minipool begins staking after ETH is assigned)",
-    }
-    if status.Trusted {
-        amountOptions = append(amountOptions, "0 ETH  (minipool begins staking after ETH is assigned)")
-    }
-
-    // Prompt for eth amount
     var amount float64
-    selected, _ := cliutils.Select("Please choose an amount of ETH to deposit:", amountOptions)
-    switch selected {
-        case 0: amount = 32
-        case 1: amount = 16
-        case 2: amount = 0
+    if !c.IsSet("amount") {
+        // Get deposit amount options
+        amountOptions := []string{
+            "32 ETH (minipool begins staking immediately)",
+            "16 ETH (minipool begins staking after ETH is assigned)",
+        }
+        if status.Trusted {
+            amountOptions = append(amountOptions, "0 ETH  (minipool begins staking after ETH is assigned)")
+        }
+        // Prompt for eth amount
+        selected, _ := cliutils.Select("Please choose an amount of ETH to deposit:", amountOptions)
+        switch selected {
+            case 0: amount = 32
+            case 1: amount = 16
+            case 2: amount = 0
+        }
+    } else {
+        amount = c.Float64("amount")
     }
     amountWei := eth.EthToWei(amount)
 
@@ -66,20 +69,44 @@ func nodeDeposit(c *cli.Context) error {
         return nil
     }
 
-    // Get network node fees
-    nodeFees, err := rp.NodeFee()
-    if err != nil {
-        return err
+    var minNodeFee float64 = 0
+    if !c.IsSet("fee") && !c.IsSet("autofee") {
+        // Get network node fees
+        nodeFees, err := rp.NodeFee()
+        if err != nil {
+            return err
+        }
+
+        // Get suggested minimum node fee
+        suggestedMinNodeFee := nodeFees.NodeFee + SuggestedNodeFeeDelta
+        if suggestedMinNodeFee < nodeFees.MinNodeFee {
+            suggestedMinNodeFee = nodeFees.MinNodeFee
+        }
+
+        // Prompt for minimum node fee
+        minNodeFee = promptMinNodeFee(nodeFees.NodeFee, suggestedMinNodeFee)
+    } else if c.IsSet("autofee") {
+        // Get network node fees
+        nodeFees, err := rp.NodeFee()
+        if err != nil {
+            return err
+        }
+
+        // Get suggested minimum node fee
+        suggestedMinNodeFee := nodeFees.NodeFee + SuggestedNodeFeeDelta
+        if suggestedMinNodeFee < nodeFees.MinNodeFee {
+            suggestedMinNodeFee = nodeFees.MinNodeFee
+        }
+        minNodeFee = suggestedMinNodeFee
+    } else {
+        // fee is set
+        minNodeFee = c.Float64("fee") / 100
+        if minNodeFee < 0 || minNodeFee > 1 {
+            return fmt.Errorf("Invalid commission rate: %.5f", minNodeFee)
+        }
     }
 
-    // Get suggested minimum node fee
-    suggestedMinNodeFee := nodeFees.NodeFee + SuggestedNodeFeeDelta
-    if suggestedMinNodeFee < nodeFees.MinNodeFee {
-        suggestedMinNodeFee = nodeFees.MinNodeFee
-    }
-
-    // Prompt for minimum node fee
-    minNodeFee := promptMinNodeFee(nodeFees.NodeFee, suggestedMinNodeFee)
+    //fmt.Printf("Amount: %.10f ETH, Fee: %.5f %%\n", eth.WeiToEth(amountWei), minNodeFee * 100)
 
     // Make deposit
     response, err := rp.NodeDeposit(amountWei, minNodeFee)
@@ -93,4 +120,3 @@ func nodeDeposit(c *cli.Context) error {
     return nil
 
 }
-

--- a/rocketpool/api/network/node-fee.go
+++ b/rocketpool/api/network/node-fee.go
@@ -10,6 +10,8 @@ import (
     "github.com/rocket-pool/smartnode/shared/types/api"
 )
 
+// Config
+const SuggestedNodeFeeDelta = -0.01 // 1% below current
 
 func getNodeFee(c *cli.Context) (*api.NodeFeeResponse, error) {
 
@@ -59,8 +61,14 @@ func getNodeFee(c *cli.Context) (*api.NodeFeeResponse, error) {
         return nil, err
     }
 
+    // Suggest minimum node fee
+    suggestedMinNodeFee := response.NodeFee + SuggestedNodeFeeDelta
+    if suggestedMinNodeFee < response.MinNodeFee {
+        suggestedMinNodeFee = response.MinNodeFee
+    }
+    response.SuggestedNodeFee = suggestedMinNodeFee
+
     // Return response
     return &response, nil
 
 }
-

--- a/shared/types/api/network.go
+++ b/shared/types/api/network.go
@@ -2,11 +2,11 @@ package api
 
 
 type NodeFeeResponse struct {
-    Status string           `json:"status"`
-    Error string            `json:"error"`
-    NodeFee float64         `json:"nodeFee"`
-    MinNodeFee float64      `json:"minNodeFee"`
-    TargetNodeFee float64   `json:"targetNodeFee"`
-    MaxNodeFee float64      `json:"maxNodeFee"`
+    Status string            `json:"status"`
+    Error string             `json:"error"`
+    NodeFee float64          `json:"nodeFee"`
+    MinNodeFee float64       `json:"minNodeFee"`
+    TargetNodeFee float64    `json:"targetNodeFee"`
+    MaxNodeFee float64       `json:"maxNodeFee"`
+    SuggestedNodeFee float64 `json:"suggestedNodeFee"`
 }
-


### PR DESCRIPTION
Add command line options for the `rocketpool node deposit` command.  Help message looks like:
```
NAME:
   rocketpool node deposit - Make a deposit and create a minipool

USAGE:
   rocketpool node deposit [options]

OPTIONS:
   --amount value, -n value  Amount of ETH to deposit (0|16|32) (default: 0)
   --autofee, -a             Use the suggested fee rate
   --fee value, -f value     Minimum node commission rate in % [0-20] (default: 0)
```
**Implementation notes:**
These command line options allows non-interactive entry to this command.  Error handling and range checks are from existing logic for interactive input.  the `--autofee` option will override the `--fee` option if they are set together.
