### PR TITLE
Add Support for Nimbus

### DIFF
--- a/rocketpool/node/stake-prelaunch-minipools.go
+++ b/rocketpool/node/stake-prelaunch-minipools.go
@@ -27,6 +27,7 @@ import (
 
 // Settings
 const ValidatorContainerSuffix = "_validator"
+const BeaconContainerSuffix = "_eth2"
 var stakePrelaunchMinipoolsInterval, _ = time.ParseDuration("5m")
 var validatorRestartTimeout, _ = time.ParseDuration("5s")
 
@@ -259,11 +260,19 @@ func (t *stakePrelaunchMinipools) stakeMinipool(mp *minipool.Minipool, withdrawa
 // Restart validator container
 func (t *stakePrelaunchMinipools) restartValidator() error {
 
-    // Get validator container name
+	// Get validator container name
+	var containerName string
     if t.cfg.Smartnode.ProjectName == "" {
         return errors.New("Rocket Pool docker project name not set")
-    }
-    containerName := t.cfg.Smartnode.ProjectName + ValidatorContainerSuffix
+	}
+	
+	switch clientType := t.bc.GetClientType(); clientType {
+	case beacon.SplitProcess:
+		containerName = t.cfg.Smartnode.ProjectName + ValidatorContainerSuffix
+	case beacon.SingleProcess:
+		containerName = t.cfg.Smartnode.ProjectName + BeaconContainerSuffix
+		t.log.Printlnf("NOTE: using a single-process type client, so the validator container is the beacon container.")
+	}
 
     // Log
     t.log.Printlnf("Restarting validator container (%s)...", containerName)

--- a/rocketpool/node/stake-prelaunch-minipools.go
+++ b/rocketpool/node/stake-prelaunch-minipools.go
@@ -272,6 +272,8 @@ func (t *stakePrelaunchMinipools) restartValidator() error {
     case beacon.SingleProcess:
         containerName = t.cfg.Smartnode.ProjectName + BeaconContainerSuffix
         t.log.Printlnf("NOTE: using a single-process type client, so the validator container is the beacon container.")
+    default:
+        return fmt.Errorf("Can't restart the validator, unknown client type [%w]", clientType)
     }
 
     // Log

--- a/rocketpool/node/stake-prelaunch-minipools.go
+++ b/rocketpool/node/stake-prelaunch-minipools.go
@@ -260,19 +260,19 @@ func (t *stakePrelaunchMinipools) stakeMinipool(mp *minipool.Minipool, withdrawa
 // Restart validator container
 func (t *stakePrelaunchMinipools) restartValidator() error {
 
-	// Get validator container name
-	var containerName string
+    // Get validator container name
+    var containerName string
     if t.cfg.Smartnode.ProjectName == "" {
         return errors.New("Rocket Pool docker project name not set")
-	}
-	
-	switch clientType := t.bc.GetClientType(); clientType {
-	case beacon.SplitProcess:
-		containerName = t.cfg.Smartnode.ProjectName + ValidatorContainerSuffix
-	case beacon.SingleProcess:
-		containerName = t.cfg.Smartnode.ProjectName + BeaconContainerSuffix
-		t.log.Printlnf("NOTE: using a single-process type client, so the validator container is the beacon container.")
-	}
+    }
+    
+    switch clientType := t.bc.GetClientType(); clientType {
+    case beacon.SplitProcess:
+        containerName = t.cfg.Smartnode.ProjectName + ValidatorContainerSuffix
+    case beacon.SingleProcess:
+        containerName = t.cfg.Smartnode.ProjectName + BeaconContainerSuffix
+        t.log.Printlnf("NOTE: using a single-process type client, so the validator container is the beacon container.")
+    }
 
     // Log
     t.log.Printlnf("Restarting validator container (%s)...", containerName)

--- a/shared/services/beacon/client.go
+++ b/shared/services/beacon/client.go
@@ -51,7 +51,7 @@ const(
 	SplitProcess BeaconClientType = iota
 
 	// This client is a "single process" where the beacon client and
-	// validator run in the same process (or run as separate processes)
+	// validator run in the same process (or run as separate processes
 	// within the same docker container)
 	SingleProcess
 )
@@ -59,7 +59,7 @@ const(
 
 // Beacon client interface
 type Client interface {
-	GetClientType() (BeaconClientType)
+    GetClientType() (BeaconClientType)
     GetSyncStatus() (SyncStatus, error)
     GetEth2Config() (Eth2Config, error)
     GetBeaconHead() (BeaconHead, error)

--- a/shared/services/beacon/client.go
+++ b/shared/services/beacon/client.go
@@ -42,9 +42,24 @@ type ValidatorStatus struct {
     Exists bool
 }
 
+// Beacon client type
+type BeaconClientType int
+const(
+	// This client is a traditional "split process" design, where the beacon
+	// client and validator process are separate and run in different
+	// containers
+	SplitProcess BeaconClientType = iota
+
+	// This client is a "single process" where the beacon client and
+	// validator run in the same process (or run as separate processes)
+	// within the same docker container)
+	SingleProcess
+)
+
 
 // Beacon client interface
 type Client interface {
+	GetClientType() (BeaconClientType)
     GetSyncStatus() (SyncStatus, error)
     GetEth2Config() (Eth2Config, error)
     GetBeaconHead() (BeaconHead, error)

--- a/shared/services/beacon/lighthouse/client.go
+++ b/shared/services/beacon/lighthouse/client.go
@@ -56,6 +56,11 @@ func NewClient(providerAddress string) *Client {
 // Close the client connection
 func (c *Client) Close() {}
 
+// Get the beacon client type
+func (c *Client) GetClientType() (beacon.BeaconClientType) {
+    return beacon.SplitProcess;
+}
+
 
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -1,0 +1,507 @@
+package nimbus
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "net/rpc/jsonrpc"
+    "strconv"
+    "strings"
+    "time"
+
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/rocket-pool/rocketpool-go/types"
+    eth2types "github.com/wealdtech/go-eth2-types/v2"
+    "golang.org/x/sync/errgroup"
+
+    "github.com/rocket-pool/smartnode/shared/services/beacon"
+    "github.com/rocket-pool/smartnode/shared/utils/eth2"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+// Config
+const (
+    RequestUrlFormat   = "%s://%s%s"
+    RequestProtocol    = "http"
+    RequestContentType = "application/json"
+
+    RequestSyncStatusPath          = "/eth/v1/node/syncing"
+    RequestEth2ConfigPath          = "/eth/v1/config/spec"
+    RequestGenesisPath             = "/eth/v1/beacon/genesis"
+    RequestFinalityCheckpointsPath = "/eth/v1/beacon/states/%s/finality_checkpoints"
+    RequestForkPath                = "/eth/v1/beacon/states/%s/fork"
+    RequestValidatorsPath          = "/eth/v1/beacon/states/%s/validators"
+    RequestVoluntaryExitPath       = "/eth/v1/beacon/pool/voluntary_exits"
+
+    MaxRequestValidatorsCount = 600
+)
+
+// Nimbus client
+type Client struct {
+    client *rpc.Client
+}
+
+// Create new Nimbus client
+func NewClient(providerAddress string) (*Client, error) {
+    
+    // Start the RPC connection
+    client, err := jsonrpc.Dial("tcp", providerAddress)
+    if err != nil {
+        return nil, fmt.Errorf("Could not connect to Nimbus RPC server: %s", err)
+    }
+    return &Client{
+        client: client
+    }, nil
+}
+
+// Close the client connection
+func (c *Client) Close() {
+    c.client.Close()
+}
+
+// Get the node's sync status
+func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
+
+    // Get sync status
+    syncStatus, err := c.getSyncStatus()
+    if err != nil {
+        return beacon.SyncStatus{}, err
+    }
+
+    // Return response
+    isSyncing := (syncStatus.Data.SyncDistance != 0)
+    return beacon.SyncStatus{
+        Syncing: isSyncing,
+    }, nil
+
+}
+
+// Get the eth2 config
+func (c *Client) GetEth2Config() (beacon.Eth2Config, error) {
+
+    // Data
+    var wg errgroup.Group
+    var eth2Config Eth2ConfigResponse
+    var genesis GenesisResponse
+
+    // Get eth2 config
+    wg.Go(func() error {
+        var err error
+        eth2Config, err = c.getEth2Config()
+        return err
+    })
+
+    // Get genesis
+    wg.Go(func() error {
+        var err error
+        genesis, err = c.getGenesis()
+        return err
+    })
+
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return beacon.Eth2Config{}, err
+    }
+
+    // Return response
+    return beacon.Eth2Config{
+        GenesisForkVersion:    genesis.Data.GenesisForkVersion,
+        GenesisValidatorsRoot: genesis.Data.GenesisValidatorsRoot,
+        GenesisEpoch:          0,
+        GenesisTime:           uint64(genesis.Data.GenesisTime),
+        SecondsPerEpoch:       uint64(eth2Config.Data.SecondsPerSlot * eth2Config.Data.SlotsPerEpoch),
+    }, nil
+
+}
+
+// Get the beacon head
+func (c *Client) GetBeaconHead() (beacon.BeaconHead, error) {
+
+    // Data
+    var wg errgroup.Group
+    var eth2Config beacon.Eth2Config
+    var finalityCheckpoints FinalityCheckpointsResponse
+
+    // Get eth2 config
+    wg.Go(func() error {
+        var err error
+        eth2Config, err = c.GetEth2Config()
+        return err
+    })
+
+    // Get finality checkpoints
+    wg.Go(func() error {
+        var err error
+        finalityCheckpoints, err = c.getFinalityCheckpoints("head")
+        return err
+    })
+
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return beacon.BeaconHead{}, err
+    }
+
+    // Return response
+    return beacon.BeaconHead{
+        Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
+        FinalizedEpoch:         uint64(finalityCheckpoints.Data.Finalized.Epoch),
+        JustifiedEpoch:         uint64(finalityCheckpoints.Data.CurrentJustified.Epoch),
+        PreviousJustifiedEpoch: uint64(finalityCheckpoints.Data.PreviousJustified.Epoch),
+    }, nil
+
+}
+
+// Get a validator's status
+func (c *Client) GetValidatorStatus(pubkey types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (beacon.ValidatorStatus, error) {
+
+    // Get validator
+    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
+    if err != nil {
+        return beacon.ValidatorStatus{}, err
+    }
+    if len(validators.Data) == 0 {
+        return beacon.ValidatorStatus{}, nil
+    }
+    validator := validators.Data[0]
+
+    // Return response
+    return beacon.ValidatorStatus{
+        Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+        WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+        Balance:                    uint64(validator.Balance),
+        EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+        Slashed:                    validator.Validator.Slashed,
+        ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+        ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+        ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+        WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+        Exists:                     true,
+    }, nil
+
+}
+
+// Get multiple validators' statuses
+func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (map[types.ValidatorPubkey]beacon.ValidatorStatus, error) {
+
+    // Get validators
+    validators, err := c.getValidatorsByOpts(pubkeys, opts)
+    if err != nil {
+        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
+    }
+
+    // Build validator status map
+    statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
+    for _, validator := range validators.Data {
+
+        // Get validator pubkey
+        pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
+
+        // Add status
+        statuses[pubkey] = beacon.ValidatorStatus{
+            Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+            WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+            Balance:                    uint64(validator.Balance),
+            EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+            Slashed:                    validator.Validator.Slashed,
+            ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+            ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+            ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+            WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+            Exists:                     true,
+        }
+
+    }
+
+    // Return
+    return statuses, nil
+
+}
+
+// Get a validator's index
+func (c *Client) GetValidatorIndex(pubkey types.ValidatorPubkey) (uint64, error) {
+
+    // Get validator
+    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
+    if err != nil {
+        return 0, err
+    }
+    if len(validators.Data) == 0 {
+        return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
+    }
+    validator := validators.Data[0]
+
+    // Return validator index
+    return uint64(validator.Index), nil
+
+}
+
+// Get domain data for a domain type at a given epoch
+func (c *Client) GetDomainData(domainType []byte, epoch uint64) ([]byte, error) {
+
+    // Data
+    var wg errgroup.Group
+    var genesis GenesisResponse
+    var fork ForkResponse
+
+    // Get genesis
+    wg.Go(func() error {
+        var err error
+        genesis, err = c.getGenesis()
+        return err
+    })
+
+    // Get fork
+    wg.Go(func() error {
+        var err error
+        fork, err = c.getFork("head")
+        return err
+    })
+
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return []byte{}, err
+    }
+
+    // Get fork version
+    var forkVersion []byte
+    if epoch < uint64(fork.Data.Epoch) {
+        forkVersion = fork.Data.PreviousVersion
+    } else {
+        forkVersion = fork.Data.CurrentVersion
+    }
+
+    // Compute & return domain
+    var dt [4]byte
+    copy(dt[:], domainType[:])
+    return eth2types.Domain(dt, forkVersion, genesis.Data.GenesisValidatorsRoot), nil
+
+}
+
+// Perform a voluntary exit on a validator
+func (c *Client) ExitValidator(validatorIndex, epoch uint64, signature types.ValidatorSignature) error {
+    return c.postVoluntaryExit(VoluntaryExitRequest{
+        Message: VoluntaryExitMessage{
+            Epoch:          uinteger(epoch),
+            ValidatorIndex: uinteger(validatorIndex),
+        },
+        Signature: signature.Bytes(),
+    })
+}
+
+// Get sync status
+func (c *Client) getSyncStatus() (SyncStatusResponse, error) {
+    responseBody, status, err := c.getRequest(RequestSyncStatusPath)
+    if err != nil {
+        return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
+    } else if status != http.StatusOK {
+        return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var syncStatus SyncStatusResponse
+    if err := json.Unmarshal(responseBody, &syncStatus); err != nil {
+        return SyncStatusResponse{}, fmt.Errorf("Could not decode node sync status: %w", err)
+    }
+    return syncStatus, nil
+}
+
+// Get the eth2 config
+func (c *Client) getEth2Config() (Eth2ConfigResponse, error) {
+    responseBody, status, err := c.getRequest(RequestEth2ConfigPath)
+    if err != nil {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
+    } else if status != http.StatusOK {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var eth2Config Eth2ConfigResponse
+    if err := json.Unmarshal(responseBody, &eth2Config); err != nil {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not decode eth2 config: %w", err)
+    }
+    return eth2Config, nil
+}
+
+// Get genesis information
+func (c *Client) getGenesis() (GenesisResponse, error) {
+    responseBody, status, err := c.getRequest(RequestGenesisPath)
+    if err != nil {
+        return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
+    } else if status != http.StatusOK {
+        return GenesisResponse{}, fmt.Errorf("Could not get genesis data: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var genesis GenesisResponse
+    if err := json.Unmarshal(responseBody, &genesis); err != nil {
+        return GenesisResponse{}, fmt.Errorf("Could not decode genesis: %w", err)
+    }
+    return genesis, nil
+}
+
+// Get finality checkpoints
+func (c *Client) getFinalityCheckpoints(stateId string) (FinalityCheckpointsResponse, error) {
+    responseBody, status, err := c.getRequest(fmt.Sprintf(RequestFinalityCheckpointsPath, stateId))
+    if err != nil {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
+    } else if status != http.StatusOK {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var finalityCheckpoints FinalityCheckpointsResponse
+    if err := json.Unmarshal(responseBody, &finalityCheckpoints); err != nil {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not decode finality checkpoints: %w", err)
+    }
+    return finalityCheckpoints, nil
+}
+
+// Get fork
+func (c *Client) getFork(stateId string) (ForkResponse, error) {
+    responseBody, status, err := c.getRequest(fmt.Sprintf(RequestForkPath, stateId))
+    if err != nil {
+        return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
+    } else if status != http.StatusOK {
+        return ForkResponse{}, fmt.Errorf("Could not get fork data: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var fork ForkResponse
+    if err := json.Unmarshal(responseBody, &fork); err != nil {
+        return ForkResponse{}, fmt.Errorf("Could not decode fork data: %w", err)
+    }
+    return fork, nil
+}
+
+// Get validators
+func (c *Client) getValidators(stateId string, pubkeys []string) (ValidatorsResponse, error) {
+    var query string
+    if len(pubkeys) > 0 {
+        query = fmt.Sprintf("?id=%s", strings.Join(pubkeys, ","))
+    }
+    responseBody, status, err := c.getRequest(fmt.Sprintf(RequestValidatorsPath, stateId) + query)
+    if err != nil {
+        return ValidatorsResponse{}, fmt.Errorf("Could not get validators: %w", err)
+    } else if status != http.StatusOK {
+        return ValidatorsResponse{}, fmt.Errorf("Could not get validators: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var validators ValidatorsResponse
+    if err := json.Unmarshal(responseBody, &validators); err != nil {
+        return ValidatorsResponse{}, fmt.Errorf("Could not decode validators: %w", err)
+    }
+    return validators, nil
+}
+
+// Get validators by pubkeys and status options
+func (c *Client) getValidatorsByOpts(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (ValidatorsResponse, error) {
+
+    // Get state ID
+    var stateId string
+    if opts == nil {
+        stateId = "head"
+    } else {
+
+        // Get eth2 config
+        eth2Config, err := c.getEth2Config()
+        if err != nil {
+            return ValidatorsResponse{}, err
+        }
+
+        // Get slot nuimber
+        slot := opts.Epoch * uint64(eth2Config.Data.SlotsPerEpoch)
+        stateId = strconv.FormatInt(int64(slot), 10)
+
+    }
+
+    // Get validators
+    if len(pubkeys) <= MaxRequestValidatorsCount {
+
+        // Get validator pubkeys
+        pubkeysHex := make([]string, len(pubkeys))
+        for ki, pubkey := range pubkeys {
+            pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
+        }
+
+        // Get & return validators
+        return c.getValidators(stateId, pubkeysHex)
+
+    } else {
+
+        // Get all validators
+        validators, err := c.getValidators(stateId, []string{})
+        if err != nil {
+            return ValidatorsResponse{}, err
+        }
+
+        // Filter validator set by pubkeys and return
+        response := ValidatorsResponse{}
+        for _, validator := range validators.Data {
+            var found bool
+            for _, pubkey := range pubkeys {
+                if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
+                    found = true
+                    break
+                }
+            }
+            if !found {
+                continue
+            }
+            response.Data = append(response.Data, validator)
+        }
+        return response, nil
+
+    }
+
+}
+
+// Send voluntary exit request
+func (c *Client) postVoluntaryExit(request VoluntaryExitRequest) error {
+    responseBody, status, err := c.postRequest(RequestVoluntaryExitPath, request)
+    if err != nil {
+        return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
+    } else if status != http.StatusOK {
+        return fmt.Errorf("Could not broadcast exit for validator at index %d: HTTP status %d; response body: '%s'", request.Message.ValidatorIndex, status, string(responseBody))
+    }
+    return nil
+}
+
+// Make a GET request to the beacon node
+func (c *Client) getRequest(requestPath string) ([]byte, int, error) {
+
+    // Send request
+    response, err := http.Get(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath))
+    if err != nil {
+        return []byte{}, 0, err
+    }
+    defer response.Body.Close()
+
+    // Get response
+    body, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+        return []byte{}, 0, err
+    }
+
+    // Return
+    return body, response.StatusCode, nil
+
+}
+
+// Make a POST request to the beacon node
+func (c *Client) postRequest(requestPath string, requestBody interface{}) ([]byte, int, error) {
+
+    // Get request body
+    requestBodyBytes, err := json.Marshal(requestBody)
+    if err != nil {
+        return []byte{}, 0, err
+    }
+    requestBodyReader := bytes.NewReader(requestBodyBytes)
+
+    // Send request
+    response, err := http.Post(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath), RequestContentType, requestBodyReader)
+    if err != nil {
+        return []byte{}, 0, err
+    }
+    defer response.Body.Close()
+
+    // Get response
+    body, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+        return []byte{}, 0, err
+    }
+
+    // Return
+    return body, response.StatusCode, nil
+
+}

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -1,414 +1,414 @@
 package nimbus
 
 import (
-	"bytes"
-	"fmt"
-	"strconv"
-	"time"
+    "bytes"
+    "fmt"
+    "strconv"
+    "time"
 
-	"github.com/ethereum/go-ethereum/common"
-	rpc "github.com/ethereum/go-ethereum/rpc"
-	"github.com/rocket-pool/rocketpool-go/types"
-	eth2types "github.com/wealdtech/go-eth2-types/v2"
-	"golang.org/x/sync/errgroup"
+    "github.com/ethereum/go-ethereum/common"
+    rpc "github.com/ethereum/go-ethereum/rpc"
+    "github.com/rocket-pool/rocketpool-go/types"
+    eth2types "github.com/wealdtech/go-eth2-types/v2"
+    "golang.org/x/sync/errgroup"
 
-	"github.com/rocket-pool/smartnode/shared/services/beacon"
-	"github.com/rocket-pool/smartnode/shared/utils/eth2"
-	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+    "github.com/rocket-pool/smartnode/shared/services/beacon"
+    "github.com/rocket-pool/smartnode/shared/utils/eth2"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Config
 const (
-	RequestSyncStatusMethod          = "get_v1_node_syncing"
-	RequestEth2ConfigMethod          = "get_v1_config_spec"
-	RequestGenesisMethod             = "get_v1_beacon_genesis"
-	RequestFinalityCheckpointsMethod = "get_v1_beacon_states_finality_checkpoints"
-	RequestForkMethod                = "get_v1_beacon_states_fork"
-	RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators_validatorId"
-	RequestVoluntaryExitMethod       = "get_v1_beacon_pool_voluntary_exits"
+    RequestSyncStatusMethod          = "get_v1_node_syncing"
+    RequestEth2ConfigMethod          = "get_v1_config_spec"
+    RequestGenesisMethod             = "get_v1_beacon_genesis"
+    RequestFinalityCheckpointsMethod = "get_v1_beacon_states_finality_checkpoints"
+    RequestForkMethod                = "get_v1_beacon_states_fork"
+    RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators_validatorId"
+    RequestVoluntaryExitMethod       = "get_v1_beacon_pool_voluntary_exits"
 
-	MaxRequestValidatorsCount = 600
+    MaxRequestValidatorsCount = 600
 )
 
 // Nimbus client
 type Client struct {
-	client *rpc.Client
+    client *rpc.Client
 }
 
 // Create new Nimbus client
 func NewClient(providerAddress string) (*Client, error) {
 
-	// Start the RPC connection
-	client, err := rpc.DialHTTP("http://" + providerAddress)
-	if err != nil {
-		return nil, fmt.Errorf("Could not connect to Nimbus RPC server: %s", err)
-	}
-	return &Client{
-		client: client,
-	}, nil
+    // Start the RPC connection
+    client, err := rpc.DialHTTP("http://" + providerAddress)
+    if err != nil {
+        return nil, fmt.Errorf("Could not connect to Nimbus RPC server: %s", err)
+    }
+    return &Client{
+        client: client,
+    }, nil
 }
 
 // Close the client connection
 func (c *Client) Close() {
-	c.client.Close()
+    c.client.Close()
 }
 
 // Get the beacon client type
 
 func (c *Client) GetClientType() beacon.BeaconClientType {
-	return beacon.SingleProcess
+    return beacon.SingleProcess
 }
 
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
 
-	// Get sync status
-	syncStatus, err := c.getSyncStatus()
-	if err != nil {
-		return beacon.SyncStatus{}, err
-	}
+    // Get sync status
+    syncStatus, err := c.getSyncStatus()
+    if err != nil {
+        return beacon.SyncStatus{}, err
+    }
 
-	// Return response
-	isSyncing := (syncStatus.SyncDistance != 0)
-	return beacon.SyncStatus{
-		Syncing: isSyncing,
-	}, nil
+    // Return response
+    isSyncing := (syncStatus.SyncDistance != 0)
+    return beacon.SyncStatus{
+        Syncing: isSyncing,
+    }, nil
 
 }
 
 // Get the eth2 config
 func (c *Client) GetEth2Config() (beacon.Eth2Config, error) {
 
-	// Data
-	var wg errgroup.Group
-	var eth2Config Eth2ConfigResponse
-	var genesis GenesisResponse
+    // Data
+    var wg errgroup.Group
+    var eth2Config Eth2ConfigResponse
+    var genesis GenesisResponse
 
-	// Get eth2 config
-	wg.Go(func() error {
-		var err error
-		eth2Config, err = c.getEth2Config()
-		return err
-	})
+    // Get eth2 config
+    wg.Go(func() error {
+        var err error
+        eth2Config, err = c.getEth2Config()
+        return err
+    })
 
-	// Get genesis
-	wg.Go(func() error {
-		var err error
-		genesis, err = c.getGenesis()
-		return err
-	})
+    // Get genesis
+    wg.Go(func() error {
+        var err error
+        genesis, err = c.getGenesis()
+        return err
+    })
 
-	// Wait for data
-	if err := wg.Wait(); err != nil {
-		return beacon.Eth2Config{}, err
-	}
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return beacon.Eth2Config{}, err
+    }
 
-	// Return response
-	return beacon.Eth2Config{
-		GenesisForkVersion:    genesis.GenesisForkVersion,
-		GenesisValidatorsRoot: genesis.GenesisValidatorsRoot,
-		GenesisEpoch:          0,
-		GenesisTime:           uint64(genesis.GenesisTime),
-		SecondsPerEpoch:       uint64(eth2Config.SecondsPerSlot * eth2Config.SlotsPerEpoch),
-	}, nil
+    // Return response
+    return beacon.Eth2Config{
+        GenesisForkVersion:    genesis.GenesisForkVersion,
+        GenesisValidatorsRoot: genesis.GenesisValidatorsRoot,
+        GenesisEpoch:          0,
+        GenesisTime:           uint64(genesis.GenesisTime),
+        SecondsPerEpoch:       uint64(eth2Config.SecondsPerSlot * eth2Config.SlotsPerEpoch),
+    }, nil
 
 }
 
 // Get the beacon head
 func (c *Client) GetBeaconHead() (beacon.BeaconHead, error) {
 
-	// Data
-	var wg errgroup.Group
-	var eth2Config beacon.Eth2Config
-	var finalityCheckpoints FinalityCheckpointsResponse
+    // Data
+    var wg errgroup.Group
+    var eth2Config beacon.Eth2Config
+    var finalityCheckpoints FinalityCheckpointsResponse
 
-	// Get eth2 config
-	wg.Go(func() error {
-		var err error
-		eth2Config, err = c.GetEth2Config()
-		return err
-	})
+    // Get eth2 config
+    wg.Go(func() error {
+        var err error
+        eth2Config, err = c.GetEth2Config()
+        return err
+    })
 
-	// Get finality checkpoints
-	wg.Go(func() error {
-		var err error
-		finalityCheckpoints, err = c.getFinalityCheckpoints("head")
-		return err
-	})
+    // Get finality checkpoints
+    wg.Go(func() error {
+        var err error
+        finalityCheckpoints, err = c.getFinalityCheckpoints("head")
+        return err
+    })
 
-	// Wait for data
-	if err := wg.Wait(); err != nil {
-		return beacon.BeaconHead{}, err
-	}
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return beacon.BeaconHead{}, err
+    }
 
-	// Return response
-	return beacon.BeaconHead{
-		Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
-		FinalizedEpoch:         uint64(finalityCheckpoints.Finalized.Epoch),
-		JustifiedEpoch:         uint64(finalityCheckpoints.CurrentJustified.Epoch),
-		PreviousJustifiedEpoch: uint64(finalityCheckpoints.PreviousJustified.Epoch),
-	}, nil
+    // Return response
+    return beacon.BeaconHead{
+        Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
+        FinalizedEpoch:         uint64(finalityCheckpoints.Finalized.Epoch),
+        JustifiedEpoch:         uint64(finalityCheckpoints.CurrentJustified.Epoch),
+        PreviousJustifiedEpoch: uint64(finalityCheckpoints.PreviousJustified.Epoch),
+    }, nil
 
 }
 
 // Get a validator's status
 func (c *Client) GetValidatorStatus(pubkey types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (beacon.ValidatorStatus, error) {
 
-	// Get validator
-	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
-	if err != nil {
-		return beacon.ValidatorStatus{}, err
-	}
-	if len(validators) == 0 {
-		return beacon.ValidatorStatus{}, nil
-	}
-	validator := validators[0]
+    // Get validator
+    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
+    if err != nil {
+        return beacon.ValidatorStatus{}, err
+    }
+    if len(validators) == 0 {
+        return beacon.ValidatorStatus{}, nil
+    }
+    validator := validators[0]
 
-	// Return response
-	return beacon.ValidatorStatus{
-		Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
-		WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
-		Balance:                    uint64(validator.Balance),
-		EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
-		Slashed:                    validator.Validator.Slashed,
-		ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-		ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-		ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-		WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-		Exists:                     true,
-	}, nil
+    // Return response
+    return beacon.ValidatorStatus{
+        Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+        WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+        Balance:                    uint64(validator.Balance),
+        EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+        Slashed:                    validator.Validator.Slashed,
+        ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+        ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+        ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+        WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+        Exists:                     true,
+    }, nil
 
 }
 
 // Get multiple validators' statuses
 func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (map[types.ValidatorPubkey]beacon.ValidatorStatus, error) {
 
-	// Get validators
-	validators, err := c.getValidatorsByOpts(pubkeys, opts)
-	if err != nil {
-		return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
-	}
+    // Get validators
+    validators, err := c.getValidatorsByOpts(pubkeys, opts)
+    if err != nil {
+        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
+    }
 
-	// Build validator status map
-	statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
-	for _, validator := range validators {
+    // Build validator status map
+    statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
+    for _, validator := range validators {
 
-		// Get validator pubkey
-		pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
+        // Get validator pubkey
+        pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
 
-		// Add status
-		statuses[pubkey] = beacon.ValidatorStatus{
-			Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
-			WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
-			Balance:                    uint64(validator.Balance),
-			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
-			Slashed:                    validator.Validator.Slashed,
-			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-			Exists:                     true,
-		}
+        // Add status
+        statuses[pubkey] = beacon.ValidatorStatus{
+            Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+            WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+            Balance:                    uint64(validator.Balance),
+            EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+            Slashed:                    validator.Validator.Slashed,
+            ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+            ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+            ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+            WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+            Exists:                     true,
+        }
 
-	}
+    }
 
-	// Return
-	return statuses, nil
+    // Return
+    return statuses, nil
 
 }
 
 // Get a validator's index
 func (c *Client) GetValidatorIndex(pubkey types.ValidatorPubkey) (uint64, error) {
 
-	// Get validator
-	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
-	if err != nil {
-		return 0, err
-	}
-	if len(validators) == 0 {
-		return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
-	}
-	validator := validators[0]
+    // Get validator
+    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
+    if err != nil {
+        return 0, err
+    }
+    if len(validators) == 0 {
+        return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
+    }
+    validator := validators[0]
 
-	// Return validator index
-	return uint64(validator.Index), nil
+    // Return validator index
+    return uint64(validator.Index), nil
 
 }
 
 // Get domain data for a domain type at a given epoch
 func (c *Client) GetDomainData(domainType []byte, epoch uint64) ([]byte, error) {
 
-	// Data
-	var wg errgroup.Group
-	var genesis GenesisResponse
-	var fork ForkResponse
+    // Data
+    var wg errgroup.Group
+    var genesis GenesisResponse
+    var fork ForkResponse
 
-	// Get genesis
-	wg.Go(func() error {
-		var err error
-		genesis, err = c.getGenesis()
-		return err
-	})
+    // Get genesis
+    wg.Go(func() error {
+        var err error
+        genesis, err = c.getGenesis()
+        return err
+    })
 
-	// Get fork
-	wg.Go(func() error {
-		var err error
-		fork, err = c.getFork("head")
-		return err
-	})
+    // Get fork
+    wg.Go(func() error {
+        var err error
+        fork, err = c.getFork("head")
+        return err
+    })
 
-	// Wait for data
-	if err := wg.Wait(); err != nil {
-		return []byte{}, err
-	}
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return []byte{}, err
+    }
 
-	// Get fork version
-	var forkVersion []byte
-	if epoch < uint64(fork.Epoch) {
-		forkVersion = fork.PreviousVersion
-	} else {
-		forkVersion = fork.CurrentVersion
-	}
+    // Get fork version
+    var forkVersion []byte
+    if epoch < uint64(fork.Epoch) {
+        forkVersion = fork.PreviousVersion
+    } else {
+        forkVersion = fork.CurrentVersion
+    }
 
-	// Compute & return domain
-	var dt [4]byte
-	copy(dt[:], domainType[:])
-	return eth2types.Domain(dt, forkVersion, genesis.GenesisValidatorsRoot), nil
+    // Compute & return domain
+    var dt [4]byte
+    copy(dt[:], domainType[:])
+    return eth2types.Domain(dt, forkVersion, genesis.GenesisValidatorsRoot), nil
 
 }
 
 // Perform a voluntary exit on a validator
 func (c *Client) ExitValidator(validatorIndex, epoch uint64, signature types.ValidatorSignature) error {
-	return c.postVoluntaryExit(VoluntaryExitRequest{
-		Message: VoluntaryExitMessage{
-			Epoch:          epoch,
-			ValidatorIndex: validatorIndex,
-		},
-		Signature: signature.Bytes(),
-	})
+    return c.postVoluntaryExit(VoluntaryExitRequest{
+        Message: VoluntaryExitMessage{
+            Epoch:          epoch,
+            ValidatorIndex: validatorIndex,
+        },
+        Signature: signature.Bytes(),
+    })
 }
 
 // Get sync status
 func (c *Client) getSyncStatus() (SyncStatusResponse, error) {
-	var syncStatus SyncStatusResponse
-	if err := c.client.Call(&syncStatus, RequestSyncStatusMethod); err != nil {
-		return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
-	}
-	return syncStatus, nil
+    var syncStatus SyncStatusResponse
+    if err := c.client.Call(&syncStatus, RequestSyncStatusMethod); err != nil {
+        return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
+    }
+    return syncStatus, nil
 }
 
 // Get the eth2 config
 func (c *Client) getEth2Config() (Eth2ConfigResponse, error) {
-	var eth2Config Eth2ConfigResponse
-	if err := c.client.Call(&eth2Config, RequestEth2ConfigMethod); err != nil {
-		return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
-	}
-	return eth2Config, nil
+    var eth2Config Eth2ConfigResponse
+    if err := c.client.Call(&eth2Config, RequestEth2ConfigMethod); err != nil {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
+    }
+    return eth2Config, nil
 }
 
 // Get genesis information
 func (c *Client) getGenesis() (GenesisResponse, error) {
-	var genesis GenesisResponse
-	if err := c.client.Call(&genesis, RequestGenesisMethod); err != nil {
-		return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
-	}
-	return genesis, nil
+    var genesis GenesisResponse
+    if err := c.client.Call(&genesis, RequestGenesisMethod); err != nil {
+        return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
+    }
+    return genesis, nil
 }
 
 // Get finality checkpoints
 func (c *Client) getFinalityCheckpoints(stateId string) (FinalityCheckpointsResponse, error) {
-	var finalityCheckpoints FinalityCheckpointsResponse
-	if err := c.client.Call(&finalityCheckpoints, RequestFinalityCheckpointsMethod, stateId); err != nil {
-		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
-	}
-	return finalityCheckpoints, nil
+    var finalityCheckpoints FinalityCheckpointsResponse
+    if err := c.client.Call(&finalityCheckpoints, RequestFinalityCheckpointsMethod, stateId); err != nil {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
+    }
+    return finalityCheckpoints, nil
 }
 
 // Get fork
 func (c *Client) getFork(stateId string) (ForkResponse, error) {
-	var fork ForkResponse
-	if err := c.client.Call(&fork, RequestForkMethod, stateId); err != nil {
-		return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
-	}
-	return fork, nil
+    var fork ForkResponse
+    if err := c.client.Call(&fork, RequestForkMethod, stateId); err != nil {
+        return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
+    }
+    return fork, nil
 }
 
 // Get validators
 func (c *Client) getValidators(stateId string, pubkeys []string) ([]Validator, error) {
-	var validators []Validator
-	params := append([]string{stateId}, pubkeys...)
-	if err := c.client.Call(&validators, RequestValidatorsMethod, params); err != nil {
-		return []Validator{}, fmt.Errorf("Could not get validators: %w", err)
-	}
-	return validators, nil
+    var validators []Validator
+    params := append([]string{stateId}, pubkeys...)
+    if err := c.client.Call(&validators, RequestValidatorsMethod, params); err != nil {
+        return []Validator{}, fmt.Errorf("Could not get validators: %w", err)
+    }
+    return validators, nil
 }
 
 // Get validators by pubkeys and status options
 func (c *Client) getValidatorsByOpts(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) ([]Validator, error) {
 
-	// Get state ID
-	var stateId string
-	if opts == nil {
-		stateId = "head"
-	} else {
+    // Get state ID
+    var stateId string
+    if opts == nil {
+        stateId = "head"
+    } else {
 
-		// Get eth2 config
-		eth2Config, err := c.getEth2Config()
-		if err != nil {
-			return []Validator{}, err
-		}
+        // Get eth2 config
+        eth2Config, err := c.getEth2Config()
+        if err != nil {
+            return []Validator{}, err
+        }
 
-		// Get slot nuimber
-		slot := opts.Epoch * uint64(eth2Config.SlotsPerEpoch)
-		stateId = strconv.FormatInt(int64(slot), 10)
+        // Get slot nuimber
+        slot := opts.Epoch * uint64(eth2Config.SlotsPerEpoch)
+        stateId = strconv.FormatInt(int64(slot), 10)
 
-	}
+    }
 
-	// Get validators
-	if len(pubkeys) <= MaxRequestValidatorsCount {
+    // Get validators
+    if len(pubkeys) <= MaxRequestValidatorsCount {
 
-		// Get validator pubkeys
-		pubkeysHex := make([]string, len(pubkeys))
-		for ki, pubkey := range pubkeys {
-			pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
-		}
+        // Get validator pubkeys
+        pubkeysHex := make([]string, len(pubkeys))
+        for ki, pubkey := range pubkeys {
+            pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
+        }
 
-		// Get & return validators
-		return c.getValidators(stateId, pubkeysHex)
+        // Get & return validators
+        return c.getValidators(stateId, pubkeysHex)
 
-	} else {
+    } else {
 
-		// Get all validators
-		validators, err := c.getValidators(stateId, []string{})
-		if err != nil {
-			return []Validator{}, err
-		}
+        // Get all validators
+        validators, err := c.getValidators(stateId, []string{})
+        if err != nil {
+            return []Validator{}, err
+        }
 
-		// Filter validator set by pubkeys and return
-		response := []Validator{}
-		for _, validator := range validators {
-			var found bool
-			for _, pubkey := range pubkeys {
-				if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
-			response = append(response, validator)
-		}
-		return response, nil
+        // Filter validator set by pubkeys and return
+        response := []Validator{}
+        for _, validator := range validators {
+            var found bool
+            for _, pubkey := range pubkeys {
+                if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
+                    found = true
+                    break
+                }
+            }
+            if !found {
+                continue
+            }
+            response = append(response, validator)
+        }
+        return response, nil
 
-	}
+    }
 
 }
 
 // Send voluntary exit request
 func (c *Client) postVoluntaryExit(request VoluntaryExitRequest) error {
-	if err := c.client.Call(nil, RequestVoluntaryExitMethod, request); err != nil {
-		return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
-	}
-	return nil
+    if err := c.client.Call(nil, RequestVoluntaryExitMethod, request); err != nil {
+        return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
+    }
+    return nil
 }

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -25,7 +25,7 @@ const (
     RequestFinalityCheckpointsMethod = "get_v1_beacon_states_finality_checkpoints"
     RequestForkMethod                = "get_v1_beacon_states_fork"
     RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators"
-    RequestVoluntaryExitMethod       = "get_v1_beacon_pool_voluntary_exits"
+    RequestVoluntaryExitMethod       = "post_v1_beacon_pool_voluntary_exits"
 
     MaxRequestValidatorsCount = 600
 )

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -53,6 +53,11 @@ func (c *Client) Close() {
     c.client.Close()
 }
 
+// Get the beacon client type
+func (c *Client) GetClientType() (beacon.BeaconClientType) {
+    return beacon.SplitProcess;
+}
+
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
 

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -336,7 +336,6 @@ func (c *Client) getFork(stateId string) (ForkResponse, error) {
 // Get validators
 func (c *Client) getValidators(stateId string, pubkeys []string) ([]Validator, error) {
     var validators []Validator
-    // params := []interface{}{stateId, pubkeys}
     if err := c.client.Call(&validators, RequestValidatorsMethod, stateId, pubkeys); err != nil {
         return []Validator{}, fmt.Errorf("Could not get validators: %w", err)
     }

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -1,413 +1,413 @@
 package nimbus
 
 import (
-    "bytes"
-    "fmt"
-    "strconv"
-    "time"
+	"bytes"
+	"fmt"
+	"strconv"
+	"time"
 
-    rpc "github.com/ethereum/go-ethereum/rpc"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/rocket-pool/rocketpool-go/types"
-    eth2types "github.com/wealdtech/go-eth2-types/v2"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/common"
+	rpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/rocket-pool/rocketpool-go/types"
+	eth2types "github.com/wealdtech/go-eth2-types/v2"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/smartnode/shared/services/beacon"
-    "github.com/rocket-pool/smartnode/shared/utils/eth2"
-    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
+	"github.com/rocket-pool/smartnode/shared/utils/eth2"
+	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Config
 const (
-    RequestSyncStatusMethod          = "get_v1_node_syncing"
-    RequestEth2ConfigMethod          = "get_v1_config_spec"
-    RequestGenesisMethod             = "get_v1_beacon_genesis"
-    RequestFinalityCheckpointsMethod = "get_v1_beacon_states_finality_checkpoints"
-    RequestForkMethod                = "get_v1_beacon_states_fork"
-    RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators_validatorId"
-    RequestVoluntaryExitMethod       = "get_v1_beacon_pool_voluntary_exits"
+	RequestSyncStatusMethod          = "get_v1_node_syncing"
+	RequestEth2ConfigMethod          = "get_v1_config_spec"
+	RequestGenesisMethod             = "get_v1_beacon_genesis"
+	RequestFinalityCheckpointsMethod = "get_v1_beacon_states_finality_checkpoints"
+	RequestForkMethod                = "get_v1_beacon_states_fork"
+	RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators_validatorId"
+	RequestVoluntaryExitMethod       = "get_v1_beacon_pool_voluntary_exits"
 
-    MaxRequestValidatorsCount = 600
+	MaxRequestValidatorsCount = 600
 )
 
 // Nimbus client
 type Client struct {
-    client *rpc.Client
+	client *rpc.Client
 }
 
 // Create new Nimbus client
 func NewClient(providerAddress string) (*Client, error) {
-    
-    // Start the RPC connection
-    client, err := rpc.DialHTTP("http://" + providerAddress)
-    if err != nil {
-        return nil, fmt.Errorf("Could not connect to Nimbus RPC server: %s", err)
-    }
-    return &Client{
-        client: client,
-    }, nil
+
+	// Start the RPC connection
+	client, err := rpc.DialHTTP("http://" + providerAddress)
+	if err != nil {
+		return nil, fmt.Errorf("Could not connect to Nimbus RPC server: %s", err)
+	}
+	return &Client{
+		client: client,
+	}, nil
 }
 
 // Close the client connection
 func (c *Client) Close() {
-    c.client.Close()
+	c.client.Close()
 }
 
 // Get the beacon client type
-func (c *Client) GetClientType() (beacon.BeaconClientType) {
-    return beacon.SplitProcess;
+func (c *Client) GetClientType() beacon.BeaconClientType {
+	return beacon.SplitProcess
 }
 
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
 
-    // Get sync status
-    syncStatus, err := c.getSyncStatus()
-    if err != nil {
-        return beacon.SyncStatus{}, err
-    }
+	// Get sync status
+	syncStatus, err := c.getSyncStatus()
+	if err != nil {
+		return beacon.SyncStatus{}, err
+	}
 
-    // Return response
-    isSyncing := (syncStatus.Result.SyncDistance != 0)
-    return beacon.SyncStatus{
-        Syncing: isSyncing,
-    }, nil
+	// Return response
+	isSyncing := (syncStatus.SyncDistance != 0)
+	return beacon.SyncStatus{
+		Syncing: isSyncing,
+	}, nil
 
 }
 
 // Get the eth2 config
 func (c *Client) GetEth2Config() (beacon.Eth2Config, error) {
 
-    // Data
-    var wg errgroup.Group
-    var eth2Config Eth2ConfigResponse
-    var genesis GenesisResponse
+	// Data
+	var wg errgroup.Group
+	var eth2Config Eth2ConfigResponse
+	var genesis GenesisResponse
 
-    // Get eth2 config
-    wg.Go(func() error {
-        var err error
-        eth2Config, err = c.getEth2Config()
-        return err
-    })
+	// Get eth2 config
+	wg.Go(func() error {
+		var err error
+		eth2Config, err = c.getEth2Config()
+		return err
+	})
 
-    // Get genesis
-    wg.Go(func() error {
-        var err error
-        genesis, err = c.getGenesis()
-        return err
-    })
+	// Get genesis
+	wg.Go(func() error {
+		var err error
+		genesis, err = c.getGenesis()
+		return err
+	})
 
-    // Wait for data
-    if err := wg.Wait(); err != nil {
-        return beacon.Eth2Config{}, err
-    }
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		return beacon.Eth2Config{}, err
+	}
 
-    // Return response
-    return beacon.Eth2Config{
-        GenesisForkVersion:    genesis.Result.GenesisForkVersion,
-        GenesisValidatorsRoot: genesis.Result.GenesisValidatorsRoot,
-        GenesisEpoch:          0,
-        GenesisTime:           uint64(genesis.Result.GenesisTime),
-        SecondsPerEpoch:       uint64(eth2Config.Result.SecondsPerSlot * eth2Config.Result.SlotsPerEpoch),
-    }, nil
+	// Return response
+	return beacon.Eth2Config{
+		GenesisForkVersion:    genesis.GenesisForkVersion,
+		GenesisValidatorsRoot: genesis.GenesisValidatorsRoot,
+		GenesisEpoch:          0,
+		GenesisTime:           uint64(genesis.GenesisTime),
+		SecondsPerEpoch:       uint64(eth2Config.SecondsPerSlot * eth2Config.SlotsPerEpoch),
+	}, nil
 
 }
 
 // Get the beacon head
 func (c *Client) GetBeaconHead() (beacon.BeaconHead, error) {
 
-    // Data
-    var wg errgroup.Group
-    var eth2Config beacon.Eth2Config
-    var finalityCheckpoints FinalityCheckpointsResponse
+	// Data
+	var wg errgroup.Group
+	var eth2Config beacon.Eth2Config
+	var finalityCheckpoints FinalityCheckpointsResponse
 
-    // Get eth2 config
-    wg.Go(func() error {
-        var err error
-        eth2Config, err = c.GetEth2Config()
-        return err
-    })
+	// Get eth2 config
+	wg.Go(func() error {
+		var err error
+		eth2Config, err = c.GetEth2Config()
+		return err
+	})
 
-    // Get finality checkpoints
-    wg.Go(func() error {
-        var err error
-        finalityCheckpoints, err = c.getFinalityCheckpoints("head")
-        return err
-    })
+	// Get finality checkpoints
+	wg.Go(func() error {
+		var err error
+		finalityCheckpoints, err = c.getFinalityCheckpoints("head")
+		return err
+	})
 
-    // Wait for data
-    if err := wg.Wait(); err != nil {
-        return beacon.BeaconHead{}, err
-    }
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		return beacon.BeaconHead{}, err
+	}
 
-    // Return response
-    return beacon.BeaconHead{
-        Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
-        FinalizedEpoch:         uint64(finalityCheckpoints.Result.Finalized.Epoch),
-        JustifiedEpoch:         uint64(finalityCheckpoints.Result.CurrentJustified.Epoch),
-        PreviousJustifiedEpoch: uint64(finalityCheckpoints.Result.PreviousJustified.Epoch),
-    }, nil
+	// Return response
+	return beacon.BeaconHead{
+		Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
+		FinalizedEpoch:         uint64(finalityCheckpoints.Finalized.Epoch),
+		JustifiedEpoch:         uint64(finalityCheckpoints.CurrentJustified.Epoch),
+		PreviousJustifiedEpoch: uint64(finalityCheckpoints.PreviousJustified.Epoch),
+	}, nil
 
 }
 
 // Get a validator's status
 func (c *Client) GetValidatorStatus(pubkey types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (beacon.ValidatorStatus, error) {
 
-    // Get validator
-    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
-    if err != nil {
-        return beacon.ValidatorStatus{}, err
-    }
-    if len(validators.Data) == 0 {
-        return beacon.ValidatorStatus{}, nil
-    }
-    validator := validators.Data[0]
+	// Get validator
+	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
+	if err != nil {
+		return beacon.ValidatorStatus{}, err
+	}
+	if len(validators) == 0 {
+		return beacon.ValidatorStatus{}, nil
+	}
+	validator := validators[0]
 
-    // Return response
-    return beacon.ValidatorStatus{
-        Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
-        WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
-        Balance:                    uint64(validator.Balance),
-        EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
-        Slashed:                    validator.Validator.Slashed,
-        ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-        ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-        ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-        WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-        Exists:                     true,
-    }, nil
+	// Return response
+	return beacon.ValidatorStatus{
+		Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+		WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+		Balance:                    uint64(validator.Balance),
+		EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+		Slashed:                    validator.Validator.Slashed,
+		ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+		ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+		ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+		WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+		Exists:                     true,
+	}, nil
 
 }
 
 // Get multiple validators' statuses
 func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (map[types.ValidatorPubkey]beacon.ValidatorStatus, error) {
 
-    // Get validators
-    validators, err := c.getValidatorsByOpts(pubkeys, opts)
-    if err != nil {
-        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
-    }
+	// Get validators
+	validators, err := c.getValidatorsByOpts(pubkeys, opts)
+	if err != nil {
+		return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
+	}
 
-    // Build validator status map
-    statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
-    for _, validator := range validators.Data {
+	// Build validator status map
+	statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
+	for _, validator := range validators {
 
-        // Get validator pubkey
-        pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
+		// Get validator pubkey
+		pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
 
-        // Add status
-        statuses[pubkey] = beacon.ValidatorStatus{
-            Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
-            WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
-            Balance:                    uint64(validator.Balance),
-            EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
-            Slashed:                    validator.Validator.Slashed,
-            ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-            ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-            ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-            WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-            Exists:                     true,
-        }
+		// Add status
+		statuses[pubkey] = beacon.ValidatorStatus{
+			Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+			WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+			Balance:                    uint64(validator.Balance),
+			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+			Slashed:                    validator.Validator.Slashed,
+			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+			Exists:                     true,
+		}
 
-    }
+	}
 
-    // Return
-    return statuses, nil
+	// Return
+	return statuses, nil
 
 }
 
 // Get a validator's index
 func (c *Client) GetValidatorIndex(pubkey types.ValidatorPubkey) (uint64, error) {
 
-    // Get validator
-    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
-    if err != nil {
-        return 0, err
-    }
-    if len(validators.Data) == 0 {
-        return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
-    }
-    validator := validators.Data[0]
+	// Get validator
+	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
+	if err != nil {
+		return 0, err
+	}
+	if len(validators) == 0 {
+		return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
+	}
+	validator := validators[0]
 
-    // Return validator index
-    return uint64(validator.Index), nil
+	// Return validator index
+	return uint64(validator.Index), nil
 
 }
 
 // Get domain data for a domain type at a given epoch
 func (c *Client) GetDomainData(domainType []byte, epoch uint64) ([]byte, error) {
 
-    // Data
-    var wg errgroup.Group
-    var genesis GenesisResponse
-    var fork ForkResponse
+	// Data
+	var wg errgroup.Group
+	var genesis GenesisResponse
+	var fork ForkResponse
 
-    // Get genesis
-    wg.Go(func() error {
-        var err error
-        genesis, err = c.getGenesis()
-        return err
-    })
+	// Get genesis
+	wg.Go(func() error {
+		var err error
+		genesis, err = c.getGenesis()
+		return err
+	})
 
-    // Get fork
-    wg.Go(func() error {
-        var err error
-        fork, err = c.getFork("head")
-        return err
-    })
+	// Get fork
+	wg.Go(func() error {
+		var err error
+		fork, err = c.getFork("head")
+		return err
+	})
 
-    // Wait for data
-    if err := wg.Wait(); err != nil {
-        return []byte{}, err
-    }
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		return []byte{}, err
+	}
 
-    // Get fork version
-    var forkVersion []byte
-    if epoch < uint64(fork.Result.Epoch) {
-        forkVersion = fork.Result.PreviousVersion
-    } else {
-        forkVersion = fork.Result.CurrentVersion
-    }
+	// Get fork version
+	var forkVersion []byte
+	if epoch < uint64(fork.Epoch) {
+		forkVersion = fork.PreviousVersion
+	} else {
+		forkVersion = fork.CurrentVersion
+	}
 
-    // Compute & return domain
-    var dt [4]byte
-    copy(dt[:], domainType[:])
-    return eth2types.Domain(dt, forkVersion, genesis.Result.GenesisValidatorsRoot), nil
+	// Compute & return domain
+	var dt [4]byte
+	copy(dt[:], domainType[:])
+	return eth2types.Domain(dt, forkVersion, genesis.GenesisValidatorsRoot), nil
 
 }
 
 // Perform a voluntary exit on a validator
 func (c *Client) ExitValidator(validatorIndex, epoch uint64, signature types.ValidatorSignature) error {
-    return c.postVoluntaryExit(VoluntaryExitRequest{
-        Message: VoluntaryExitMessage{
-            Epoch:          epoch,
-            ValidatorIndex: validatorIndex,
-        },
-        Signature: signature.Bytes(),
-    })
+	return c.postVoluntaryExit(VoluntaryExitRequest{
+		Message: VoluntaryExitMessage{
+			Epoch:          epoch,
+			ValidatorIndex: validatorIndex,
+		},
+		Signature: signature.Bytes(),
+	})
 }
 
 // Get sync status
 func (c *Client) getSyncStatus() (SyncStatusResponse, error) {
-    var syncStatus SyncStatusResponse
-    if err := c.client.Call(&syncStatus, RequestSyncStatusMethod); err != nil {
-        return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
-    }
-    return syncStatus, nil
+	var syncStatus SyncStatusResponse
+	if err := c.client.Call(&syncStatus, RequestSyncStatusMethod); err != nil {
+		return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
+	}
+	return syncStatus, nil
 }
 
 // Get the eth2 config
 func (c *Client) getEth2Config() (Eth2ConfigResponse, error) {
-    var eth2Config Eth2ConfigResponse
-    if err := c.client.Call(&eth2Config, RequestEth2ConfigMethod); err != nil {
-        return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
-    }
-    return eth2Config, nil
+	var eth2Config Eth2ConfigResponse
+	if err := c.client.Call(&eth2Config, RequestEth2ConfigMethod); err != nil {
+		return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
+	}
+	return eth2Config, nil
 }
 
 // Get genesis information
 func (c *Client) getGenesis() (GenesisResponse, error) {
-    var genesis GenesisResponse
-    if err := c.client.Call(&genesis, RequestGenesisMethod); err != nil {
-        return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
-    }
-    return genesis, nil
+	var genesis GenesisResponse
+	if err := c.client.Call(&genesis, RequestGenesisMethod); err != nil {
+		return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
+	}
+	return genesis, nil
 }
 
 // Get finality checkpoints
 func (c *Client) getFinalityCheckpoints(stateId string) (FinalityCheckpointsResponse, error) {
-    var finalityCheckpoints FinalityCheckpointsResponse
-    if err := c.client.Call(&finalityCheckpoints, RequestFinalityCheckpointsMethod, stateId); err != nil {
-        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
-    }
-    return finalityCheckpoints, nil
+	var finalityCheckpoints FinalityCheckpointsResponse
+	if err := c.client.Call(&finalityCheckpoints, RequestFinalityCheckpointsMethod, stateId); err != nil {
+		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
+	}
+	return finalityCheckpoints, nil
 }
 
 // Get fork
 func (c *Client) getFork(stateId string) (ForkResponse, error) {
-    var fork ForkResponse
-    if err := c.client.Call(&fork, RequestForkMethod, stateId); err != nil {
-        return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
-    }
-    return fork, nil
+	var fork ForkResponse
+	if err := c.client.Call(&fork, RequestForkMethod, stateId); err != nil {
+		return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
+	}
+	return fork, nil
 }
 
 // Get validators
-func (c *Client) getValidators(stateId string, pubkeys []string) (ValidatorsResponse, error) {
-    var validators ValidatorsResponse
-    params := append([]string{stateId}, pubkeys...)
-    if err := c.client.Call(&validators, RequestValidatorsMethod, params); err != nil {
-        return ValidatorsResponse{}, fmt.Errorf("Could not get validators: %w", err)
-    }
-    return validators, nil
+func (c *Client) getValidators(stateId string, pubkeys []string) ([]Validator, error) {
+	var validators []Validator
+	params := append([]string{stateId}, pubkeys...)
+	if err := c.client.Call(&validators, RequestValidatorsMethod, params); err != nil {
+		return []Validator{}, fmt.Errorf("Could not get validators: %w", err)
+	}
+	return validators, nil
 }
 
 // Get validators by pubkeys and status options
-func (c *Client) getValidatorsByOpts(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (ValidatorsResponse, error) {
+func (c *Client) getValidatorsByOpts(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) ([]Validator, error) {
 
-    // Get state ID
-    var stateId string
-    if opts == nil {
-        stateId = "head"
-    } else {
+	// Get state ID
+	var stateId string
+	if opts == nil {
+		stateId = "head"
+	} else {
 
-        // Get eth2 config
-        eth2Config, err := c.getEth2Config()
-        if err != nil {
-            return ValidatorsResponse{}, err
-        }
+		// Get eth2 config
+		eth2Config, err := c.getEth2Config()
+		if err != nil {
+			return []Validator{}, err
+		}
 
-        // Get slot nuimber
-        slot := opts.Epoch * uint64(eth2Config.Result.SlotsPerEpoch)
-        stateId = strconv.FormatInt(int64(slot), 10)
+		// Get slot nuimber
+		slot := opts.Epoch * uint64(eth2Config.SlotsPerEpoch)
+		stateId = strconv.FormatInt(int64(slot), 10)
 
-    }
+	}
 
-    // Get validators
-    if len(pubkeys) <= MaxRequestValidatorsCount {
+	// Get validators
+	if len(pubkeys) <= MaxRequestValidatorsCount {
 
-        // Get validator pubkeys
-        pubkeysHex := make([]string, len(pubkeys))
-        for ki, pubkey := range pubkeys {
-            pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
-        }
+		// Get validator pubkeys
+		pubkeysHex := make([]string, len(pubkeys))
+		for ki, pubkey := range pubkeys {
+			pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
+		}
 
-        // Get & return validators
-        return c.getValidators(stateId, pubkeysHex)
+		// Get & return validators
+		return c.getValidators(stateId, pubkeysHex)
 
-    } else {
+	} else {
 
-        // Get all validators
-        validators, err := c.getValidators(stateId, []string{})
-        if err != nil {
-            return ValidatorsResponse{}, err
-        }
+		// Get all validators
+		validators, err := c.getValidators(stateId, []string{})
+		if err != nil {
+			return []Validator{}, err
+		}
 
-        // Filter validator set by pubkeys and return
-        response := ValidatorsResponse{}
-        for _, validator := range validators.Data {
-            var found bool
-            for _, pubkey := range pubkeys {
-                if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
-                    found = true
-                    break
-                }
-            }
-            if !found {
-                continue
-            }
-            response.Data = append(response.Data, validator)
-        }
-        return response, nil
+		// Filter validator set by pubkeys and return
+		response := []Validator{}
+		for _, validator := range validators {
+			var found bool
+			for _, pubkey := range pubkeys {
+				if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+			response = append(response, validator)
+		}
+		return response, nil
 
-    }
+	}
 
 }
 
 // Send voluntary exit request
 func (c *Client) postVoluntaryExit(request VoluntaryExitRequest) error {
-    if err := c.client.Call(nil, RequestVoluntaryExitMethod, request); err != nil {
-        return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
-    }
-    return nil
+	if err := c.client.Call(nil, RequestVoluntaryExitMethod, request); err != nil {
+		return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
+	}
+	return nil
 }

--- a/shared/services/beacon/nimbus/client.go
+++ b/shared/services/beacon/nimbus/client.go
@@ -24,7 +24,7 @@ const (
     RequestGenesisMethod             = "get_v1_beacon_genesis"
     RequestFinalityCheckpointsMethod = "get_v1_beacon_states_finality_checkpoints"
     RequestForkMethod                = "get_v1_beacon_states_fork"
-    RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators_validatorId"
+    RequestValidatorsMethod          = "get_v1_beacon_states_stateId_validators"
     RequestVoluntaryExitMethod       = "get_v1_beacon_pool_voluntary_exits"
 
     MaxRequestValidatorsCount = 600
@@ -336,8 +336,8 @@ func (c *Client) getFork(stateId string) (ForkResponse, error) {
 // Get validators
 func (c *Client) getValidators(stateId string, pubkeys []string) ([]Validator, error) {
     var validators []Validator
-    params := append([]string{stateId}, pubkeys...)
-    if err := c.client.Call(&validators, RequestValidatorsMethod, params); err != nil {
+    // params := []interface{}{stateId, pubkeys}
+    if err := c.client.Call(&validators, RequestValidatorsMethod, stateId, pubkeys); err != nil {
         return []Validator{}, fmt.Errorf("Could not get validators: %w", err)
     }
     return validators, nil

--- a/shared/services/beacon/nimbus/types.go
+++ b/shared/services/beacon/nimbus/types.go
@@ -1,93 +1,93 @@
 package nimbus
 
 import (
-	"encoding/hex"
-	"encoding/json"
-	"strconv"
+    "encoding/hex"
+    "encoding/json"
+    "strconv"
 
-	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Request types
 type VoluntaryExitRequest struct {
-	Message   VoluntaryExitMessage `json:"message"`
-	Signature byteArray            `json:"signature"`
+    Message   VoluntaryExitMessage `json:"message"`
+    Signature byteArray            `json:"signature"`
 }
 type VoluntaryExitMessage struct {
-	Epoch          uint64 `json:"epoch"`
-	ValidatorIndex uint64 `json:"validator_index"`
+    Epoch          uint64 `json:"epoch"`
+    ValidatorIndex uint64 `json:"validator_index"`
 }
 
 // Response types
 type SyncStatusResponse struct {
-	HeadSlot     uint64 `json:"head_slot"`
-	SyncDistance uint64 `json:"sync_distance"`
+    HeadSlot     uint64 `json:"head_slot"`
+    SyncDistance uint64 `json:"sync_distance"`
 }
 type Eth2ConfigResponse struct {
-	SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
-	SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
+    SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
+    SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
 }
 type GenesisResponse struct {
-	GenesisTime           uint64    `json:"genesis_time"`
-	GenesisForkVersion    byteArray `json:"genesis_fork_version"`
-	GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
+    GenesisTime           uint64    `json:"genesis_time"`
+    GenesisForkVersion    byteArray `json:"genesis_fork_version"`
+    GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
 }
 type FinalityCheckpointsResponse struct {
-	PreviousJustified struct {
-		Epoch uint64 `json:"epoch"`
-	} `json:"previous_justified"`
-	CurrentJustified struct {
-		Epoch uint64 `json:"epoch"`
-	} `json:"current_justified"`
-	Finalized struct {
-		Epoch uint64 `json:"epoch"`
-	} `json:"finalized"`
+    PreviousJustified struct {
+        Epoch uint64 `json:"epoch"`
+    } `json:"previous_justified"`
+    CurrentJustified struct {
+        Epoch uint64 `json:"epoch"`
+    } `json:"current_justified"`
+    Finalized struct {
+        Epoch uint64 `json:"epoch"`
+    } `json:"finalized"`
 }
 type ForkResponse struct {
-	PreviousVersion byteArray `json:"previous_version"`
-	CurrentVersion  byteArray `json:"current_version"`
-	Epoch           uint64    `json:"epoch"`
+    PreviousVersion byteArray `json:"previous_version"`
+    CurrentVersion  byteArray `json:"current_version"`
+    Epoch           uint64    `json:"epoch"`
 }
 
 type Validator struct {
-	Index     uint64 `json:"index"`
-	Balance   uint64 `json:"balance"`
-	Status    string `json:"status"`
-	Validator struct {
-		Pubkey                     byteArray `json:"pubkey"`
-		WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
-		EffectiveBalance           uint64    `json:"effective_balance"`
-		Slashed                    bool      `json:"slashed"`
-		ActivationEligibilityEpoch uint64    `json:"activation_eligibility_epoch"`
-		ActivationEpoch            uint64    `json:"activation_epoch"`
-		ExitEpoch                  int64     `json:"exit_epoch"`         // Nimbus uses -1 for FAR_FUTURE_EPOCH so this has to be a signed int
-		WithdrawableEpoch          int64     `json:"withdrawable_epoch"` // Same here
-	} `json:"validator"`
+    Index     uint64 `json:"index"`
+    Balance   uint64 `json:"balance"`
+    Status    string `json:"status"`
+    Validator struct {
+        Pubkey                     byteArray `json:"pubkey"`
+        WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
+        EffectiveBalance           uint64    `json:"effective_balance"`
+        Slashed                    bool      `json:"slashed"`
+        ActivationEligibilityEpoch uint64    `json:"activation_eligibility_epoch"`
+        ActivationEpoch            uint64    `json:"activation_epoch"`
+        ExitEpoch                  int64     `json:"exit_epoch"`         // Nimbus uses -1 for FAR_FUTURE_EPOCH so this has to be a signed int
+        WithdrawableEpoch          int64     `json:"withdrawable_epoch"` // Same here
+    } `json:"validator"`
 }
 
 // Unsigned integer type
 type uinteger uint64
 
 func (i uinteger) MarshalJSON() ([]byte, error) {
-	return json.Marshal(strconv.Itoa(int(i)))
+    return json.Marshal(strconv.Itoa(int(i)))
 }
 func (i *uinteger) UnmarshalJSON(data []byte) error {
 
-	// Unmarshal string
-	var dataStr string
-	if err := json.Unmarshal(data, &dataStr); err != nil {
-		return err
-	}
+    // Unmarshal string
+    var dataStr string
+    if err := json.Unmarshal(data, &dataStr); err != nil {
+        return err
+    }
 
-	// Parse integer value
-	value, err := strconv.ParseUint(dataStr, 10, 64)
-	if err != nil {
-		return err
-	}
+    // Parse integer value
+    value, err := strconv.ParseUint(dataStr, 10, 64)
+    if err != nil {
+        return err
+    }
 
-	// Set value and return
-	*i = uinteger(value)
-	return nil
+    // Set value and return
+    *i = uinteger(value)
+    return nil
 
 }
 
@@ -95,24 +95,24 @@ func (i *uinteger) UnmarshalJSON(data []byte) error {
 type byteArray []byte
 
 func (b byteArray) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
+    return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
 }
 func (b *byteArray) UnmarshalJSON(data []byte) error {
 
-	// Unmarshal string
-	var dataStr string
-	if err := json.Unmarshal(data, &dataStr); err != nil {
-		return err
-	}
+    // Unmarshal string
+    var dataStr string
+    if err := json.Unmarshal(data, &dataStr); err != nil {
+        return err
+    }
 
-	// Decode hex
-	value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
-	if err != nil {
-		return err
-	}
+    // Decode hex
+    value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
+    if err != nil {
+        return err
+    }
 
-	// Set value and return
-	*b = value
-	return nil
+    // Set value and return
+    *b = value
+    return nil
 
 }

--- a/shared/services/beacon/nimbus/types.go
+++ b/shared/services/beacon/nimbus/types.go
@@ -1,105 +1,93 @@
 package nimbus
 
 import (
-    "encoding/hex"
-    "encoding/json"
-    "strconv"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
 
-    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Request types
 type VoluntaryExitRequest struct {
-    Message   VoluntaryExitMessage `json:"message"`
-    Signature byteArray            `json:"signature"`
+	Message   VoluntaryExitMessage `json:"message"`
+	Signature byteArray            `json:"signature"`
 }
 type VoluntaryExitMessage struct {
-    Epoch          uint64 `json:"epoch"`
-    ValidatorIndex uint64 `json:"validator_index"`
+	Epoch          uint64 `json:"epoch"`
+	ValidatorIndex uint64 `json:"validator_index"`
 }
 
 // Response types
 type SyncStatusResponse struct {
-    Result struct {
-        HeadSlot     uint64 `json:"head_slot"`
-        SyncDistance uint64 `json:"sync_distance"`
-    } `json:"result"`
+	HeadSlot     uint64 `json:"head_slot"`
+	SyncDistance uint64 `json:"sync_distance"`
 }
 type Eth2ConfigResponse struct {
-    Result struct {
-        SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
-        SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
-    } `json:"result"`
+	SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
+	SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
 }
 type GenesisResponse struct {
-    Result struct {
-        GenesisTime           uint64  `json:"genesis_time"`
-        GenesisForkVersion    byteArray `json:"genesis_fork_version"`
-        GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
-    } `json:"result"`
+	GenesisTime           uint64    `json:"genesis_time"`
+	GenesisForkVersion    byteArray `json:"genesis_fork_version"`
+	GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
 }
 type FinalityCheckpointsResponse struct {
-    Result struct {
-        PreviousJustified struct {
-            Epoch uint64 `json:"epoch"`
-        } `json:"previous_justified"`
-        CurrentJustified struct {
-            Epoch uint64 `json:"epoch"`
-        } `json:"current_justified"`
-        Finalized struct {
-            Epoch uint64 `json:"epoch"`
-        } `json:"finalized"`
-    } `json:"result"`
+	PreviousJustified struct {
+		Epoch uint64 `json:"epoch"`
+	} `json:"previous_justified"`
+	CurrentJustified struct {
+		Epoch uint64 `json:"epoch"`
+	} `json:"current_justified"`
+	Finalized struct {
+		Epoch uint64 `json:"epoch"`
+	} `json:"finalized"`
 }
 type ForkResponse struct {
-    Result struct {
-        PreviousVersion byteArray `json:"previous_version"`
-        CurrentVersion  byteArray `json:"current_version"`
-        Epoch           uint64  `json:"epoch"`
-    } `json:"result"`
+	PreviousVersion byteArray `json:"previous_version"`
+	CurrentVersion  byteArray `json:"current_version"`
+	Epoch           uint64    `json:"epoch"`
 }
-type ValidatorsResponse struct {
-    Data []Validator `json:"data"`
-}
+
 type Validator struct {
-    Index     uint64 `json:"index"`
-    Balance   uint64 `json:"balance"`
-    Status    string   `json:"status"`
-    Validator struct {
-        Pubkey                     byteArray `json:"pubkey"`
-        WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
-        EffectiveBalance           uint64  `json:"effective_balance"`
-        Slashed                    bool      `json:"slashed"`
-        ActivationEligibilityEpoch uint64  `json:"activation_eligibility_epoch"`
-        ActivationEpoch            uint64  `json:"activation_epoch"`
-        ExitEpoch                  int64  `json:"exit_epoch"` // Nimbus uses -1 for FAR_FUTURE_EPOCH so this has to be a signed int
-        WithdrawableEpoch          int64  `json:"withdrawable_epoch"` // Same here
-    } `json:"validator"`
+	Index     uint64 `json:"index"`
+	Balance   uint64 `json:"balance"`
+	Status    string `json:"status"`
+	Validator struct {
+		Pubkey                     byteArray `json:"pubkey"`
+		WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
+		EffectiveBalance           uint64    `json:"effective_balance"`
+		Slashed                    bool      `json:"slashed"`
+		ActivationEligibilityEpoch uint64    `json:"activation_eligibility_epoch"`
+		ActivationEpoch            uint64    `json:"activation_epoch"`
+		ExitEpoch                  int64     `json:"exit_epoch"`         // Nimbus uses -1 for FAR_FUTURE_EPOCH so this has to be a signed int
+		WithdrawableEpoch          int64     `json:"withdrawable_epoch"` // Same here
+	} `json:"validator"`
 }
 
 // Unsigned integer type
 type uinteger uint64
 
 func (i uinteger) MarshalJSON() ([]byte, error) {
-    return json.Marshal(strconv.Itoa(int(i)))
+	return json.Marshal(strconv.Itoa(int(i)))
 }
 func (i *uinteger) UnmarshalJSON(data []byte) error {
 
-    // Unmarshal string
-    var dataStr string
-    if err := json.Unmarshal(data, &dataStr); err != nil {
-        return err
-    }
+	// Unmarshal string
+	var dataStr string
+	if err := json.Unmarshal(data, &dataStr); err != nil {
+		return err
+	}
 
-    // Parse integer value
-    value, err := strconv.ParseUint(dataStr, 10, 64)
-    if err != nil {
-        return err
-    }
+	// Parse integer value
+	value, err := strconv.ParseUint(dataStr, 10, 64)
+	if err != nil {
+		return err
+	}
 
-    // Set value and return
-    *i = uinteger(value)
-    return nil
+	// Set value and return
+	*i = uinteger(value)
+	return nil
 
 }
 
@@ -107,24 +95,24 @@ func (i *uinteger) UnmarshalJSON(data []byte) error {
 type byteArray []byte
 
 func (b byteArray) MarshalJSON() ([]byte, error) {
-    return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
+	return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
 }
 func (b *byteArray) UnmarshalJSON(data []byte) error {
 
-    // Unmarshal string
-    var dataStr string
-    if err := json.Unmarshal(data, &dataStr); err != nil {
-        return err
-    }
+	// Unmarshal string
+	var dataStr string
+	if err := json.Unmarshal(data, &dataStr); err != nil {
+		return err
+	}
 
-    // Decode hex
-    value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
-    if err != nil {
-        return err
-    }
+	// Decode hex
+	value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
+	if err != nil {
+		return err
+	}
 
-    // Set value and return
-    *b = value
-    return nil
+	// Set value and return
+	*b = value
+	return nil
 
 }

--- a/shared/services/beacon/nimbus/types.go
+++ b/shared/services/beacon/nimbus/types.go
@@ -14,8 +14,8 @@ type VoluntaryExitRequest struct {
     Signature byteArray            `json:"signature"`
 }
 type VoluntaryExitMessage struct {
-    Epoch          uinteger `json:"epoch"`
-    ValidatorIndex uinteger `json:"validator_index"`
+    Epoch          uint64 `json:"epoch"`
+    ValidatorIndex uint64 `json:"validator_index"`
 }
 
 // Response types

--- a/shared/services/beacon/nimbus/types.go
+++ b/shared/services/beacon/nimbus/types.go
@@ -1,0 +1,130 @@
+package nimbus
+
+import (
+    "encoding/hex"
+    "encoding/json"
+    "strconv"
+
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+// Request types
+type VoluntaryExitRequest struct {
+    Message   VoluntaryExitMessage `json:"message"`
+    Signature byteArray            `json:"signature"`
+}
+type VoluntaryExitMessage struct {
+    Epoch          uinteger `json:"epoch"`
+    ValidatorIndex uinteger `json:"validator_index"`
+}
+
+// Response types
+type SyncStatusResponse struct {
+    Result struct {
+        HeadSlot     uint64 `json:"head_slot"`
+        SyncDistance uint64 `json:"sync_distance"`
+    } `json:"result"`
+}
+type Eth2ConfigResponse struct {
+    Result struct {
+        SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
+        SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
+    } `json:"result"`
+}
+type GenesisResponse struct {
+    Result struct {
+        GenesisTime           uint64  `json:"genesis_time"`
+        GenesisForkVersion    byteArray `json:"genesis_fork_version"`
+        GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
+    } `json:"result"`
+}
+type FinalityCheckpointsResponse struct {
+    Result struct {
+        PreviousJustified struct {
+            Epoch uint64 `json:"epoch"`
+        } `json:"previous_justified"`
+        CurrentJustified struct {
+            Epoch uint64 `json:"epoch"`
+        } `json:"current_justified"`
+        Finalized struct {
+            Epoch uint64 `json:"epoch"`
+        } `json:"finalized"`
+    } `json:"result"`
+}
+type ForkResponse struct {
+    Result struct {
+        PreviousVersion byteArray `json:"previous_version"`
+        CurrentVersion  byteArray `json:"current_version"`
+        Epoch           uint64  `json:"epoch"`
+    } `json:"result"`
+}
+type ValidatorsResponse struct {
+    Data []Validator `json:"data"`
+}
+type Validator struct {
+    Index     uint64 `json:"index"`
+    Balance   uint64 `json:"balance"`
+    Status    string   `json:"status"`
+    Validator struct {
+        Pubkey                     byteArray `json:"pubkey"`
+        WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
+        EffectiveBalance           uint64  `json:"effective_balance"`
+        Slashed                    bool      `json:"slashed"`
+        ActivationEligibilityEpoch uint64  `json:"activation_eligibility_epoch"`
+        ActivationEpoch            uint64  `json:"activation_epoch"`
+        ExitEpoch                  int64  `json:"exit_epoch"` // Nimbus uses -1 for FAR_FUTURE_EPOCH so this has to be a signed int
+        WithdrawableEpoch          int64  `json:"withdrawable_epoch"` // Same here
+    } `json:"validator"`
+}
+
+// Unsigned integer type
+type uinteger uint64
+
+func (i uinteger) MarshalJSON() ([]byte, error) {
+    return json.Marshal(strconv.Itoa(int(i)))
+}
+func (i *uinteger) UnmarshalJSON(data []byte) error {
+
+    // Unmarshal string
+    var dataStr string
+    if err := json.Unmarshal(data, &dataStr); err != nil {
+        return err
+    }
+
+    // Parse integer value
+    value, err := strconv.ParseUint(dataStr, 10, 64)
+    if err != nil {
+        return err
+    }
+
+    // Set value and return
+    *i = uinteger(value)
+    return nil
+
+}
+
+// Byte array type
+type byteArray []byte
+
+func (b byteArray) MarshalJSON() ([]byte, error) {
+    return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
+}
+func (b *byteArray) UnmarshalJSON(data []byte) error {
+
+    // Unmarshal string
+    var dataStr string
+    if err := json.Unmarshal(data, &dataStr); err != nil {
+        return err
+    }
+
+    // Decode hex
+    value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
+    if err != nil {
+        return err
+    }
+
+    // Set value and return
+    *b = value
+    return nil
+
+}

--- a/shared/services/beacon/prysm/client.go
+++ b/shared/services/beacon/prysm/client.go
@@ -53,6 +53,11 @@ func (c *Client) Close() {
     c.conn.Close()
 }
 
+// Get the beacon client type
+func (c *Client) GetClientType() (beacon.BeaconClientType) {
+    return beacon.SplitProcess;
+}
+
 
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {

--- a/shared/services/beacon/teku/client.go
+++ b/shared/services/beacon/teku/client.go
@@ -62,7 +62,7 @@ func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
 	}
 
 	// Return response
-	isSyncing := (syncStatus.Data.SyncDistance == 0)
+	isSyncing := (syncStatus.Data.SyncDistance != 0)
 	return beacon.SyncStatus{
 		Syncing: isSyncing,
 	}, nil

--- a/shared/services/beacon/teku/client.go
+++ b/shared/services/beacon/teku/client.go
@@ -1,0 +1,498 @@
+package teku
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rocket-pool/rocketpool-go/types"
+	eth2types "github.com/wealdtech/go-eth2-types/v2"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
+	"github.com/rocket-pool/smartnode/shared/utils/eth2"
+	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+// Config
+const (
+	RequestUrlFormat   = "%s://%s%s"
+	RequestProtocol    = "http"
+	RequestContentType = "application/json"
+
+	RequestSyncStatusPath          = "/eth/v1/node/syncing"
+	RequestEth2ConfigPath          = "/eth/v1/config/spec"
+	RequestGenesisPath             = "/eth/v1/beacon/genesis"
+	RequestFinalityCheckpointsPath = "/eth/v1/beacon/states/%s/finality_checkpoints"
+	RequestForkPath                = "/eth/v1/beacon/states/%s/fork"
+	RequestValidatorsPath          = "/eth/v1/beacon/states/%s/validators"
+	RequestVoluntaryExitPath       = "/eth/v1/beacon/pool/voluntary_exits"
+
+	MaxRequestValidatorsCount = 600
+)
+
+// Teku client
+type Client struct {
+	providerAddress string
+}
+
+// Create new Teku client
+func NewClient(providerAddress string) *Client {
+	return &Client{
+		providerAddress: providerAddress,
+	}
+}
+
+// Close the client connection
+func (c *Client) Close() {}
+
+// Get the node's sync status
+func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
+
+	// Get sync status
+	syncStatus, err := c.getSyncStatus()
+	if err != nil {
+		return beacon.SyncStatus{}, err
+	}
+
+	// Return response
+	isSyncing := (syncStatus.Data.SyncDistance == 0)
+	return beacon.SyncStatus{
+		Syncing: isSyncing,
+	}, nil
+
+}
+
+// Get the eth2 config
+func (c *Client) GetEth2Config() (beacon.Eth2Config, error) {
+
+	// Data
+	var wg errgroup.Group
+	var eth2Config Eth2ConfigResponse
+	var genesis GenesisResponse
+
+	// Get eth2 config
+	wg.Go(func() error {
+		var err error
+		eth2Config, err = c.getEth2Config()
+		return err
+	})
+
+	// Get genesis
+	wg.Go(func() error {
+		var err error
+		genesis, err = c.getGenesis()
+		return err
+	})
+
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		return beacon.Eth2Config{}, err
+	}
+
+	// Return response
+	return beacon.Eth2Config{
+		GenesisForkVersion:    genesis.Data.GenesisForkVersion,
+		GenesisValidatorsRoot: genesis.Data.GenesisValidatorsRoot,
+		GenesisEpoch:          0,
+		GenesisTime:           uint64(genesis.Data.GenesisTime),
+		SecondsPerEpoch:       uint64(eth2Config.Data.SecondsPerSlot * eth2Config.Data.SlotsPerEpoch),
+	}, nil
+
+}
+
+// Get the beacon head
+func (c *Client) GetBeaconHead() (beacon.BeaconHead, error) {
+
+	// Data
+	var wg errgroup.Group
+	var eth2Config beacon.Eth2Config
+	var finalityCheckpoints FinalityCheckpointsResponse
+
+	// Get eth2 config
+	wg.Go(func() error {
+		var err error
+		eth2Config, err = c.GetEth2Config()
+		return err
+	})
+
+	// Get finality checkpoints
+	wg.Go(func() error {
+		var err error
+		finalityCheckpoints, err = c.getFinalityCheckpoints("head")
+		return err
+	})
+
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		return beacon.BeaconHead{}, err
+	}
+
+	// Return response
+	return beacon.BeaconHead{
+		Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
+		FinalizedEpoch:         uint64(finalityCheckpoints.Data.Finalized.Epoch),
+		JustifiedEpoch:         uint64(finalityCheckpoints.Data.CurrentJustified.Epoch),
+		PreviousJustifiedEpoch: uint64(finalityCheckpoints.Data.PreviousJustified.Epoch),
+	}, nil
+
+}
+
+// Get a validator's status
+func (c *Client) GetValidatorStatus(pubkey types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (beacon.ValidatorStatus, error) {
+
+	// Get validator
+	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
+	if err != nil {
+		return beacon.ValidatorStatus{}, err
+	}
+	if len(validators.Data) == 0 {
+		return beacon.ValidatorStatus{}, nil
+	}
+	validator := validators.Data[0]
+
+	// Return response
+	return beacon.ValidatorStatus{
+		Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+		WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+		Balance:                    uint64(validator.Balance),
+		EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+		Slashed:                    validator.Validator.Slashed,
+		ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+		ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+		ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+		WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+		Exists:                     true,
+	}, nil
+
+}
+
+// Get multiple validators' statuses
+func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (map[types.ValidatorPubkey]beacon.ValidatorStatus, error) {
+
+	// Get validators
+	validators, err := c.getValidatorsByOpts(pubkeys, opts)
+	if err != nil {
+		return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
+	}
+
+	// Build validator status map
+	statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
+	for _, validator := range validators.Data {
+
+		// Get validator pubkey
+		pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
+
+		// Add status
+		statuses[pubkey] = beacon.ValidatorStatus{
+			Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+			WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+			Balance:                    uint64(validator.Balance),
+			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+			Slashed:                    validator.Validator.Slashed,
+			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+			Exists:                     true,
+		}
+
+	}
+
+	// Return
+	return statuses, nil
+
+}
+
+// Get a validator's index
+func (c *Client) GetValidatorIndex(pubkey types.ValidatorPubkey) (uint64, error) {
+
+	// Get validator
+	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
+	if err != nil {
+		return 0, err
+	}
+	if len(validators.Data) == 0 {
+		return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
+	}
+	validator := validators.Data[0]
+
+	// Return validator index
+	return uint64(validator.Index), nil
+
+}
+
+// Get domain data for a domain type at a given epoch
+func (c *Client) GetDomainData(domainType []byte, epoch uint64) ([]byte, error) {
+
+	// Data
+	var wg errgroup.Group
+	var genesis GenesisResponse
+	var fork ForkResponse
+
+	// Get genesis
+	wg.Go(func() error {
+		var err error
+		genesis, err = c.getGenesis()
+		return err
+	})
+
+	// Get fork
+	wg.Go(func() error {
+		var err error
+		fork, err = c.getFork("head")
+		return err
+	})
+
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		return []byte{}, err
+	}
+
+	// Get fork version
+	var forkVersion []byte
+	if epoch < uint64(fork.Data.Epoch) {
+		forkVersion = fork.Data.PreviousVersion
+	} else {
+		forkVersion = fork.Data.CurrentVersion
+	}
+
+	// Compute & return domain
+	var dt [4]byte
+	copy(dt[:], domainType[:])
+	return eth2types.Domain(dt, forkVersion, genesis.Data.GenesisValidatorsRoot), nil
+
+}
+
+// Perform a voluntary exit on a validator
+func (c *Client) ExitValidator(validatorIndex, epoch uint64, signature types.ValidatorSignature) error {
+	return c.postVoluntaryExit(VoluntaryExitRequest{
+		Message: VoluntaryExitMessage{
+			Epoch:          uinteger(epoch),
+			ValidatorIndex: uinteger(validatorIndex),
+		},
+		Signature: signature.Bytes(),
+	})
+}
+
+// Get sync status
+func (c *Client) getSyncStatus() (SyncStatusResponse, error) {
+	responseBody, status, err := c.getRequest(RequestSyncStatusPath)
+	if err != nil {
+		return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
+	} else if status != http.StatusOK {
+		return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: HTTP status %d; response body: '%s'", status, string(responseBody))
+	}
+	var syncStatus SyncStatusResponse
+	if err := json.Unmarshal(responseBody, &syncStatus); err != nil {
+		return SyncStatusResponse{}, fmt.Errorf("Could not decode node sync status: %w", err)
+	}
+	return syncStatus, nil
+}
+
+// Get the eth2 config
+func (c *Client) getEth2Config() (Eth2ConfigResponse, error) {
+	responseBody, status, err := c.getRequest(RequestEth2ConfigPath)
+	if err != nil {
+		return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
+	} else if status != http.StatusOK {
+		return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: HTTP status %d; response body: '%s'", status, string(responseBody))
+	}
+	var eth2Config Eth2ConfigResponse
+	if err := json.Unmarshal(responseBody, &eth2Config); err != nil {
+		return Eth2ConfigResponse{}, fmt.Errorf("Could not decode eth2 config: %w", err)
+	}
+	return eth2Config, nil
+}
+
+// Get genesis information
+func (c *Client) getGenesis() (GenesisResponse, error) {
+	responseBody, status, err := c.getRequest(RequestGenesisPath)
+	if err != nil {
+		return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
+	} else if status != http.StatusOK {
+		return GenesisResponse{}, fmt.Errorf("Could not get genesis data: HTTP status %d; response body: '%s'", status, string(responseBody))
+	}
+	var genesis GenesisResponse
+	if err := json.Unmarshal(responseBody, &genesis); err != nil {
+		return GenesisResponse{}, fmt.Errorf("Could not decode genesis: %w", err)
+	}
+	return genesis, nil
+}
+
+// Get finality checkpoints
+func (c *Client) getFinalityCheckpoints(stateId string) (FinalityCheckpointsResponse, error) {
+	responseBody, status, err := c.getRequest(fmt.Sprintf(RequestFinalityCheckpointsPath, stateId))
+	if err != nil {
+		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
+	} else if status != http.StatusOK {
+		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: HTTP status %d; response body: '%s'", status, string(responseBody))
+	}
+	var finalityCheckpoints FinalityCheckpointsResponse
+	if err := json.Unmarshal(responseBody, &finalityCheckpoints); err != nil {
+		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not decode finality checkpoints: %w", err)
+	}
+	return finalityCheckpoints, nil
+}
+
+// Get fork
+func (c *Client) getFork(stateId string) (ForkResponse, error) {
+	responseBody, status, err := c.getRequest(fmt.Sprintf(RequestForkPath, stateId))
+	if err != nil {
+		return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
+	} else if status != http.StatusOK {
+		return ForkResponse{}, fmt.Errorf("Could not get fork data: HTTP status %d; response body: '%s'", status, string(responseBody))
+	}
+	var fork ForkResponse
+	if err := json.Unmarshal(responseBody, &fork); err != nil {
+		return ForkResponse{}, fmt.Errorf("Could not decode fork data: %w", err)
+	}
+	return fork, nil
+}
+
+// Get validators
+func (c *Client) getValidators(stateId string, pubkeys []string) (ValidatorsResponse, error) {
+	var query string
+	if len(pubkeys) > 0 {
+		query = fmt.Sprintf("?id=%s", strings.Join(pubkeys, ","))
+	}
+	responseBody, status, err := c.getRequest(fmt.Sprintf(RequestValidatorsPath, stateId) + query)
+	if err != nil {
+		return ValidatorsResponse{}, fmt.Errorf("Could not get validators: %w", err)
+	} else if status != http.StatusOK {
+		return ValidatorsResponse{}, fmt.Errorf("Could not get validators: HTTP status %d; response body: '%s'", status, string(responseBody))
+	}
+	var validators ValidatorsResponse
+	if err := json.Unmarshal(responseBody, &validators); err != nil {
+		return ValidatorsResponse{}, fmt.Errorf("Could not decode validators: %w", err)
+	}
+	return validators, nil
+}
+
+// Get validators by pubkeys and status options
+func (c *Client) getValidatorsByOpts(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (ValidatorsResponse, error) {
+
+	// Get state ID
+	var stateId string
+	if opts == nil {
+		stateId = "head"
+	} else {
+
+		// Get eth2 config
+		eth2Config, err := c.getEth2Config()
+		if err != nil {
+			return ValidatorsResponse{}, err
+		}
+
+		// Get slot nuimber
+		slot := opts.Epoch * uint64(eth2Config.Data.SlotsPerEpoch)
+		stateId = strconv.FormatInt(int64(slot), 10)
+
+	}
+
+	// Get validators
+	if len(pubkeys) <= MaxRequestValidatorsCount {
+
+		// Get validator pubkeys
+		pubkeysHex := make([]string, len(pubkeys))
+		for ki, pubkey := range pubkeys {
+			pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
+		}
+
+		// Get & return validators
+		return c.getValidators(stateId, pubkeysHex)
+
+	} else {
+
+		// Get all validators
+		validators, err := c.getValidators(stateId, []string{})
+		if err != nil {
+			return ValidatorsResponse{}, err
+		}
+
+		// Filter validator set by pubkeys and return
+		response := ValidatorsResponse{}
+		for _, validator := range validators.Data {
+			var found bool
+			for _, pubkey := range pubkeys {
+				if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+			response.Data = append(response.Data, validator)
+		}
+		return response, nil
+
+	}
+
+}
+
+// Send voluntary exit request
+func (c *Client) postVoluntaryExit(request VoluntaryExitRequest) error {
+	responseBody, status, err := c.postRequest(RequestVoluntaryExitPath, request)
+	if err != nil {
+		return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
+	} else if status != http.StatusOK {
+		return fmt.Errorf("Could not broadcast exit for validator at index %d: HTTP status %d; response body: '%s'", request.Message.ValidatorIndex, status, string(responseBody))
+	}
+	return nil
+}
+
+// Make a GET request to the beacon node
+func (c *Client) getRequest(requestPath string) ([]byte, int, error) {
+
+	// Send request
+	response, err := http.Get(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath))
+	if err != nil {
+		return []byte{}, 0, err
+	}
+	defer response.Body.Close()
+
+	// Get response
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+
+	// Return
+	return body, response.StatusCode, nil
+
+}
+
+// Make a POST request to the beacon node
+func (c *Client) postRequest(requestPath string, requestBody interface{}) ([]byte, int, error) {
+
+	// Get request body
+	requestBodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+	requestBodyReader := bytes.NewReader(requestBodyBytes)
+
+	// Send request
+	response, err := http.Post(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath), RequestContentType, requestBodyReader)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+	defer response.Body.Close()
+
+	// Get response
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return []byte{}, 0, err
+	}
+
+	// Return
+	return body, response.StatusCode, nil
+
+}

--- a/shared/services/beacon/teku/client.go
+++ b/shared/services/beacon/teku/client.go
@@ -1,52 +1,52 @@
 package teku
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "strconv"
+    "strings"
+    "time"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/rocket-pool/rocketpool-go/types"
-	eth2types "github.com/wealdtech/go-eth2-types/v2"
-	"golang.org/x/sync/errgroup"
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/rocket-pool/rocketpool-go/types"
+    eth2types "github.com/wealdtech/go-eth2-types/v2"
+    "golang.org/x/sync/errgroup"
 
-	"github.com/rocket-pool/smartnode/shared/services/beacon"
-	"github.com/rocket-pool/smartnode/shared/utils/eth2"
-	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+    "github.com/rocket-pool/smartnode/shared/services/beacon"
+    "github.com/rocket-pool/smartnode/shared/utils/eth2"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Config
 const (
-	RequestUrlFormat   = "%s://%s%s"
-	RequestProtocol    = "http"
-	RequestContentType = "application/json"
+    RequestUrlFormat   = "%s://%s%s"
+    RequestProtocol    = "http"
+    RequestContentType = "application/json"
 
-	RequestSyncStatusPath          = "/eth/v1/node/syncing"
-	RequestEth2ConfigPath          = "/eth/v1/config/spec"
-	RequestGenesisPath             = "/eth/v1/beacon/genesis"
-	RequestFinalityCheckpointsPath = "/eth/v1/beacon/states/%s/finality_checkpoints"
-	RequestForkPath                = "/eth/v1/beacon/states/%s/fork"
-	RequestValidatorsPath          = "/eth/v1/beacon/states/%s/validators"
-	RequestVoluntaryExitPath       = "/eth/v1/beacon/pool/voluntary_exits"
+    RequestSyncStatusPath          = "/eth/v1/node/syncing"
+    RequestEth2ConfigPath          = "/eth/v1/config/spec"
+    RequestGenesisPath             = "/eth/v1/beacon/genesis"
+    RequestFinalityCheckpointsPath = "/eth/v1/beacon/states/%s/finality_checkpoints"
+    RequestForkPath                = "/eth/v1/beacon/states/%s/fork"
+    RequestValidatorsPath          = "/eth/v1/beacon/states/%s/validators"
+    RequestVoluntaryExitPath       = "/eth/v1/beacon/pool/voluntary_exits"
 
-	MaxRequestValidatorsCount = 600
+    MaxRequestValidatorsCount = 600
 )
 
 // Teku client
 type Client struct {
-	providerAddress string
+    providerAddress string
 }
 
 // Create new Teku client
 func NewClient(providerAddress string) *Client {
-	return &Client{
-		providerAddress: providerAddress,
-	}
+    return &Client{
+        providerAddress: providerAddress,
+    }
 }
 
 // Close the client connection
@@ -55,444 +55,444 @@ func (c *Client) Close() {}
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
 
-	// Get sync status
-	syncStatus, err := c.getSyncStatus()
-	if err != nil {
-		return beacon.SyncStatus{}, err
-	}
+    // Get sync status
+    syncStatus, err := c.getSyncStatus()
+    if err != nil {
+        return beacon.SyncStatus{}, err
+    }
 
-	// Return response
-	isSyncing := (syncStatus.Data.SyncDistance != 0)
-	return beacon.SyncStatus{
-		Syncing: isSyncing,
-	}, nil
+    // Return response
+    isSyncing := (syncStatus.Data.SyncDistance != 0)
+    return beacon.SyncStatus{
+        Syncing: isSyncing,
+    }, nil
 
 }
 
 // Get the eth2 config
 func (c *Client) GetEth2Config() (beacon.Eth2Config, error) {
 
-	// Data
-	var wg errgroup.Group
-	var eth2Config Eth2ConfigResponse
-	var genesis GenesisResponse
+    // Data
+    var wg errgroup.Group
+    var eth2Config Eth2ConfigResponse
+    var genesis GenesisResponse
 
-	// Get eth2 config
-	wg.Go(func() error {
-		var err error
-		eth2Config, err = c.getEth2Config()
-		return err
-	})
+    // Get eth2 config
+    wg.Go(func() error {
+        var err error
+        eth2Config, err = c.getEth2Config()
+        return err
+    })
 
-	// Get genesis
-	wg.Go(func() error {
-		var err error
-		genesis, err = c.getGenesis()
-		return err
-	})
+    // Get genesis
+    wg.Go(func() error {
+        var err error
+        genesis, err = c.getGenesis()
+        return err
+    })
 
-	// Wait for data
-	if err := wg.Wait(); err != nil {
-		return beacon.Eth2Config{}, err
-	}
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return beacon.Eth2Config{}, err
+    }
 
-	// Return response
-	return beacon.Eth2Config{
-		GenesisForkVersion:    genesis.Data.GenesisForkVersion,
-		GenesisValidatorsRoot: genesis.Data.GenesisValidatorsRoot,
-		GenesisEpoch:          0,
-		GenesisTime:           uint64(genesis.Data.GenesisTime),
-		SecondsPerEpoch:       uint64(eth2Config.Data.SecondsPerSlot * eth2Config.Data.SlotsPerEpoch),
-	}, nil
+    // Return response
+    return beacon.Eth2Config{
+        GenesisForkVersion:    genesis.Data.GenesisForkVersion,
+        GenesisValidatorsRoot: genesis.Data.GenesisValidatorsRoot,
+        GenesisEpoch:          0,
+        GenesisTime:           uint64(genesis.Data.GenesisTime),
+        SecondsPerEpoch:       uint64(eth2Config.Data.SecondsPerSlot * eth2Config.Data.SlotsPerEpoch),
+    }, nil
 
 }
 
 // Get the beacon head
 func (c *Client) GetBeaconHead() (beacon.BeaconHead, error) {
 
-	// Data
-	var wg errgroup.Group
-	var eth2Config beacon.Eth2Config
-	var finalityCheckpoints FinalityCheckpointsResponse
+    // Data
+    var wg errgroup.Group
+    var eth2Config beacon.Eth2Config
+    var finalityCheckpoints FinalityCheckpointsResponse
 
-	// Get eth2 config
-	wg.Go(func() error {
-		var err error
-		eth2Config, err = c.GetEth2Config()
-		return err
-	})
+    // Get eth2 config
+    wg.Go(func() error {
+        var err error
+        eth2Config, err = c.GetEth2Config()
+        return err
+    })
 
-	// Get finality checkpoints
-	wg.Go(func() error {
-		var err error
-		finalityCheckpoints, err = c.getFinalityCheckpoints("head")
-		return err
-	})
+    // Get finality checkpoints
+    wg.Go(func() error {
+        var err error
+        finalityCheckpoints, err = c.getFinalityCheckpoints("head")
+        return err
+    })
 
-	// Wait for data
-	if err := wg.Wait(); err != nil {
-		return beacon.BeaconHead{}, err
-	}
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return beacon.BeaconHead{}, err
+    }
 
-	// Return response
-	return beacon.BeaconHead{
-		Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
-		FinalizedEpoch:         uint64(finalityCheckpoints.Data.Finalized.Epoch),
-		JustifiedEpoch:         uint64(finalityCheckpoints.Data.CurrentJustified.Epoch),
-		PreviousJustifiedEpoch: uint64(finalityCheckpoints.Data.PreviousJustified.Epoch),
-	}, nil
+    // Return response
+    return beacon.BeaconHead{
+        Epoch:                  eth2.EpochAt(eth2Config, uint64(time.Now().Unix())),
+        FinalizedEpoch:         uint64(finalityCheckpoints.Data.Finalized.Epoch),
+        JustifiedEpoch:         uint64(finalityCheckpoints.Data.CurrentJustified.Epoch),
+        PreviousJustifiedEpoch: uint64(finalityCheckpoints.Data.PreviousJustified.Epoch),
+    }, nil
 
 }
 
 // Get a validator's status
 func (c *Client) GetValidatorStatus(pubkey types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (beacon.ValidatorStatus, error) {
 
-	// Get validator
-	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
-	if err != nil {
-		return beacon.ValidatorStatus{}, err
-	}
-	if len(validators.Data) == 0 {
-		return beacon.ValidatorStatus{}, nil
-	}
-	validator := validators.Data[0]
+    // Get validator
+    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, opts)
+    if err != nil {
+        return beacon.ValidatorStatus{}, err
+    }
+    if len(validators.Data) == 0 {
+        return beacon.ValidatorStatus{}, nil
+    }
+    validator := validators.Data[0]
 
-	// Return response
-	return beacon.ValidatorStatus{
-		Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
-		WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
-		Balance:                    uint64(validator.Balance),
-		EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
-		Slashed:                    validator.Validator.Slashed,
-		ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-		ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-		ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-		WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-		Exists:                     true,
-	}, nil
+    // Return response
+    return beacon.ValidatorStatus{
+        Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+        WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+        Balance:                    uint64(validator.Balance),
+        EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+        Slashed:                    validator.Validator.Slashed,
+        ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+        ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+        ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+        WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+        Exists:                     true,
+    }, nil
 
 }
 
 // Get multiple validators' statuses
 func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (map[types.ValidatorPubkey]beacon.ValidatorStatus, error) {
 
-	// Get validators
-	validators, err := c.getValidatorsByOpts(pubkeys, opts)
-	if err != nil {
-		return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
-	}
+    // Get validators
+    validators, err := c.getValidatorsByOpts(pubkeys, opts)
+    if err != nil {
+        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, err
+    }
 
-	// Build validator status map
-	statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
-	for _, validator := range validators.Data {
+    // Build validator status map
+    statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
+    for _, validator := range validators.Data {
 
-		// Get validator pubkey
-		pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
+        // Get validator pubkey
+        pubkey := types.BytesToValidatorPubkey(validator.Validator.Pubkey)
 
-		// Add status
-		statuses[pubkey] = beacon.ValidatorStatus{
-			Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
-			WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
-			Balance:                    uint64(validator.Balance),
-			EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
-			Slashed:                    validator.Validator.Slashed,
-			ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
-			ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
-			ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
-			WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
-			Exists:                     true,
-		}
+        // Add status
+        statuses[pubkey] = beacon.ValidatorStatus{
+            Pubkey:                     types.BytesToValidatorPubkey(validator.Validator.Pubkey),
+            WithdrawalCredentials:      common.BytesToHash(validator.Validator.WithdrawalCredentials),
+            Balance:                    uint64(validator.Balance),
+            EffectiveBalance:           uint64(validator.Validator.EffectiveBalance),
+            Slashed:                    validator.Validator.Slashed,
+            ActivationEligibilityEpoch: uint64(validator.Validator.ActivationEligibilityEpoch),
+            ActivationEpoch:            uint64(validator.Validator.ActivationEpoch),
+            ExitEpoch:                  uint64(validator.Validator.ExitEpoch),
+            WithdrawableEpoch:          uint64(validator.Validator.WithdrawableEpoch),
+            Exists:                     true,
+        }
 
-	}
+    }
 
-	// Return
-	return statuses, nil
+    // Return
+    return statuses, nil
 
 }
 
 // Get a validator's index
 func (c *Client) GetValidatorIndex(pubkey types.ValidatorPubkey) (uint64, error) {
 
-	// Get validator
-	validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
-	if err != nil {
-		return 0, err
-	}
-	if len(validators.Data) == 0 {
-		return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
-	}
-	validator := validators.Data[0]
+    // Get validator
+    validators, err := c.getValidatorsByOpts([]types.ValidatorPubkey{pubkey}, nil)
+    if err != nil {
+        return 0, err
+    }
+    if len(validators.Data) == 0 {
+        return 0, fmt.Errorf("Validator %s index not found.", pubkey.Hex())
+    }
+    validator := validators.Data[0]
 
-	// Return validator index
-	return uint64(validator.Index), nil
+    // Return validator index
+    return uint64(validator.Index), nil
 
 }
 
 // Get domain data for a domain type at a given epoch
 func (c *Client) GetDomainData(domainType []byte, epoch uint64) ([]byte, error) {
 
-	// Data
-	var wg errgroup.Group
-	var genesis GenesisResponse
-	var fork ForkResponse
+    // Data
+    var wg errgroup.Group
+    var genesis GenesisResponse
+    var fork ForkResponse
 
-	// Get genesis
-	wg.Go(func() error {
-		var err error
-		genesis, err = c.getGenesis()
-		return err
-	})
+    // Get genesis
+    wg.Go(func() error {
+        var err error
+        genesis, err = c.getGenesis()
+        return err
+    })
 
-	// Get fork
-	wg.Go(func() error {
-		var err error
-		fork, err = c.getFork("head")
-		return err
-	})
+    // Get fork
+    wg.Go(func() error {
+        var err error
+        fork, err = c.getFork("head")
+        return err
+    })
 
-	// Wait for data
-	if err := wg.Wait(); err != nil {
-		return []byte{}, err
-	}
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return []byte{}, err
+    }
 
-	// Get fork version
-	var forkVersion []byte
-	if epoch < uint64(fork.Data.Epoch) {
-		forkVersion = fork.Data.PreviousVersion
-	} else {
-		forkVersion = fork.Data.CurrentVersion
-	}
+    // Get fork version
+    var forkVersion []byte
+    if epoch < uint64(fork.Data.Epoch) {
+        forkVersion = fork.Data.PreviousVersion
+    } else {
+        forkVersion = fork.Data.CurrentVersion
+    }
 
-	// Compute & return domain
-	var dt [4]byte
-	copy(dt[:], domainType[:])
-	return eth2types.Domain(dt, forkVersion, genesis.Data.GenesisValidatorsRoot), nil
+    // Compute & return domain
+    var dt [4]byte
+    copy(dt[:], domainType[:])
+    return eth2types.Domain(dt, forkVersion, genesis.Data.GenesisValidatorsRoot), nil
 
 }
 
 // Perform a voluntary exit on a validator
 func (c *Client) ExitValidator(validatorIndex, epoch uint64, signature types.ValidatorSignature) error {
-	return c.postVoluntaryExit(VoluntaryExitRequest{
-		Message: VoluntaryExitMessage{
-			Epoch:          uinteger(epoch),
-			ValidatorIndex: uinteger(validatorIndex),
-		},
-		Signature: signature.Bytes(),
-	})
+    return c.postVoluntaryExit(VoluntaryExitRequest{
+        Message: VoluntaryExitMessage{
+            Epoch:          uinteger(epoch),
+            ValidatorIndex: uinteger(validatorIndex),
+        },
+        Signature: signature.Bytes(),
+    })
 }
 
 // Get sync status
 func (c *Client) getSyncStatus() (SyncStatusResponse, error) {
-	responseBody, status, err := c.getRequest(RequestSyncStatusPath)
-	if err != nil {
-		return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
-	} else if status != http.StatusOK {
-		return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: HTTP status %d; response body: '%s'", status, string(responseBody))
-	}
-	var syncStatus SyncStatusResponse
-	if err := json.Unmarshal(responseBody, &syncStatus); err != nil {
-		return SyncStatusResponse{}, fmt.Errorf("Could not decode node sync status: %w", err)
-	}
-	return syncStatus, nil
+    responseBody, status, err := c.getRequest(RequestSyncStatusPath)
+    if err != nil {
+        return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: %w", err)
+    } else if status != http.StatusOK {
+        return SyncStatusResponse{}, fmt.Errorf("Could not get node sync status: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var syncStatus SyncStatusResponse
+    if err := json.Unmarshal(responseBody, &syncStatus); err != nil {
+        return SyncStatusResponse{}, fmt.Errorf("Could not decode node sync status: %w", err)
+    }
+    return syncStatus, nil
 }
 
 // Get the eth2 config
 func (c *Client) getEth2Config() (Eth2ConfigResponse, error) {
-	responseBody, status, err := c.getRequest(RequestEth2ConfigPath)
-	if err != nil {
-		return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
-	} else if status != http.StatusOK {
-		return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: HTTP status %d; response body: '%s'", status, string(responseBody))
-	}
-	var eth2Config Eth2ConfigResponse
-	if err := json.Unmarshal(responseBody, &eth2Config); err != nil {
-		return Eth2ConfigResponse{}, fmt.Errorf("Could not decode eth2 config: %w", err)
-	}
-	return eth2Config, nil
+    responseBody, status, err := c.getRequest(RequestEth2ConfigPath)
+    if err != nil {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: %w", err)
+    } else if status != http.StatusOK {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not get eth2 config: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var eth2Config Eth2ConfigResponse
+    if err := json.Unmarshal(responseBody, &eth2Config); err != nil {
+        return Eth2ConfigResponse{}, fmt.Errorf("Could not decode eth2 config: %w", err)
+    }
+    return eth2Config, nil
 }
 
 // Get genesis information
 func (c *Client) getGenesis() (GenesisResponse, error) {
-	responseBody, status, err := c.getRequest(RequestGenesisPath)
-	if err != nil {
-		return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
-	} else if status != http.StatusOK {
-		return GenesisResponse{}, fmt.Errorf("Could not get genesis data: HTTP status %d; response body: '%s'", status, string(responseBody))
-	}
-	var genesis GenesisResponse
-	if err := json.Unmarshal(responseBody, &genesis); err != nil {
-		return GenesisResponse{}, fmt.Errorf("Could not decode genesis: %w", err)
-	}
-	return genesis, nil
+    responseBody, status, err := c.getRequest(RequestGenesisPath)
+    if err != nil {
+        return GenesisResponse{}, fmt.Errorf("Could not get genesis data: %w", err)
+    } else if status != http.StatusOK {
+        return GenesisResponse{}, fmt.Errorf("Could not get genesis data: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var genesis GenesisResponse
+    if err := json.Unmarshal(responseBody, &genesis); err != nil {
+        return GenesisResponse{}, fmt.Errorf("Could not decode genesis: %w", err)
+    }
+    return genesis, nil
 }
 
 // Get finality checkpoints
 func (c *Client) getFinalityCheckpoints(stateId string) (FinalityCheckpointsResponse, error) {
-	responseBody, status, err := c.getRequest(fmt.Sprintf(RequestFinalityCheckpointsPath, stateId))
-	if err != nil {
-		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
-	} else if status != http.StatusOK {
-		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: HTTP status %d; response body: '%s'", status, string(responseBody))
-	}
-	var finalityCheckpoints FinalityCheckpointsResponse
-	if err := json.Unmarshal(responseBody, &finalityCheckpoints); err != nil {
-		return FinalityCheckpointsResponse{}, fmt.Errorf("Could not decode finality checkpoints: %w", err)
-	}
-	return finalityCheckpoints, nil
+    responseBody, status, err := c.getRequest(fmt.Sprintf(RequestFinalityCheckpointsPath, stateId))
+    if err != nil {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: %w", err)
+    } else if status != http.StatusOK {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not get finality checkpoints: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var finalityCheckpoints FinalityCheckpointsResponse
+    if err := json.Unmarshal(responseBody, &finalityCheckpoints); err != nil {
+        return FinalityCheckpointsResponse{}, fmt.Errorf("Could not decode finality checkpoints: %w", err)
+    }
+    return finalityCheckpoints, nil
 }
 
 // Get fork
 func (c *Client) getFork(stateId string) (ForkResponse, error) {
-	responseBody, status, err := c.getRequest(fmt.Sprintf(RequestForkPath, stateId))
-	if err != nil {
-		return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
-	} else if status != http.StatusOK {
-		return ForkResponse{}, fmt.Errorf("Could not get fork data: HTTP status %d; response body: '%s'", status, string(responseBody))
-	}
-	var fork ForkResponse
-	if err := json.Unmarshal(responseBody, &fork); err != nil {
-		return ForkResponse{}, fmt.Errorf("Could not decode fork data: %w", err)
-	}
-	return fork, nil
+    responseBody, status, err := c.getRequest(fmt.Sprintf(RequestForkPath, stateId))
+    if err != nil {
+        return ForkResponse{}, fmt.Errorf("Could not get fork data: %w", err)
+    } else if status != http.StatusOK {
+        return ForkResponse{}, fmt.Errorf("Could not get fork data: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var fork ForkResponse
+    if err := json.Unmarshal(responseBody, &fork); err != nil {
+        return ForkResponse{}, fmt.Errorf("Could not decode fork data: %w", err)
+    }
+    return fork, nil
 }
 
 // Get validators
 func (c *Client) getValidators(stateId string, pubkeys []string) (ValidatorsResponse, error) {
-	var query string
-	if len(pubkeys) > 0 {
-		query = fmt.Sprintf("?id=%s", strings.Join(pubkeys, ","))
-	}
-	responseBody, status, err := c.getRequest(fmt.Sprintf(RequestValidatorsPath, stateId) + query)
-	if err != nil {
-		return ValidatorsResponse{}, fmt.Errorf("Could not get validators: %w", err)
-	} else if status != http.StatusOK {
-		return ValidatorsResponse{}, fmt.Errorf("Could not get validators: HTTP status %d; response body: '%s'", status, string(responseBody))
-	}
-	var validators ValidatorsResponse
-	if err := json.Unmarshal(responseBody, &validators); err != nil {
-		return ValidatorsResponse{}, fmt.Errorf("Could not decode validators: %w", err)
-	}
-	return validators, nil
+    var query string
+    if len(pubkeys) > 0 {
+        query = fmt.Sprintf("?id=%s", strings.Join(pubkeys, ","))
+    }
+    responseBody, status, err := c.getRequest(fmt.Sprintf(RequestValidatorsPath, stateId) + query)
+    if err != nil {
+        return ValidatorsResponse{}, fmt.Errorf("Could not get validators: %w", err)
+    } else if status != http.StatusOK {
+        return ValidatorsResponse{}, fmt.Errorf("Could not get validators: HTTP status %d; response body: '%s'", status, string(responseBody))
+    }
+    var validators ValidatorsResponse
+    if err := json.Unmarshal(responseBody, &validators); err != nil {
+        return ValidatorsResponse{}, fmt.Errorf("Could not decode validators: %w", err)
+    }
+    return validators, nil
 }
 
 // Get validators by pubkeys and status options
 func (c *Client) getValidatorsByOpts(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (ValidatorsResponse, error) {
 
-	// Get state ID
-	var stateId string
-	if opts == nil {
-		stateId = "head"
-	} else {
+    // Get state ID
+    var stateId string
+    if opts == nil {
+        stateId = "head"
+    } else {
 
-		// Get eth2 config
-		eth2Config, err := c.getEth2Config()
-		if err != nil {
-			return ValidatorsResponse{}, err
-		}
+        // Get eth2 config
+        eth2Config, err := c.getEth2Config()
+        if err != nil {
+            return ValidatorsResponse{}, err
+        }
 
-		// Get slot nuimber
-		slot := opts.Epoch * uint64(eth2Config.Data.SlotsPerEpoch)
-		stateId = strconv.FormatInt(int64(slot), 10)
+        // Get slot nuimber
+        slot := opts.Epoch * uint64(eth2Config.Data.SlotsPerEpoch)
+        stateId = strconv.FormatInt(int64(slot), 10)
 
-	}
+    }
 
-	// Get validators
-	if len(pubkeys) <= MaxRequestValidatorsCount {
+    // Get validators
+    if len(pubkeys) <= MaxRequestValidatorsCount {
 
-		// Get validator pubkeys
-		pubkeysHex := make([]string, len(pubkeys))
-		for ki, pubkey := range pubkeys {
-			pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
-		}
+        // Get validator pubkeys
+        pubkeysHex := make([]string, len(pubkeys))
+        for ki, pubkey := range pubkeys {
+            pubkeysHex[ki] = hexutil.AddPrefix(pubkey.Hex())
+        }
 
-		// Get & return validators
-		return c.getValidators(stateId, pubkeysHex)
+        // Get & return validators
+        return c.getValidators(stateId, pubkeysHex)
 
-	} else {
+    } else {
 
-		// Get all validators
-		validators, err := c.getValidators(stateId, []string{})
-		if err != nil {
-			return ValidatorsResponse{}, err
-		}
+        // Get all validators
+        validators, err := c.getValidators(stateId, []string{})
+        if err != nil {
+            return ValidatorsResponse{}, err
+        }
 
-		// Filter validator set by pubkeys and return
-		response := ValidatorsResponse{}
-		for _, validator := range validators.Data {
-			var found bool
-			for _, pubkey := range pubkeys {
-				if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
-			response.Data = append(response.Data, validator)
-		}
-		return response, nil
+        // Filter validator set by pubkeys and return
+        response := ValidatorsResponse{}
+        for _, validator := range validators.Data {
+            var found bool
+            for _, pubkey := range pubkeys {
+                if bytes.Equal(validator.Validator.Pubkey, pubkey.Bytes()) {
+                    found = true
+                    break
+                }
+            }
+            if !found {
+                continue
+            }
+            response.Data = append(response.Data, validator)
+        }
+        return response, nil
 
-	}
+    }
 
 }
 
 // Send voluntary exit request
 func (c *Client) postVoluntaryExit(request VoluntaryExitRequest) error {
-	responseBody, status, err := c.postRequest(RequestVoluntaryExitPath, request)
-	if err != nil {
-		return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
-	} else if status != http.StatusOK {
-		return fmt.Errorf("Could not broadcast exit for validator at index %d: HTTP status %d; response body: '%s'", request.Message.ValidatorIndex, status, string(responseBody))
-	}
-	return nil
+    responseBody, status, err := c.postRequest(RequestVoluntaryExitPath, request)
+    if err != nil {
+        return fmt.Errorf("Could not broadcast exit for validator at index %d: %w", request.Message.ValidatorIndex, err)
+    } else if status != http.StatusOK {
+        return fmt.Errorf("Could not broadcast exit for validator at index %d: HTTP status %d; response body: '%s'", request.Message.ValidatorIndex, status, string(responseBody))
+    }
+    return nil
 }
 
 // Make a GET request to the beacon node
 func (c *Client) getRequest(requestPath string) ([]byte, int, error) {
 
-	// Send request
-	response, err := http.Get(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath))
-	if err != nil {
-		return []byte{}, 0, err
-	}
-	defer response.Body.Close()
+    // Send request
+    response, err := http.Get(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath))
+    if err != nil {
+        return []byte{}, 0, err
+    }
+    defer response.Body.Close()
 
-	// Get response
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return []byte{}, 0, err
-	}
+    // Get response
+    body, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+        return []byte{}, 0, err
+    }
 
-	// Return
-	return body, response.StatusCode, nil
+    // Return
+    return body, response.StatusCode, nil
 
 }
 
 // Make a POST request to the beacon node
 func (c *Client) postRequest(requestPath string, requestBody interface{}) ([]byte, int, error) {
 
-	// Get request body
-	requestBodyBytes, err := json.Marshal(requestBody)
-	if err != nil {
-		return []byte{}, 0, err
-	}
-	requestBodyReader := bytes.NewReader(requestBodyBytes)
+    // Get request body
+    requestBodyBytes, err := json.Marshal(requestBody)
+    if err != nil {
+        return []byte{}, 0, err
+    }
+    requestBodyReader := bytes.NewReader(requestBodyBytes)
 
-	// Send request
-	response, err := http.Post(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath), RequestContentType, requestBodyReader)
-	if err != nil {
-		return []byte{}, 0, err
-	}
-	defer response.Body.Close()
+    // Send request
+    response, err := http.Post(fmt.Sprintf(RequestUrlFormat, RequestProtocol, c.providerAddress, requestPath), RequestContentType, requestBodyReader)
+    if err != nil {
+        return []byte{}, 0, err
+    }
+    defer response.Body.Close()
 
-	// Get response
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return []byte{}, 0, err
-	}
+    // Get response
+    body, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+        return []byte{}, 0, err
+    }
 
-	// Return
-	return body, response.StatusCode, nil
+    // Return
+    return body, response.StatusCode, nil
 
 }

--- a/shared/services/beacon/teku/client.go
+++ b/shared/services/beacon/teku/client.go
@@ -52,6 +52,11 @@ func NewClient(providerAddress string) *Client {
 // Close the client connection
 func (c *Client) Close() {}
 
+// Get the beacon client type
+func (c *Client) GetClientType() (beacon.BeaconClientType) {
+    return beacon.SplitProcess;
+}
+
 // Get the node's sync status
 func (c *Client) GetSyncStatus() (beacon.SyncStatus, error) {
 

--- a/shared/services/beacon/teku/types.go
+++ b/shared/services/beacon/teku/types.go
@@ -1,0 +1,130 @@
+package teku
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+
+	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+// Request types
+type VoluntaryExitRequest struct {
+	Message   VoluntaryExitMessage `json:"message"`
+	Signature byteArray            `json:"signature"`
+}
+type VoluntaryExitMessage struct {
+	Epoch          uinteger `json:"epoch"`
+	ValidatorIndex uinteger `json:"validator_index"`
+}
+
+// Response types
+type SyncStatusResponse struct {
+	Data struct {
+		HeadSlot     uinteger `json:"head_slot"`
+		SyncDistance uinteger `json:"sync_distance"`
+	} `json:"data"`
+}
+type Eth2ConfigResponse struct {
+	Data struct {
+		SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
+		SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
+	} `json:"data"`
+}
+type GenesisResponse struct {
+	Data struct {
+		GenesisTime           uinteger  `json:"genesis_time"`
+		GenesisForkVersion    byteArray `json:"genesis_fork_version"`
+		GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
+	} `json:"data"`
+}
+type FinalityCheckpointsResponse struct {
+	Data struct {
+		PreviousJustified struct {
+			Epoch uinteger `json:"epoch"`
+		} `json:"previous_justified"`
+		CurrentJustified struct {
+			Epoch uinteger `json:"epoch"`
+		} `json:"current_justified"`
+		Finalized struct {
+			Epoch uinteger `json:"epoch"`
+		} `json:"finalized"`
+	} `json:"data"`
+}
+type ForkResponse struct {
+	Data struct {
+		PreviousVersion byteArray `json:"previous_version"`
+		CurrentVersion  byteArray `json:"current_version"`
+		Epoch           uinteger  `json:"epoch"`
+	} `json:"data"`
+}
+type ValidatorsResponse struct {
+	Data []Validator `json:"data"`
+}
+type Validator struct {
+	Index     uinteger `json:"index"`
+	Balance   uinteger `json:"balance"`
+	Status    string   `json:"status"`
+	Validator struct {
+		Pubkey                     byteArray `json:"pubkey"`
+		WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
+		EffectiveBalance           uinteger  `json:"effective_balance"`
+		Slashed                    bool      `json:"slashed"`
+		ActivationEligibilityEpoch uinteger  `json:"activation_eligibility_epoch"`
+		ActivationEpoch            uinteger  `json:"activation_epoch"`
+		ExitEpoch                  uinteger  `json:"exit_epoch"`
+		WithdrawableEpoch          uinteger  `json:"withdrawable_epoch"`
+	} `json:"validator"`
+}
+
+// Unsigned integer type
+type uinteger uint64
+
+func (i uinteger) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.Itoa(int(i)))
+}
+func (i *uinteger) UnmarshalJSON(data []byte) error {
+
+	// Unmarshal string
+	var dataStr string
+	if err := json.Unmarshal(data, &dataStr); err != nil {
+		return err
+	}
+
+	// Parse integer value
+	value, err := strconv.ParseUint(dataStr, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	// Set value and return
+	*i = uinteger(value)
+	return nil
+
+}
+
+// Byte array type
+type byteArray []byte
+
+func (b byteArray) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
+}
+func (b *byteArray) UnmarshalJSON(data []byte) error {
+
+	// Unmarshal string
+	var dataStr string
+	if err := json.Unmarshal(data, &dataStr); err != nil {
+		return err
+	}
+
+	// Decode hex
+	value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
+	if err != nil {
+		return err
+	}
+
+	// Set value and return
+	*b = value
+	return nil
+
+}

--- a/shared/services/beacon/teku/types.go
+++ b/shared/services/beacon/teku/types.go
@@ -1,105 +1,105 @@
 package teku
 
 import (
-	"encoding/hex"
-	"encoding/json"
-	"strconv"
+    "encoding/hex"
+    "encoding/json"
+    "strconv"
 
-	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Request types
 type VoluntaryExitRequest struct {
-	Message   VoluntaryExitMessage `json:"message"`
-	Signature byteArray            `json:"signature"`
+    Message   VoluntaryExitMessage `json:"message"`
+    Signature byteArray            `json:"signature"`
 }
 type VoluntaryExitMessage struct {
-	Epoch          uinteger `json:"epoch"`
-	ValidatorIndex uinteger `json:"validator_index"`
+    Epoch          uinteger `json:"epoch"`
+    ValidatorIndex uinteger `json:"validator_index"`
 }
 
 // Response types
 type SyncStatusResponse struct {
-	Data struct {
-		HeadSlot     uinteger `json:"head_slot"`
-		SyncDistance uinteger `json:"sync_distance"`
-	} `json:"data"`
+    Data struct {
+        HeadSlot     uinteger `json:"head_slot"`
+        SyncDistance uinteger `json:"sync_distance"`
+    } `json:"data"`
 }
 type Eth2ConfigResponse struct {
-	Data struct {
-		SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
-		SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
-	} `json:"data"`
+    Data struct {
+        SecondsPerSlot uinteger `json:"SECONDS_PER_SLOT"`
+        SlotsPerEpoch  uinteger `json:"SLOTS_PER_EPOCH"`
+    } `json:"data"`
 }
 type GenesisResponse struct {
-	Data struct {
-		GenesisTime           uinteger  `json:"genesis_time"`
-		GenesisForkVersion    byteArray `json:"genesis_fork_version"`
-		GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
-	} `json:"data"`
+    Data struct {
+        GenesisTime           uinteger  `json:"genesis_time"`
+        GenesisForkVersion    byteArray `json:"genesis_fork_version"`
+        GenesisValidatorsRoot byteArray `json:"genesis_validators_root"`
+    } `json:"data"`
 }
 type FinalityCheckpointsResponse struct {
-	Data struct {
-		PreviousJustified struct {
-			Epoch uinteger `json:"epoch"`
-		} `json:"previous_justified"`
-		CurrentJustified struct {
-			Epoch uinteger `json:"epoch"`
-		} `json:"current_justified"`
-		Finalized struct {
-			Epoch uinteger `json:"epoch"`
-		} `json:"finalized"`
-	} `json:"data"`
+    Data struct {
+        PreviousJustified struct {
+            Epoch uinteger `json:"epoch"`
+        } `json:"previous_justified"`
+        CurrentJustified struct {
+            Epoch uinteger `json:"epoch"`
+        } `json:"current_justified"`
+        Finalized struct {
+            Epoch uinteger `json:"epoch"`
+        } `json:"finalized"`
+    } `json:"data"`
 }
 type ForkResponse struct {
-	Data struct {
-		PreviousVersion byteArray `json:"previous_version"`
-		CurrentVersion  byteArray `json:"current_version"`
-		Epoch           uinteger  `json:"epoch"`
-	} `json:"data"`
+    Data struct {
+        PreviousVersion byteArray `json:"previous_version"`
+        CurrentVersion  byteArray `json:"current_version"`
+        Epoch           uinteger  `json:"epoch"`
+    } `json:"data"`
 }
 type ValidatorsResponse struct {
-	Data []Validator `json:"data"`
+    Data []Validator `json:"data"`
 }
 type Validator struct {
-	Index     uinteger `json:"index"`
-	Balance   uinteger `json:"balance"`
-	Status    string   `json:"status"`
-	Validator struct {
-		Pubkey                     byteArray `json:"pubkey"`
-		WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
-		EffectiveBalance           uinteger  `json:"effective_balance"`
-		Slashed                    bool      `json:"slashed"`
-		ActivationEligibilityEpoch uinteger  `json:"activation_eligibility_epoch"`
-		ActivationEpoch            uinteger  `json:"activation_epoch"`
-		ExitEpoch                  uinteger  `json:"exit_epoch"`
-		WithdrawableEpoch          uinteger  `json:"withdrawable_epoch"`
-	} `json:"validator"`
+    Index     uinteger `json:"index"`
+    Balance   uinteger `json:"balance"`
+    Status    string   `json:"status"`
+    Validator struct {
+        Pubkey                     byteArray `json:"pubkey"`
+        WithdrawalCredentials      byteArray `json:"withdrawal_credentials"`
+        EffectiveBalance           uinteger  `json:"effective_balance"`
+        Slashed                    bool      `json:"slashed"`
+        ActivationEligibilityEpoch uinteger  `json:"activation_eligibility_epoch"`
+        ActivationEpoch            uinteger  `json:"activation_epoch"`
+        ExitEpoch                  uinteger  `json:"exit_epoch"`
+        WithdrawableEpoch          uinteger  `json:"withdrawable_epoch"`
+    } `json:"validator"`
 }
 
 // Unsigned integer type
 type uinteger uint64
 
 func (i uinteger) MarshalJSON() ([]byte, error) {
-	return json.Marshal(strconv.Itoa(int(i)))
+    return json.Marshal(strconv.Itoa(int(i)))
 }
 func (i *uinteger) UnmarshalJSON(data []byte) error {
 
-	// Unmarshal string
-	var dataStr string
-	if err := json.Unmarshal(data, &dataStr); err != nil {
-		return err
-	}
+    // Unmarshal string
+    var dataStr string
+    if err := json.Unmarshal(data, &dataStr); err != nil {
+        return err
+    }
 
-	// Parse integer value
-	value, err := strconv.ParseUint(dataStr, 10, 64)
-	if err != nil {
-		return err
-	}
+    // Parse integer value
+    value, err := strconv.ParseUint(dataStr, 10, 64)
+    if err != nil {
+        return err
+    }
 
-	// Set value and return
-	*i = uinteger(value)
-	return nil
+    // Set value and return
+    *i = uinteger(value)
+    return nil
 
 }
 
@@ -107,24 +107,24 @@ func (i *uinteger) UnmarshalJSON(data []byte) error {
 type byteArray []byte
 
 func (b byteArray) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
+    return json.Marshal(hexutil.AddPrefix(hex.EncodeToString(b)))
 }
 func (b *byteArray) UnmarshalJSON(data []byte) error {
 
-	// Unmarshal string
-	var dataStr string
-	if err := json.Unmarshal(data, &dataStr); err != nil {
-		return err
-	}
+    // Unmarshal string
+    var dataStr string
+    if err := json.Unmarshal(data, &dataStr); err != nil {
+        return err
+    }
 
-	// Decode hex
-	value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
-	if err != nil {
-		return err
-	}
+    // Decode hex
+    value, err := hex.DecodeString(hexutil.RemovePrefix(dataStr))
+    if err != nil {
+        return err
+    }
 
-	// Set value and return
-	*b = value
-	return nil
+    // Set value and return
+    *b = value
+    return nil
 
 }

--- a/shared/services/config/config.go
+++ b/shared/services/config/config.go
@@ -29,6 +29,7 @@ type RocketPoolConfig struct {
 }
 type Chain struct {
     Provider string                     `yaml:"provider,omitempty"`
+    WsProvider string                   `yaml:"ws_provider,omitempty"` // Websocket API for ETH1
     Client struct {
         Options []ClientOption          `yaml:"options,omitempty"`
         Selected string                 `yaml:"selected,omitempty"`

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -340,6 +340,7 @@ func (c *Client) compose(composeFiles []string, args string) (string, error) {
         fmt.Sprintf("VALIDATOR_CLIENT='%s'",        cfg.GetSelectedEth2Client().ID),
         fmt.Sprintf("VALIDATOR_IMAGE='%s'",         cfg.GetSelectedEth2Client().GetValidatorImage()),
         fmt.Sprintf("ETH1_PROVIDER='%s'",           cfg.Chains.Eth1.Provider),
+        fmt.Sprintf("ETH1_WS_PROVIDER='%s'",        cfg.Chains.Eth1.WsProvider),
         fmt.Sprintf("ETH2_PROVIDER='%s'",           cfg.Chains.Eth2.Provider),
     }
     for _, param := range cfg.Chains.Eth1.Client.Params {

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -1,196 +1,178 @@
 package services
 
 import (
-    "fmt"
-    "sync"
+	"fmt"
+	"sync"
 
-    "github.com/docker/docker/client"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/ethclient"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/urfave/cli"
+	"github.com/docker/docker/client"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/urfave/cli"
 
-    "github.com/rocket-pool/smartnode/shared/services/beacon"
-    "github.com/rocket-pool/smartnode/shared/services/beacon/lighthouse"
-    "github.com/rocket-pool/smartnode/shared/services/beacon/prysm"
-    "github.com/rocket-pool/smartnode/shared/services/config"
-    "github.com/rocket-pool/smartnode/shared/services/passwords"
-    "github.com/rocket-pool/smartnode/shared/services/wallet"
-    lhkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
-    prkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
-    tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
+	"github.com/rocket-pool/smartnode/shared/services/beacon/lighthouse"
+	"github.com/rocket-pool/smartnode/shared/services/beacon/prysm"
+	"github.com/rocket-pool/smartnode/shared/services/beacon/teku"
+	"github.com/rocket-pool/smartnode/shared/services/config"
+	"github.com/rocket-pool/smartnode/shared/services/passwords"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
+	lhkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
+	prkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
+	tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
 )
-
 
 // Config
 const DockerAPIVersion = "1.40"
 
-
 // Service instances & initializers
 var (
-    cfg config.RocketPoolConfig
-    passwordManager *passwords.PasswordManager
-    nodeWallet *wallet.Wallet
-    ethClient *ethclient.Client
-    rocketPool *rocketpool.RocketPool
-    beaconClient beacon.Client
-    docker *client.Client
+	cfg             config.RocketPoolConfig
+	passwordManager *passwords.PasswordManager
+	nodeWallet      *wallet.Wallet
+	ethClient       *ethclient.Client
+	rocketPool      *rocketpool.RocketPool
+	beaconClient    beacon.Client
+	docker          *client.Client
 
-    initCfg sync.Once
-    initPasswordManager sync.Once
-    initNodeWallet sync.Once
-    initEthClient sync.Once
-    initRocketPool sync.Once
-    initBeaconClient sync.Once
-    initDocker sync.Once
+	initCfg             sync.Once
+	initPasswordManager sync.Once
+	initNodeWallet      sync.Once
+	initEthClient       sync.Once
+	initRocketPool      sync.Once
+	initBeaconClient    sync.Once
+	initDocker          sync.Once
 )
-
 
 //
 // Service providers
 //
 
-
 func GetConfig(c *cli.Context) (config.RocketPoolConfig, error) {
-    return getConfig(c)
+	return getConfig(c)
 }
-
 
 func GetPasswordManager(c *cli.Context) (*passwords.PasswordManager, error) {
-    cfg, err := getConfig(c)
-    if err != nil {
-        return nil, err
-    }
-    return getPasswordManager(cfg), nil
+	cfg, err := getConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	return getPasswordManager(cfg), nil
 }
-
 
 func GetWallet(c *cli.Context) (*wallet.Wallet, error) {
-    cfg, err := getConfig(c)
-    if err != nil {
-        return nil, err
-    }
-    pm := getPasswordManager(cfg)
-    return getWallet(cfg, pm)
+	cfg, err := getConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	pm := getPasswordManager(cfg)
+	return getWallet(cfg, pm)
 }
-
 
 func GetEthClient(c *cli.Context) (*ethclient.Client, error) {
-    cfg, err := getConfig(c)
-    if err != nil {
-        return nil, err
-    }
-    return getEthClient(cfg)
+	cfg, err := getConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	return getEthClient(cfg)
 }
-
 
 func GetRocketPool(c *cli.Context) (*rocketpool.RocketPool, error) {
-    cfg, err := getConfig(c)
-    if err != nil {
-        return nil, err
-    }
-    ec, err := getEthClient(cfg)
-    if err != nil {
-        return nil, err
-    }
-    return getRocketPool(cfg, ec)
+	cfg, err := getConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	ec, err := getEthClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return getRocketPool(cfg, ec)
 }
-
 
 func GetBeaconClient(c *cli.Context) (beacon.Client, error) {
-    cfg, err := getConfig(c)
-    if err != nil {
-        return nil, err
-    }
-    return getBeaconClient(cfg)
+	cfg, err := getConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	return getBeaconClient(cfg)
 }
-
 
 func GetDocker(c *cli.Context) (*client.Client, error) {
-    return getDocker()
+	return getDocker()
 }
-
 
 //
 // Service instance getters
 //
 
-
 func getConfig(c *cli.Context) (config.RocketPoolConfig, error) {
-    var err error
-    initCfg.Do(func() {
-        cfg, err = config.Load(c)
-    })
-    return cfg, err
+	var err error
+	initCfg.Do(func() {
+		cfg, err = config.Load(c)
+	})
+	return cfg, err
 }
-
 
 func getPasswordManager(cfg config.RocketPoolConfig) *passwords.PasswordManager {
-    initPasswordManager.Do(func() {
-        passwordManager = passwords.NewPasswordManager(cfg.Smartnode.PasswordPath)
-    })
-    return passwordManager
+	initPasswordManager.Do(func() {
+		passwordManager = passwords.NewPasswordManager(cfg.Smartnode.PasswordPath)
+	})
+	return passwordManager
 }
-
 
 func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wallet.Wallet, error) {
-    var err error
-    initNodeWallet.Do(func() {
-        nodeWallet, err = wallet.NewWallet(cfg.Smartnode.WalletPath, pm)
-        if err == nil {
-            lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-            prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-            tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-            nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
-            nodeWallet.AddKeystore("prysm", prysmKeystore)
-            nodeWallet.AddKeystore("teku", tekuKeystore)
-        }
-    })
-    return nodeWallet, err
+	var err error
+	initNodeWallet.Do(func() {
+		nodeWallet, err = wallet.NewWallet(cfg.Smartnode.WalletPath, pm)
+		if err == nil {
+			lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+			prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+			tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+			nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
+			nodeWallet.AddKeystore("prysm", prysmKeystore)
+			nodeWallet.AddKeystore("teku", tekuKeystore)
+		}
+	})
+	return nodeWallet, err
 }
-
 
 func getEthClient(cfg config.RocketPoolConfig) (*ethclient.Client, error) {
-    var err error
-    initEthClient.Do(func() {
-        ethClient, err = ethclient.Dial(cfg.Chains.Eth1.Provider)
-    })
-    return ethClient, err
+	var err error
+	initEthClient.Do(func() {
+		ethClient, err = ethclient.Dial(cfg.Chains.Eth1.Provider)
+	})
+	return ethClient, err
 }
-
 
 func getRocketPool(cfg config.RocketPoolConfig, client *ethclient.Client) (*rocketpool.RocketPool, error) {
-    var err error
-    initRocketPool.Do(func() {
-        rocketPool, err = rocketpool.NewRocketPool(client, common.HexToAddress(cfg.Rocketpool.StorageAddress))
-    })
-    return rocketPool, err
+	var err error
+	initRocketPool.Do(func() {
+		rocketPool, err = rocketpool.NewRocketPool(client, common.HexToAddress(cfg.Rocketpool.StorageAddress))
+	})
+	return rocketPool, err
 }
-
 
 func getBeaconClient(cfg config.RocketPoolConfig) (beacon.Client, error) {
-    var err error
-    initBeaconClient.Do(func() {
-        switch cfg.Chains.Eth2.Client.Selected {
-            case "lighthouse":
-                beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
-            case "prysm":
-                beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
-            case "teku":
-                beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
-            default:
-                err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
-        }
-    })
-    return beaconClient, err
+	var err error
+	initBeaconClient.Do(func() {
+		switch cfg.Chains.Eth2.Client.Selected {
+		case "lighthouse":
+			beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
+		case "prysm":
+			beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
+		case "teku":
+			beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
+		default:
+			err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
+		}
+	})
+	return beaconClient, err
 }
-
 
 func getDocker() (*client.Client, error) {
-    var err error
-    initDocker.Do(func() {
-        docker, err = client.NewClientWithOpts(client.WithVersion(DockerAPIVersion))
-    })
-    return docker, err
+	var err error
+	initDocker.Do(func() {
+		docker, err = client.NewClientWithOpts(client.WithVersion(DockerAPIVersion))
+	})
+	return docker, err
 }
-

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -144,8 +144,8 @@ func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wal
             lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
             prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
             tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-			nimbusKeystore := nmkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-			nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
+            nimbusKeystore := nmkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+            nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
             nodeWallet.AddKeystore("prysm", prysmKeystore)
             nodeWallet.AddKeystore("teku", tekuKeystore)
             nodeWallet.AddKeystore("nimbus", nimbusKeystore)
@@ -182,8 +182,8 @@ func getBeaconClient(cfg config.RocketPoolConfig) (beacon.Client, error) {
             case "prysm":
                 beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
             case "teku":
-				beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
-			case "nimbus":
+                beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
+            case "nimbus":
                 beaconClient, err = nimbus.NewClient(cfg.Chains.Eth2.Provider)
             default:
                 err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -22,35 +22,40 @@ import (
     tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
 )
 
+
 // Config
 const DockerAPIVersion = "1.40"
 
+
 // Service instances & initializers
 var (
-    cfg             config.RocketPoolConfig
+    cfg config.RocketPoolConfig
     passwordManager *passwords.PasswordManager
-    nodeWallet      *wallet.Wallet
-    ethClient       *ethclient.Client
-    rocketPool      *rocketpool.RocketPool
-    beaconClient    beacon.Client
-    docker          *client.Client
+    nodeWallet *wallet.Wallet
+    ethClient *ethclient.Client
+    rocketPool *rocketpool.RocketPool
+    beaconClient beacon.Client
+    docker *client.Client
 
-    initCfg             sync.Once
+    initCfg sync.Once
     initPasswordManager sync.Once
-    initNodeWallet      sync.Once
-    initEthClient       sync.Once
-    initRocketPool      sync.Once
-    initBeaconClient    sync.Once
-    initDocker          sync.Once
+    initNodeWallet sync.Once
+    initEthClient sync.Once
+    initRocketPool sync.Once
+    initBeaconClient sync.Once
+    initDocker sync.Once
 )
+
 
 //
 // Service providers
 //
 
+
 func GetConfig(c *cli.Context) (config.RocketPoolConfig, error) {
     return getConfig(c)
 }
+
 
 func GetPasswordManager(c *cli.Context) (*passwords.PasswordManager, error) {
     cfg, err := getConfig(c)
@@ -59,6 +64,7 @@ func GetPasswordManager(c *cli.Context) (*passwords.PasswordManager, error) {
     }
     return getPasswordManager(cfg), nil
 }
+
 
 func GetWallet(c *cli.Context) (*wallet.Wallet, error) {
     cfg, err := getConfig(c)
@@ -69,6 +75,7 @@ func GetWallet(c *cli.Context) (*wallet.Wallet, error) {
     return getWallet(cfg, pm)
 }
 
+
 func GetEthClient(c *cli.Context) (*ethclient.Client, error) {
     cfg, err := getConfig(c)
     if err != nil {
@@ -76,6 +83,7 @@ func GetEthClient(c *cli.Context) (*ethclient.Client, error) {
     }
     return getEthClient(cfg)
 }
+
 
 func GetRocketPool(c *cli.Context) (*rocketpool.RocketPool, error) {
     cfg, err := getConfig(c)
@@ -89,6 +97,7 @@ func GetRocketPool(c *cli.Context) (*rocketpool.RocketPool, error) {
     return getRocketPool(cfg, ec)
 }
 
+
 func GetBeaconClient(c *cli.Context) (beacon.Client, error) {
     cfg, err := getConfig(c)
     if err != nil {
@@ -97,13 +106,16 @@ func GetBeaconClient(c *cli.Context) (beacon.Client, error) {
     return getBeaconClient(cfg)
 }
 
+
 func GetDocker(c *cli.Context) (*client.Client, error) {
     return getDocker()
 }
 
+
 //
 // Service instance getters
 //
+
 
 func getConfig(c *cli.Context) (config.RocketPoolConfig, error) {
     var err error
@@ -113,12 +125,14 @@ func getConfig(c *cli.Context) (config.RocketPoolConfig, error) {
     return cfg, err
 }
 
+
 func getPasswordManager(cfg config.RocketPoolConfig) *passwords.PasswordManager {
     initPasswordManager.Do(func() {
         passwordManager = passwords.NewPasswordManager(cfg.Smartnode.PasswordPath)
     })
     return passwordManager
 }
+
 
 func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wallet.Wallet, error) {
     var err error
@@ -136,6 +150,7 @@ func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wal
     return nodeWallet, err
 }
 
+
 func getEthClient(cfg config.RocketPoolConfig) (*ethclient.Client, error) {
     var err error
     initEthClient.Do(func() {
@@ -143,6 +158,7 @@ func getEthClient(cfg config.RocketPoolConfig) (*ethclient.Client, error) {
     })
     return ethClient, err
 }
+
 
 func getRocketPool(cfg config.RocketPoolConfig, client *ethclient.Client) (*rocketpool.RocketPool, error) {
     var err error
@@ -152,22 +168,24 @@ func getRocketPool(cfg config.RocketPoolConfig, client *ethclient.Client) (*rock
     return rocketPool, err
 }
 
+
 func getBeaconClient(cfg config.RocketPoolConfig) (beacon.Client, error) {
     var err error
     initBeaconClient.Do(func() {
         switch cfg.Chains.Eth2.Client.Selected {
-        case "lighthouse":
-            beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
-        case "prysm":
-            beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
-        case "teku":
-            beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
-        default:
-            err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
+            case "lighthouse":
+                beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
+            case "prysm":
+                beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
+            case "teku":
+                beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
+            default:
+                err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
         }
     })
     return beaconClient, err
 }
+
 
 func getDocker() (*client.Client, error) {
     var err error

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -14,12 +14,14 @@ import (
     "github.com/rocket-pool/smartnode/shared/services/beacon/lighthouse"
     "github.com/rocket-pool/smartnode/shared/services/beacon/prysm"
     "github.com/rocket-pool/smartnode/shared/services/beacon/teku"
+    "github.com/rocket-pool/smartnode/shared/services/beacon/nimbus"
     "github.com/rocket-pool/smartnode/shared/services/config"
     "github.com/rocket-pool/smartnode/shared/services/passwords"
     "github.com/rocket-pool/smartnode/shared/services/wallet"
     lhkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
     prkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
     tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
+    nmkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/nimbus"
 )
 
 
@@ -142,9 +144,11 @@ func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wal
             lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
             prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
             tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-            nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
+			nimbusKeystore := nmkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+			nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
             nodeWallet.AddKeystore("prysm", prysmKeystore)
             nodeWallet.AddKeystore("teku", tekuKeystore)
+            nodeWallet.AddKeystore("nimbus", nimbusKeystore)
         }
     })
     return nodeWallet, err
@@ -178,7 +182,9 @@ func getBeaconClient(cfg config.RocketPoolConfig) (beacon.Client, error) {
             case "prysm":
                 beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
             case "teku":
-                beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
+				beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
+			case "nimbus":
+                beaconClient, err = nimbus.NewClient(cfg.Chains.Eth2.Provider)
             default:
                 err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
         }

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -18,6 +18,7 @@ import (
     "github.com/rocket-pool/smartnode/shared/services/wallet"
     lhkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
     prkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
+    tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
 )
 
 
@@ -139,8 +140,10 @@ func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wal
         if err == nil {
             lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
             prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+            tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
             nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
             nodeWallet.AddKeystore("prysm", prysmKeystore)
+            nodeWallet.AddKeystore("teku", tekuKeystore)
         }
     })
     return nodeWallet, err
@@ -173,6 +176,8 @@ func getBeaconClient(cfg config.RocketPoolConfig) (beacon.Client, error) {
                 beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
             case "prysm":
                 beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
+            case "teku":
+                beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
             default:
                 err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
         }

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -1,25 +1,25 @@
 package services
 
 import (
-	"fmt"
-	"sync"
+    "fmt"
+    "sync"
 
-	"github.com/docker/docker/client"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/rocket-pool/rocketpool-go/rocketpool"
-	"github.com/urfave/cli"
+    "github.com/docker/docker/client"
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/ethereum/go-ethereum/ethclient"
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
+    "github.com/urfave/cli"
 
-	"github.com/rocket-pool/smartnode/shared/services/beacon"
-	"github.com/rocket-pool/smartnode/shared/services/beacon/lighthouse"
-	"github.com/rocket-pool/smartnode/shared/services/beacon/prysm"
-	"github.com/rocket-pool/smartnode/shared/services/beacon/teku"
-	"github.com/rocket-pool/smartnode/shared/services/config"
-	"github.com/rocket-pool/smartnode/shared/services/passwords"
-	"github.com/rocket-pool/smartnode/shared/services/wallet"
-	lhkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
-	prkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
-	tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
+    "github.com/rocket-pool/smartnode/shared/services/beacon"
+    "github.com/rocket-pool/smartnode/shared/services/beacon/lighthouse"
+    "github.com/rocket-pool/smartnode/shared/services/beacon/prysm"
+    "github.com/rocket-pool/smartnode/shared/services/beacon/teku"
+    "github.com/rocket-pool/smartnode/shared/services/config"
+    "github.com/rocket-pool/smartnode/shared/services/passwords"
+    "github.com/rocket-pool/smartnode/shared/services/wallet"
+    lhkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
+    prkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
+    tkkeystore "github.com/rocket-pool/smartnode/shared/services/wallet/keystore/teku"
 )
 
 // Config
@@ -27,21 +27,21 @@ const DockerAPIVersion = "1.40"
 
 // Service instances & initializers
 var (
-	cfg             config.RocketPoolConfig
-	passwordManager *passwords.PasswordManager
-	nodeWallet      *wallet.Wallet
-	ethClient       *ethclient.Client
-	rocketPool      *rocketpool.RocketPool
-	beaconClient    beacon.Client
-	docker          *client.Client
+    cfg             config.RocketPoolConfig
+    passwordManager *passwords.PasswordManager
+    nodeWallet      *wallet.Wallet
+    ethClient       *ethclient.Client
+    rocketPool      *rocketpool.RocketPool
+    beaconClient    beacon.Client
+    docker          *client.Client
 
-	initCfg             sync.Once
-	initPasswordManager sync.Once
-	initNodeWallet      sync.Once
-	initEthClient       sync.Once
-	initRocketPool      sync.Once
-	initBeaconClient    sync.Once
-	initDocker          sync.Once
+    initCfg             sync.Once
+    initPasswordManager sync.Once
+    initNodeWallet      sync.Once
+    initEthClient       sync.Once
+    initRocketPool      sync.Once
+    initBeaconClient    sync.Once
+    initDocker          sync.Once
 )
 
 //
@@ -49,56 +49,56 @@ var (
 //
 
 func GetConfig(c *cli.Context) (config.RocketPoolConfig, error) {
-	return getConfig(c)
+    return getConfig(c)
 }
 
 func GetPasswordManager(c *cli.Context) (*passwords.PasswordManager, error) {
-	cfg, err := getConfig(c)
-	if err != nil {
-		return nil, err
-	}
-	return getPasswordManager(cfg), nil
+    cfg, err := getConfig(c)
+    if err != nil {
+        return nil, err
+    }
+    return getPasswordManager(cfg), nil
 }
 
 func GetWallet(c *cli.Context) (*wallet.Wallet, error) {
-	cfg, err := getConfig(c)
-	if err != nil {
-		return nil, err
-	}
-	pm := getPasswordManager(cfg)
-	return getWallet(cfg, pm)
+    cfg, err := getConfig(c)
+    if err != nil {
+        return nil, err
+    }
+    pm := getPasswordManager(cfg)
+    return getWallet(cfg, pm)
 }
 
 func GetEthClient(c *cli.Context) (*ethclient.Client, error) {
-	cfg, err := getConfig(c)
-	if err != nil {
-		return nil, err
-	}
-	return getEthClient(cfg)
+    cfg, err := getConfig(c)
+    if err != nil {
+        return nil, err
+    }
+    return getEthClient(cfg)
 }
 
 func GetRocketPool(c *cli.Context) (*rocketpool.RocketPool, error) {
-	cfg, err := getConfig(c)
-	if err != nil {
-		return nil, err
-	}
-	ec, err := getEthClient(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return getRocketPool(cfg, ec)
+    cfg, err := getConfig(c)
+    if err != nil {
+        return nil, err
+    }
+    ec, err := getEthClient(cfg)
+    if err != nil {
+        return nil, err
+    }
+    return getRocketPool(cfg, ec)
 }
 
 func GetBeaconClient(c *cli.Context) (beacon.Client, error) {
-	cfg, err := getConfig(c)
-	if err != nil {
-		return nil, err
-	}
-	return getBeaconClient(cfg)
+    cfg, err := getConfig(c)
+    if err != nil {
+        return nil, err
+    }
+    return getBeaconClient(cfg)
 }
 
 func GetDocker(c *cli.Context) (*client.Client, error) {
-	return getDocker()
+    return getDocker()
 }
 
 //
@@ -106,73 +106,73 @@ func GetDocker(c *cli.Context) (*client.Client, error) {
 //
 
 func getConfig(c *cli.Context) (config.RocketPoolConfig, error) {
-	var err error
-	initCfg.Do(func() {
-		cfg, err = config.Load(c)
-	})
-	return cfg, err
+    var err error
+    initCfg.Do(func() {
+        cfg, err = config.Load(c)
+    })
+    return cfg, err
 }
 
 func getPasswordManager(cfg config.RocketPoolConfig) *passwords.PasswordManager {
-	initPasswordManager.Do(func() {
-		passwordManager = passwords.NewPasswordManager(cfg.Smartnode.PasswordPath)
-	})
-	return passwordManager
+    initPasswordManager.Do(func() {
+        passwordManager = passwords.NewPasswordManager(cfg.Smartnode.PasswordPath)
+    })
+    return passwordManager
 }
 
 func getWallet(cfg config.RocketPoolConfig, pm *passwords.PasswordManager) (*wallet.Wallet, error) {
-	var err error
-	initNodeWallet.Do(func() {
-		nodeWallet, err = wallet.NewWallet(cfg.Smartnode.WalletPath, pm)
-		if err == nil {
-			lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-			prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-			tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
-			nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
-			nodeWallet.AddKeystore("prysm", prysmKeystore)
-			nodeWallet.AddKeystore("teku", tekuKeystore)
-		}
-	})
-	return nodeWallet, err
+    var err error
+    initNodeWallet.Do(func() {
+        nodeWallet, err = wallet.NewWallet(cfg.Smartnode.WalletPath, pm)
+        if err == nil {
+            lighthouseKeystore := lhkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+            prysmKeystore := prkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+            tekuKeystore := tkkeystore.NewKeystore(cfg.Smartnode.ValidatorKeychainPath, pm)
+            nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
+            nodeWallet.AddKeystore("prysm", prysmKeystore)
+            nodeWallet.AddKeystore("teku", tekuKeystore)
+        }
+    })
+    return nodeWallet, err
 }
 
 func getEthClient(cfg config.RocketPoolConfig) (*ethclient.Client, error) {
-	var err error
-	initEthClient.Do(func() {
-		ethClient, err = ethclient.Dial(cfg.Chains.Eth1.Provider)
-	})
-	return ethClient, err
+    var err error
+    initEthClient.Do(func() {
+        ethClient, err = ethclient.Dial(cfg.Chains.Eth1.Provider)
+    })
+    return ethClient, err
 }
 
 func getRocketPool(cfg config.RocketPoolConfig, client *ethclient.Client) (*rocketpool.RocketPool, error) {
-	var err error
-	initRocketPool.Do(func() {
-		rocketPool, err = rocketpool.NewRocketPool(client, common.HexToAddress(cfg.Rocketpool.StorageAddress))
-	})
-	return rocketPool, err
+    var err error
+    initRocketPool.Do(func() {
+        rocketPool, err = rocketpool.NewRocketPool(client, common.HexToAddress(cfg.Rocketpool.StorageAddress))
+    })
+    return rocketPool, err
 }
 
 func getBeaconClient(cfg config.RocketPoolConfig) (beacon.Client, error) {
-	var err error
-	initBeaconClient.Do(func() {
-		switch cfg.Chains.Eth2.Client.Selected {
-		case "lighthouse":
-			beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
-		case "prysm":
-			beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
-		case "teku":
-			beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
-		default:
-			err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
-		}
-	})
-	return beaconClient, err
+    var err error
+    initBeaconClient.Do(func() {
+        switch cfg.Chains.Eth2.Client.Selected {
+        case "lighthouse":
+            beaconClient = lighthouse.NewClient(cfg.Chains.Eth2.Provider)
+        case "prysm":
+            beaconClient, err = prysm.NewClient(cfg.Chains.Eth2.Provider)
+        case "teku":
+            beaconClient = teku.NewClient(cfg.Chains.Eth2.Provider)
+        default:
+            err = fmt.Errorf("Unknown Eth 2.0 client '%s' selected", cfg.Chains.Eth2.Client.Selected)
+        }
+    })
+    return beaconClient, err
 }
 
 func getDocker() (*client.Client, error) {
-	var err error
-	initDocker.Do(func() {
-		docker, err = client.NewClientWithOpts(client.WithVersion(DockerAPIVersion))
-	})
-	return docker, err
+    var err error
+    initDocker.Do(func() {
+        docker, err = client.NewClientWithOpts(client.WithVersion(DockerAPIVersion))
+    })
+    return docker, err
 }

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -200,3 +200,4 @@ func getDocker() (*client.Client, error) {
     })
     return docker, err
 }
+

--- a/shared/services/wallet/keystore/nimbus/keystore.go
+++ b/shared/services/wallet/keystore/nimbus/keystore.go
@@ -1,0 +1,122 @@
+package nimbus
+
+import (
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "path/filepath"
+
+    "github.com/google/uuid"
+    rptypes "github.com/rocket-pool/rocketpool-go/types"
+    eth2types "github.com/wealdtech/go-eth2-types/v2"
+    eth2ks "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+
+    "github.com/rocket-pool/smartnode/shared/services/passwords"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+
+// Config
+const (
+    KeystoreDir = "nimbus"
+    SecretsDir = "secrets"
+    ValidatorsDir = "validators"
+    KeyFileName = "keystore.json"
+    DirMode = 0700
+    FileMode = 0600
+)
+
+
+// Lighthouse keystore
+type Keystore struct {
+    keystorePath string
+    pm *passwords.PasswordManager
+    encryptor *eth2ks.Encryptor
+}
+
+
+// Encrypted validator key store
+type validatorKey struct {
+    Crypto map[string]interface{}   `json:"crypto"`
+    Version uint                    `json:"version"`
+    UUID uuid.UUID                  `json:"uuid"`
+    Path string                     `json:"path"`
+    Pubkey rptypes.ValidatorPubkey  `json:"pubkey"`
+}
+
+
+// Create new lighthouse keystore
+func NewKeystore(keystorePath string, passwordManager *passwords.PasswordManager) *Keystore {
+    return &Keystore{
+        keystorePath: keystorePath,
+        pm: passwordManager,
+        encryptor: eth2ks.New(),
+    }
+}
+
+
+// Store a validator key
+func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPath string) error {
+
+    // Get validator pubkey
+    pubkey := rptypes.BytesToValidatorPubkey(key.PublicKey().Marshal())
+
+    // Get wallet password
+    password, err := ks.pm.GetPassword()
+    if err != nil {
+        return fmt.Errorf("Could not get wallet password: %w", err)
+    }
+
+    // Encrypt key
+    encryptedKey, err := ks.encryptor.Encrypt(key.Marshal(), password)
+    if err != nil {
+        return fmt.Errorf("Could not encrypt validator key: %w", err)
+    }
+
+    // Create key store
+    keyStore := validatorKey{
+        Crypto: encryptedKey,
+        Version: ks.encryptor.Version(),
+        UUID: uuid.New(),
+        Path: derivationPath,
+        Pubkey: pubkey,
+    }
+
+    // Encode key store
+    keyStoreBytes, err := json.Marshal(keyStore)
+    if err != nil {
+        return fmt.Errorf("Could not encode validator key: %w", err)
+    }
+
+    // Get secret file path
+    secretFilePath := filepath.Join(ks.keystorePath, KeystoreDir, SecretsDir, hexutil.AddPrefix(pubkey.Hex()))
+
+    // Create secrets dir
+    if err := os.MkdirAll(filepath.Dir(secretFilePath), DirMode); err != nil {
+        return fmt.Errorf("Could not create validator secrets folder: %w", err)
+    }
+
+    // Write secret to disk
+    if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
+        return fmt.Errorf("Could not write validator secret to disk: %w", err)
+    }
+
+    // Get key file path
+    keyFilePath := filepath.Join(ks.keystorePath, KeystoreDir, ValidatorsDir, hexutil.AddPrefix(pubkey.Hex()), KeyFileName)
+
+    // Create key dir
+    if err := os.MkdirAll(filepath.Dir(keyFilePath), DirMode); err != nil {
+        return fmt.Errorf("Could not create validator key folder: %w", err)
+    }
+
+    // Write key store to disk
+    if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
+        return fmt.Errorf("Could not write validator key to disk: %w", err)
+    }
+
+    // Return
+    return nil
+
+}
+

--- a/shared/services/wallet/keystore/teku/keystore.go
+++ b/shared/services/wallet/keystore/teku/keystore.go
@@ -1,115 +1,115 @@
 package teku
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "path/filepath"
 
-	"github.com/google/uuid"
-	rptypes "github.com/rocket-pool/rocketpool-go/types"
-	eth2types "github.com/wealdtech/go-eth2-types/v2"
-	eth2ks "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+    "github.com/google/uuid"
+    rptypes "github.com/rocket-pool/rocketpool-go/types"
+    eth2types "github.com/wealdtech/go-eth2-types/v2"
+    eth2ks "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 
-	"github.com/rocket-pool/smartnode/shared/services/passwords"
-	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+    "github.com/rocket-pool/smartnode/shared/services/passwords"
+    hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
 // Config
 const (
-	KeystoreDir   = "teku"
-	SecretsDir    = "passwords"
-	ValidatorsDir = "keys"
-	DirMode       = 0700
-	FileMode      = 0600
+    KeystoreDir   = "teku"
+    SecretsDir    = "passwords"
+    ValidatorsDir = "keys"
+    DirMode       = 0700
+    FileMode      = 0600
 )
 
 // Teku keystore
 type Keystore struct {
-	keystorePath string
-	pm           *passwords.PasswordManager
-	encryptor    *eth2ks.Encryptor
+    keystorePath string
+    pm           *passwords.PasswordManager
+    encryptor    *eth2ks.Encryptor
 }
 
 // Encrypted validator key store
 type validatorKey struct {
-	Crypto  map[string]interface{}  `json:"crypto"`
-	Version uint                    `json:"version"`
-	UUID    uuid.UUID               `json:"uuid"`
-	Path    string                  `json:"path"`
-	Pubkey  rptypes.ValidatorPubkey `json:"pubkey"`
+    Crypto  map[string]interface{}  `json:"crypto"`
+    Version uint                    `json:"version"`
+    UUID    uuid.UUID               `json:"uuid"`
+    Path    string                  `json:"path"`
+    Pubkey  rptypes.ValidatorPubkey `json:"pubkey"`
 }
 
 // Create new teku keystore
 func NewKeystore(keystorePath string, passwordManager *passwords.PasswordManager) *Keystore {
-	return &Keystore{
-		keystorePath: keystorePath,
-		pm:           passwordManager,
-		encryptor:    eth2ks.New(eth2ks.WithCipher("scrypt")),
-	}
+    return &Keystore{
+        keystorePath: keystorePath,
+        pm:           passwordManager,
+        encryptor:    eth2ks.New(eth2ks.WithCipher("scrypt")),
+    }
 }
 
 // Store a validator key
 func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPath string) error {
 
-	// Get validator pubkey
-	pubkey := rptypes.BytesToValidatorPubkey(key.PublicKey().Marshal())
+    // Get validator pubkey
+    pubkey := rptypes.BytesToValidatorPubkey(key.PublicKey().Marshal())
 
-	// Get wallet password
-	password, err := ks.pm.GetPassword()
-	if err != nil {
-		return fmt.Errorf("Could not get wallet password: %w", err)
-	}
+    // Get wallet password
+    password, err := ks.pm.GetPassword()
+    if err != nil {
+        return fmt.Errorf("Could not get wallet password: %w", err)
+    }
 
-	// Encrypt key
-	encryptedKey, err := ks.encryptor.Encrypt(key.Marshal(), password)
-	if err != nil {
-		return fmt.Errorf("Could not encrypt validator key: %w", err)
-	}
+    // Encrypt key
+    encryptedKey, err := ks.encryptor.Encrypt(key.Marshal(), password)
+    if err != nil {
+        return fmt.Errorf("Could not encrypt validator key: %w", err)
+    }
 
-	// Create key store
-	keyStore := validatorKey{
-		Crypto:  encryptedKey,
-		Version: ks.encryptor.Version(),
-		UUID:    uuid.New(),
-		Path:    derivationPath,
-		Pubkey:  pubkey,
-	}
+    // Create key store
+    keyStore := validatorKey{
+        Crypto:  encryptedKey,
+        Version: ks.encryptor.Version(),
+        UUID:    uuid.New(),
+        Path:    derivationPath,
+        Pubkey:  pubkey,
+    }
 
-	// Encode key store
-	keyStoreBytes, err := json.Marshal(keyStore)
-	if err != nil {
-		return fmt.Errorf("Could not encode validator key: %w", err)
-	}
+    // Encode key store
+    keyStoreBytes, err := json.Marshal(keyStore)
+    if err != nil {
+        return fmt.Errorf("Could not encode validator key: %w", err)
+    }
 
-	// Get secret file path
-	secretFilePath := filepath.Join(ks.keystorePath, KeystoreDir, SecretsDir, hexutil.AddPrefix(pubkey.Hex())+".txt")
+    // Get secret file path
+    secretFilePath := filepath.Join(ks.keystorePath, KeystoreDir, SecretsDir, hexutil.AddPrefix(pubkey.Hex())+".txt")
 
-	// Create secrets dir
-	if err := os.MkdirAll(filepath.Dir(secretFilePath), DirMode); err != nil {
-		return fmt.Errorf("Could not create validator secrets folder: %w", err)
-	}
+    // Create secrets dir
+    if err := os.MkdirAll(filepath.Dir(secretFilePath), DirMode); err != nil {
+        return fmt.Errorf("Could not create validator secrets folder: %w", err)
+    }
 
-	// Write secret to disk
-	if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
-		return fmt.Errorf("Could not write validator secret to disk: %w", err)
-	}
+    // Write secret to disk
+    if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
+        return fmt.Errorf("Could not write validator secret to disk: %w", err)
+    }
 
-	// Get key file path
-	keyFilePath := filepath.Join(ks.keystorePath, KeystoreDir, ValidatorsDir, hexutil.AddPrefix(pubkey.Hex())+".json")
+    // Get key file path
+    keyFilePath := filepath.Join(ks.keystorePath, KeystoreDir, ValidatorsDir, hexutil.AddPrefix(pubkey.Hex())+".json")
 
-	// Create key dir
-	if err := os.MkdirAll(filepath.Dir(keyFilePath), DirMode); err != nil {
-		return fmt.Errorf("Could not create validator key folder: %w", err)
-	}
+    // Create key dir
+    if err := os.MkdirAll(filepath.Dir(keyFilePath), DirMode); err != nil {
+        return fmt.Errorf("Could not create validator key folder: %w", err)
+    }
 
-	// Write key store to disk
-	if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
-		return fmt.Errorf("Could not write validator key to disk: %w", err)
-	}
+    // Write key store to disk
+    if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
+        return fmt.Errorf("Could not write validator key to disk: %w", err)
+    }
 
-	// Return
-	return nil
+    // Return
+    return nil
 
 }

--- a/shared/services/wallet/keystore/teku/keystore.go
+++ b/shared/services/wallet/keystore/teku/keystore.go
@@ -1,0 +1,115 @@
+package teku
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	rptypes "github.com/rocket-pool/rocketpool-go/types"
+	eth2types "github.com/wealdtech/go-eth2-types/v2"
+	eth2ks "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+
+	"github.com/rocket-pool/smartnode/shared/services/passwords"
+	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+// Config
+const (
+	KeystoreDir   = "teku"
+	SecretsDir    = "passwords"
+	ValidatorsDir = "keys"
+	DirMode       = 0700
+	FileMode      = 0600
+)
+
+// Teku keystore
+type Keystore struct {
+	keystorePath string
+	pm           *passwords.PasswordManager
+	encryptor    *eth2ks.Encryptor
+}
+
+// Encrypted validator key store
+type validatorKey struct {
+	Crypto  map[string]interface{}  `json:"crypto"`
+	Version uint                    `json:"version"`
+	UUID    uuid.UUID               `json:"uuid"`
+	Path    string                  `json:"path"`
+	Pubkey  rptypes.ValidatorPubkey `json:"pubkey"`
+}
+
+// Create new teku keystore
+func NewKeystore(keystorePath string, passwordManager *passwords.PasswordManager) *Keystore {
+	return &Keystore{
+		keystorePath: keystorePath,
+		pm:           passwordManager,
+		encryptor:    eth2ks.New(eth2ks.WithCipher("scrypt")),
+	}
+}
+
+// Store a validator key
+func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPath string) error {
+
+	// Get validator pubkey
+	pubkey := rptypes.BytesToValidatorPubkey(key.PublicKey().Marshal())
+
+	// Get wallet password
+	password, err := ks.pm.GetPassword()
+	if err != nil {
+		return fmt.Errorf("Could not get wallet password: %w", err)
+	}
+
+	// Encrypt key
+	encryptedKey, err := ks.encryptor.Encrypt(key.Marshal(), password)
+	if err != nil {
+		return fmt.Errorf("Could not encrypt validator key: %w", err)
+	}
+
+	// Create key store
+	keyStore := validatorKey{
+		Crypto:  encryptedKey,
+		Version: ks.encryptor.Version(),
+		UUID:    uuid.New(),
+		Path:    derivationPath,
+		Pubkey:  pubkey,
+	}
+
+	// Encode key store
+	keyStoreBytes, err := json.Marshal(keyStore)
+	if err != nil {
+		return fmt.Errorf("Could not encode validator key: %w", err)
+	}
+
+	// Get secret file path
+	secretFilePath := filepath.Join(ks.keystorePath, KeystoreDir, SecretsDir, hexutil.AddPrefix(pubkey.Hex())+".txt")
+
+	// Create secrets dir
+	if err := os.MkdirAll(filepath.Dir(secretFilePath), DirMode); err != nil {
+		return fmt.Errorf("Could not create validator secrets folder: %w", err)
+	}
+
+	// Write secret to disk
+	if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
+		return fmt.Errorf("Could not write validator secret to disk: %w", err)
+	}
+
+	// Get key file path
+	keyFilePath := filepath.Join(ks.keystorePath, KeystoreDir, ValidatorsDir, hexutil.AddPrefix(pubkey.Hex())+".json")
+
+	// Create key dir
+	if err := os.MkdirAll(filepath.Dir(keyFilePath), DirMode); err != nil {
+		return fmt.Errorf("Could not create validator key folder: %w", err)
+	}
+
+	// Write key store to disk
+	if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
+		return fmt.Errorf("Could not write validator key to disk: %w", err)
+	}
+
+	// Return
+	return nil
+
+}


### PR DESCRIPTION
This is one of two PRs that adds support for the Nimbus ETH2 client to Rocket Pool (the other being in `smartnode-install`). This was a nontrivial add, so here are my notes on my changes beyond simply adding a new client and keystore.

**NOTE: this builds on top of the Teku PR I already submitted. If you accept this, you'll get all of those changes for free so you can ignore that PR.**

### Nimbus JSON-RPC Bug
So first things first, Nimbus v1.0.7 has a bug in its json-rpc library that breaks when you send requests that omit the `params` object if it's empty. [I fixed this already](https://github.com/status-im/nim-json-rpc/pull/94) and it's [been merged](https://github.com/status-im/nimbus-eth2/commit/ece50c47068b52da45c9ee73919328d53bb0184b) but we can't *officially* support Nimbus until they push a new Docker image with this fix in. Stay tuned for that.

### Single Process
Unlike the other clients, Nimbus (currently) only runs as a single process that is both the beacon client and the validator. This conflicts with RP's current model, where ETH2 clients are split into separate containers for beacon and validator activity, respectively. This poses some challenges, most of which are mitigated in the `smartnode-install` PR but there are a few changes that had to happen in this repository:
- I added a new method called `GetClientType()` to beacon clients. This class returns an enum value - either `SplitProcess` or `SingleProcess`. `SplitProcess` is meant to capture the "normal" model, where the beacon client and validator are run separately. `SingleProcess` captures clients like Nimbus that run as a single process.
- In `restartValidator()` in `stake-prelaunch-minipools.go`, I added some logic that checks the client type. If it's a single process, it will restart the `rocketpool_eth2` image instead of the `rocketpool_validator` image.

### Websocket API in Geth
Nimbus doesn't support HTTP APIs for web3 / ETH1 clients like the other clients do. It only supports Websockets. To work around that, I added a new variable called `WsProvider` to the config defined in `shared/services/config/config.go ` and a corresponding value in `shared/services/rocketpool/client.go ` for the rest of the client to use. More details on this are available in the `smartnode-install` PR.

I think that's everything. I've tested this on Dockerized and non-Dockerized setups, and it behaves as expected in both environments. I suggest we use the next beta to thoroughly try this out, provided Status released a fixed version of the Nimbus image in time.