### PR TITLE
clarify withdrawable minipool status

### DIFF
--- a/rocketpool-cli/minipool/status.go
+++ b/rocketpool-cli/minipool/status.go
@@ -14,6 +14,16 @@ import (
 )
 
 
+// short blurb describing each status
+var minipoolStatusDescriptions = []string {
+    "", // Initialized
+    "", // Prelaunch
+    "", // Staking
+    "Exited state - withdraw may not be available until after delay", // Withdrawable
+    "Exited and withdrawn", // Dissolved
+}
+
+
 func getStatus(c *cli.Context) error {
 
     // Get RP client
@@ -58,10 +68,13 @@ func getStatus(c *cli.Context) error {
     if len(status.Minipools) == 0 {
         fmt.Println("The node does not have any minipools yet.")
     }
-    for _, statusName := range types.MinipoolStatuses {
+    for i, statusName := range types.MinipoolStatuses {
         minipools, ok := statusMinipools[statusName]
         if !ok { continue }
         fmt.Printf("%d %s minipool(s):\n", len(minipools), statusName)
+        if len(minipoolStatusDescriptions[i]) > 0 {
+        fmt.Printf("(%s)\n", minipoolStatusDescriptions[i])
+        }
         fmt.Println("")
         for _, minipool := range minipools {
             fmt.Printf("-----------------\n")
@@ -94,6 +107,7 @@ func getStatus(c *cli.Context) error {
             }
             if minipool.Status.Status == types.Withdrawable {
             fmt.Printf("Final balance:     %.6f ETH\n", math.RoundDown(eth.WeiToEth(minipool.Staking.EndBalance), 6))
+            fmt.Printf("Withdrawal available in: %d blocks\n", minipool.WithdrawalAvailableInBlocks)
             }
             fmt.Printf("\n")
         }

--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -46,7 +46,7 @@ func getStatus(c *cli.Context) error {
             fmt.Printf("- %d staking\n", status.MinipoolCounts.Staking)
         }
         if status.MinipoolCounts.Withdrawable > 0 {
-            fmt.Printf("- %d withdrawable\n", status.MinipoolCounts.Withdrawable)
+            fmt.Printf("- %d withdrawable (after delay)\n", status.MinipoolCounts.Withdrawable)
         }
         if status.MinipoolCounts.Dissolved > 0 {
             fmt.Printf("- %d dissolved\n", status.MinipoolCounts.Dissolved)

--- a/rocketpool/api/minipool/utils.go
+++ b/rocketpool/api/minipool/utils.go
@@ -201,6 +201,13 @@ func getMinipoolDetails(rp *rocketpool.RocketPool, minipoolAddress common.Addres
     details.RefundAvailable = (details.Node.RefundBalance.Cmp(big.NewInt(0)) > 0)
     details.WithdrawalAvailable = (details.Status.Status == types.Withdrawable && (currentBlock - details.Status.StatusBlock) >= withdrawalDelay)
     details.CloseAvailable = (details.Status.Status == types.Dissolved)
+    if details.Status.Status == types.Withdrawable {
+        if details.WithdrawalAvailable {
+            details.WithdrawalAvailableInBlocks = 0
+        } else {
+            details.WithdrawalAvailableInBlocks = withdrawalDelay - (currentBlock - details.Status.StatusBlock)
+        }
+    }
     return details, nil
 
 }

--- a/shared/types/api/minipool.go
+++ b/shared/types/api/minipool.go
@@ -28,6 +28,7 @@ type MinipoolDetails struct {
     Validator ValidatorDetails              `json:"validator"`
     RefundAvailable bool                    `json:"refundAvailable"`
     WithdrawalAvailable bool                `json:"withdrawalAvailable"`
+    WithdrawalAvailableInBlocks uint64      `json:"withdrawalAvailableAfterBlock"`
     CloseAvailable bool                     `json:"closeAvailable"`
 }
 type ValidatorDetails struct {


### PR DESCRIPTION
Fixes rocket-pool/smartnode#82
- Add number of blocks until withdrawal is available to minipool status
- Ability to show short blurb with each minipool status print

Example minipool status print out:
```
API server listening at: 127.0.0.1:37587

2 Withdrawable minipool(s):
(Exited state - withdraw may not be available until after delay)

-----------------
Address:           0x00000000000000000000000000000000000000001
Status updated:    2021-01-27, 05:53 +0000 UTC
Node fee:          9.999991%
Node deposit:      16.000000 ETH
Final balance:     32.364214 ETH
Withdrawal available in: 53096 blocks

-----------------

Address:           0x00000000000000000000000000000000000000002
Status updated:    2021-01-27, 06:00 +0000 UTC
Node fee:          20.000000%
Node deposit:      16.000000 ETH
Final balance:     32.362945 ETH
Withdrawal available in: 53122 blocks

```