### PR TITLE
Parameterize docker variables

### DIFF
--- a/shared/services/config/config.go
+++ b/shared/services/config/config.go
@@ -16,6 +16,9 @@ type RocketPoolConfig struct {
         StorageAddress string           `yaml:"storageAddress,omitempty"`
     }                                   `yaml:"rocketpool,omitempty"`
     Smartnode struct {
+        ProjectName string              `yaml:"projectName,omitempty"`
+        NetworkName string              `yaml:"networkName,omitempty"`
+        Image string                    `yaml:"image,omitempty"`
         PasswordPath string             `yaml:"passwordPath,omitempty"`
         WalletPath string               `yaml:"walletPath,omitempty"`
         ValidatorKeychainPath string    `yaml:"validatorKeychainPath,omitempty"`
@@ -27,6 +30,7 @@ type RocketPoolConfig struct {
 }
 type Chain struct {
     Provider string                     `yaml:"provider,omitempty"`
+    VolumeName string                   `yaml:"volumeName,omitempty"`
     Client struct {
         Options []ClientOption          `yaml:"options,omitempty"`
         Selected string                 `yaml:"selected,omitempty"`


### PR DESCRIPTION
The following parameters are added in `config.yml` and `settings.yml`:
- `smartnode`
  - `projectName`
  - `networkName`
  - `image`
- `chain`
  - `volumeName`

These fields replace corresponding docker variable names to enable multiple and different configurations of rocketpool to run on the same host machine.

For example, these parameters can be used to run and test a different versions of Rocketpool, Eth1 node, Eth2 node or validators before switching over completely.  This would be a useful feature to have on mainnet to minimise downtime.