### PR TITLE
Fix withdrawn minipool balances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/prysmaticlabs/ethereumapis v0.0.0-20200729044127-8027cc96e2c0
-	github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae
-	github.com/rocket-pool/rocketpool-go v0.0.0-20201105022215-e79c6a7154c0
+	github.com/prysmaticlabs/go-ssz v0.0.0-20210121151755-f6208871c388
+	github.com/rocket-pool/rocketpool-go v0.0.0-20210204000737-dee4548f8b3a
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	github.com/urfave/cli v1.22.4
 	github.com/wealdtech/go-eth2-types/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/ferranbt/fastssz v0.0.0-20200514094935-99fccaf93472/go.mod h1:LlFXPmgrgVYsuoFDwV8rDJ9tvt1pLQdjKvU1b5IRES0=
 github.com/ferranbt/fastssz v0.0.0-20200728110133-0b6e349af87a h1:qLZC3oQLJ5eb18EZS3yDcnX7zmlEt8WTWlQR7x5wS5I=
 github.com/ferranbt/fastssz v0.0.0-20200728110133-0b6e349af87a/go.mod h1:DyEu2iuLBnb/T51BlsiO3yLYdJC6UbGMrIkqK1KmQxM=
+github.com/ferranbt/fastssz v0.0.0-20210120143747-11b9eff30ea9 h1:9VDpsWq096+oGMDTT/SgBD/VgZYf4pTF+KTPmZ+OaKM=
+github.com/ferranbt/fastssz v0.0.0-20210120143747-11b9eff30ea9/go.mod h1:DyEu2iuLBnb/T51BlsiO3yLYdJC6UbGMrIkqK1KmQxM=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
@@ -178,6 +180,7 @@ github.com/minio/highwayhash v1.0.1 h1:dZ6IIu8Z14VlC0VpfKofAhCy74wu/Qb5gcn52yWoz
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
+github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
@@ -220,13 +223,19 @@ github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669 h1:cX6YR
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200618145306-2ae0807bef65 h1:hJfAWrlxx7SKpn4S/h2JGl2HHwA1a2wSS3HAzzZ0F+U=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200618145306-2ae0807bef65/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20210121075346-fee7b721f342 h1:SMro7Z5L2ACvcKREIVJDn8LvoVTY1TY2rTlPJmDlUWc=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20210121075346-fee7b721f342/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/go-ssz v0.0.0-20200101200214-e24db4d9e963/go.mod h1:VecIJZrewdAuhVckySLFt2wAAHRME934bSDurP8ftkc=
 github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae h1:7qd0Af1ozWKBU3c93YW2RH+/09hJns9+ftqWUZyts9c=
 github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae/go.mod h1:VecIJZrewdAuhVckySLFt2wAAHRME934bSDurP8ftkc=
+github.com/prysmaticlabs/go-ssz v0.0.0-20210121151755-f6208871c388 h1:4bD+ujqGfY4zoDUF3q9MhdmpPXzdp03DYUIlXeQ72kk=
+github.com/prysmaticlabs/go-ssz v0.0.0-20210121151755-f6208871c388/go.mod h1:VecIJZrewdAuhVckySLFt2wAAHRME934bSDurP8ftkc=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rocket-pool/rocketpool-go v0.0.0-20201105022215-e79c6a7154c0 h1:gUIqhuqpuovtgGJnQGjQvf3+SWsa672X6/VdNMtLwzI=
 github.com/rocket-pool/rocketpool-go v0.0.0-20201105022215-e79c6a7154c0/go.mod h1:1Prh+giH948mU3t917HTA4r4TX/o4h7KsbVhQjU72fY=
+github.com/rocket-pool/rocketpool-go v0.0.0-20210204000737-dee4548f8b3a h1:BHNvKTGgcpp45iJYzvxrK+RL5jQb3bZfvcLBwy5oaOs=
+github.com/rocket-pool/rocketpool-go v0.0.0-20210204000737-dee4548f8b3a/go.mod h1:Hvj1hs2zE4pk5LabsyJi9DNRTaEhhK0uEPV8UBjAW84=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=

