### PR TITLE
Restart validator service on non-docker setup

### DIFF
--- a/rocketpool/node/stake-prelaunch-minipools.go
+++ b/rocketpool/node/stake-prelaunch-minipools.go
@@ -4,6 +4,10 @@ import (
     "context"
     "errors"
     "fmt"
+    "io/ioutil"
+    "os"
+    "os/exec"
+    "strings"
     "time"
 
     "github.com/docker/docker/api/types"
@@ -259,43 +263,66 @@ func (t *stakePrelaunchMinipools) stakeMinipool(mp *minipool.Minipool, withdrawa
 // Restart validator container
 func (t *stakePrelaunchMinipools) restartValidator() error {
 
-    // Get validator container name
-    if t.cfg.Smartnode.ProjectName == "" {
-        return errors.New("Rocket Pool docker project name not set")
-    }
-    containerName := t.cfg.Smartnode.ProjectName + ValidatorContainerSuffix
+    if isInsideDocker() {    
+        // Get validator container name
+        if t.cfg.Smartnode.ProjectName == "" {
+            return errors.New("Rocket Pool docker project name not set")
+        }
+        containerName := t.cfg.Smartnode.ProjectName + ValidatorContainerSuffix
 
-    // Log
-    t.log.Printlnf("Restarting validator container (%s)...", containerName)
+        t.log.Printlnf("Restarting validator container (%s)...", containerName)
 
-    // Get all containers
-    containers, err := t.d.ContainerList(context.Background(), types.ContainerListOptions{All: true})
-    if err != nil {
-        return fmt.Errorf("Could not get docker containers: %w", err)
-    }
+        // Get all containers
+        containers, err := t.d.ContainerList(context.Background(), types.ContainerListOptions{All: true})
+        if err != nil {
+            return fmt.Errorf("Could not get docker containers: %w", err)
+        }
 
-    // Get validator container ID
-    var validatorContainerId string
-    for _, container := range containers {
-        if container.Names[0] == "/" + containerName {
-            validatorContainerId = container.ID
-            break
+        // Get validator container ID
+        var validatorContainerId string
+        for _, container := range containers {
+            if container.Names[0] == "/" + containerName {
+                validatorContainerId = container.ID
+                break
+            }
+        }
+        if validatorContainerId == "" {
+            return errors.New("Validator container not found")
+        }
+
+        // Restart validator container
+        if err := t.d.ContainerRestart(context.Background(), validatorContainerId, &validatorRestartTimeout); err != nil {
+            return fmt.Errorf("Could not restart validator container: %w", err)
+        }
+
+    } else {
+        scriptPath := os.ExpandEnv(t.cfg.Smartnode.ValidatorRestartCommand)
+
+        t.log.Printlnf("Restarting validator with command: '%s'", scriptPath)
+
+        cmd := exec.Command(scriptPath)
+        cmd.Stdout = os.Stdout
+        cmd.Stderr = os.Stderr
+        err := cmd.Run()
+        if err != nil {
+            return fmt.Errorf("Script failed with error: %w", err)
         }
     }
-    if validatorContainerId == "" {
-        return errors.New("Validator container not found")
-    }
 
-    // Restart validator container
-    if err := t.d.ContainerRestart(context.Background(), validatorContainerId, &validatorRestartTimeout); err != nil {
-        return fmt.Errorf("Could not restart validator container: %w", err)
-    }
-
-    // Log
-    t.log.Println("Successfully restarted validator container.")
-
-    // Return
+    t.log.Println("Successfully restarted validator")
     return nil
+}
 
+
+// Checks whether this process in running inside a docker container
+func isInsideDocker() bool {
+
+    cgroup, err := ioutil.ReadFile("/proc/1/cgroup")
+    if err != nil {
+        return false
+    }
+    cgroupStr := string(cgroup)
+    // check whether cgroup contains docker
+    return strings.Contains(cgroupStr, "docker")
 }
 

--- a/shared/services/config/config.go
+++ b/shared/services/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
     "fmt"
     "io/ioutil"
+    "os"
 
     "github.com/imdario/mergo"
     "github.com/urfave/cli"
@@ -125,11 +126,11 @@ func Merge(configs ...*RocketPoolConfig) RocketPoolConfig {
 func Load(c *cli.Context) (RocketPoolConfig, error) {
 
     // Load configs
-    globalConfig, err := loadFile(c.GlobalString("config"), true)
+    globalConfig, err := loadFile(os.ExpandEnv(c.GlobalString("config")), true)
     if err != nil {
         return RocketPoolConfig{}, err
     }
-    userConfig, err := loadFile(c.GlobalString("settings"), false)
+    userConfig, err := loadFile(os.ExpandEnv(c.GlobalString("settings")), false)
     if err != nil {
         return RocketPoolConfig{}, err
     }

--- a/shared/services/config/config.go
+++ b/shared/services/config/config.go
@@ -22,6 +22,7 @@ type RocketPoolConfig struct {
         PasswordPath string             `yaml:"passwordPath,omitempty"`
         WalletPath string               `yaml:"walletPath,omitempty"`
         ValidatorKeychainPath string    `yaml:"validatorKeychainPath,omitempty"`
+        ValidatorRestartCommand string  `yaml:"validatorRestartCommand,omitempty"`
     }                                   `yaml:"smartnode,omitempty"`
     Chains struct {
         Eth1 Chain                      `yaml:"eth1,omitempty"`

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -64,7 +64,7 @@ func NewClient(configPath, daemonPath, hostAddress, user, keyPath, keyPassphrase
         }
 
         // Read private key
-        keyBytes, err := ioutil.ReadFile(keyPath)
+        keyBytes, err := ioutil.ReadFile(os.ExpandEnv(keyPath))
         if err != nil {
             return nil, fmt.Errorf("Could not read SSH private key at %s: %w", keyPath, err)
         }
@@ -94,8 +94,8 @@ func NewClient(configPath, daemonPath, hostAddress, user, keyPath, keyPassphrase
 
     // Return client
     return &Client{
-        configPath: configPath,
-        daemonPath: daemonPath,
+        configPath: os.ExpandEnv(configPath),
+        daemonPath: os.ExpandEnv(daemonPath),
         client: sshClient,
     }, nil
 


### PR DESCRIPTION
Fixes rocket-pool/smartnode#86 

- detect whether we are running inside a container
- if we are in docker then proceed to restart container as usual
- if we are not in docker then execute the configured command