--- a/rocketpool/api/node/deposit.go
+++ b/rocketpool/api/node/deposit.go
@@ -8,7 +8,6 @@ import (
     "github.com/ethereum/go-ethereum/common"
     "github.com/rocket-pool/rocketpool-go/node"
     "github.com/rocket-pool/rocketpool-go/settings"
-    "github.com/rocket-pool/rocketpool-go/utils/contract"
     "github.com/urfave/cli"
     "golang.org/x/sync/errgroup"
 
@@ -95,8 +94,6 @@ func nodeDeposit(c *cli.Context, amountWei *big.Int, minNodeFee float64) (*api.N
     if err := services.RequireNodeRegistered(c); err != nil { return nil, err }
     w, err := services.GetWallet(c)
     if err != nil { return nil, err }
-    ec, err := services.GetEthClient(c)
-    if err != nil { return nil, err }
     rp, err := services.GetRocketPool(c)
     if err != nil { return nil, err }
 
@@ -117,14 +114,12 @@ func nodeDeposit(c *cli.Context, amountWei *big.Int, minNodeFee float64) (*api.N
     }
     response.TxHash = txReceipt.TxHash
 
-    // Get minipool manager contract details
-    minipoolManagerAddress, minipoolManagerABI, err := contract.GetDetails(rp, "rocketMinipoolManager")
-    if err != nil {
-        return nil, err
-    }
+    // Get minipool manager contract
+    rocketMinipoolManager, err := rp.GetContract("rocketMinipoolManager")
+    if err != nil { return nil, err }
 
     // Get created minipool address
-    minipoolCreatedEvents, err := contract.GetTransactionEvents(ec, minipoolManagerAddress, minipoolManagerABI, txReceipt, "MinipoolCreated", minipoolCreated{})
+    minipoolCreatedEvents, err := rocketMinipoolManager.GetTransactionEvents(txReceipt, "MinipoolCreated", minipoolCreated{})
     if err != nil || len(minipoolCreatedEvents) == 0 {
         return nil, errors.New("Could not get minipool created event")
     }

--- a/rocketpool/watchtower/process-withdrawals.go
+++ b/rocketpool/watchtower/process-withdrawals.go
@@ -1,8 +1,15 @@
 package watchtower
 
 import (
+    "fmt"
+
+    "github.com/rocket-pool/rocketpool-go/network"
+    "github.com/rocket-pool/rocketpool-go/minipool"
+    "github.com/rocket-pool/rocketpool-go/node"
     "github.com/rocket-pool/rocketpool-go/rocketpool"
+    "github.com/rocket-pool/rocketpool-go/settings"
     "github.com/urfave/cli"
+    "golang.org/x/sync/errgroup"
 
     "github.com/rocket-pool/smartnode/shared/services"
     "github.com/rocket-pool/smartnode/shared/services/wallet"
@@ -42,10 +49,75 @@ func newProcessWithdrawals(c *cli.Context, logger log.ColorLogger) (*processWith
 // Process withdrawals
 func (t *processWithdrawals) run() error {
 
-    // Process withdrawals
-    // TODO: implement
+    // Wait for eth clients to sync
+    if err := services.WaitEthClientSynced(t.c, true); err != nil {
+        return err
+    }
+    if err := services.WaitBeaconClientSynced(t.c, true); err != nil {
+        return err
+    }
 
-    // Return
+    // Get node account
+    nodeAccount, err := t.w.GetNodeAccount()
+    if err != nil {
+        return err
+    }
+
+    // Data
+    var wg errgroup.Group
+    var nodeTrusted bool
+    var processWithdrawalsEnabled bool
+
+    // Get data
+    wg.Go(func() error {
+        var err error
+        nodeTrusted, err = node.GetNodeTrusted(t.rp, nodeAccount.Address, nil)
+        return err
+    })
+    wg.Go(func() error {
+        var err error
+        processWithdrawalsEnabled, err = settings.GetProcessWithdrawalsEnabled(t.rp, nil)
+        return err
+    })
+
+    // Wait for data
+    if err := wg.Wait(); err != nil {
+        return err
+    }
+
+    // Check node trusted status & settings
+    if !(nodeTrusted && processWithdrawalsEnabled) {
+        return nil
+    }
+
+    t.log.Println("Checking for withdrawals to process...")
+
+    // Get minipool withdrawable details
+    withdrawalDetails, err := minipool.GetUnprocessedMinipools(t.rp, nil)
+    if err != nil {
+        return err
+    }
+    if len(withdrawalDetails) == 0 {
+        return nil
+    }
+
+    t.log.Printlnf("%d minipools are unprocessed...", len(withdrawalDetails))
+
+    // Submit minipools withdrawable status
+    for _, withdrawal := range withdrawalDetails {
+        // Logic: should only process withdraw when minipool.WithDraw() has been called
+        if !withdrawal.Exists && !withdrawal.WithdrawalProcessed {
+            // TODO TODO TODO TODO TODO TODO TODO TODO
+            // _real_ ETH2 withdraw logic goes here
+            // no clients have any implementation yet
+
+            _, err := network.ProcessWithdrawal(t.rp, withdrawal.Pubkey, nil)
+            if err != nil {
+                t.log.Println(fmt.Errorf("Could not process withdrawal for minipool %s: %w", withdrawal.Pubkey.Hex(), err))
+            }
+        }
+    }
+
     return nil
 
 }


### PR DESCRIPTION
Fixes rocket-pool/smartnode#85
- use the `minipools.unprocessed.index` collection of minipools
- calculate the withdrawable balance to the staking pool
- indicate that the minipool has been withdrawn but not yet processed
- add withdrawn but unprocessed staking balance to the tally