### PR TITLE
Fix Prysm watchtower network balance

### DIFF
--- a/shared/services/beacon/prysm/client.go
+++ b/shared/services/beacon/prysm/client.go
@@ -184,6 +184,8 @@ func (c *Client) GetValidatorStatus(pubkey types.ValidatorPubkey, opts *beacon.V
 // Get multiple validators' statuses
 func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *beacon.ValidatorStatusOptions) (map[types.ValidatorPubkey]beacon.ValidatorStatus, error) {
 
+    statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus, len(pubkeys))
+
     // Build validator statuses request
     validatorsRequest := &pb.ListValidatorsRequest{
         PublicKeys: make([][]byte, len(pubkeys)),
@@ -194,63 +196,87 @@ func (c *Client) GetValidatorStatuses(pubkeys []types.ValidatorPubkey, opts *bea
     if opts != nil {
         validatorsRequest.QueryFilter = &pb.ListValidatorsRequest_Epoch{Epoch: opts.Epoch}
     }
+    
+    // loop for multiple page response
+    // loopIndex is for sanity to exit infinite loop
+    for loopIndex := 0; loopIndex < 10000; loopIndex++ {
+        // Get validator statuses
+        response, err := c.bc.ListValidators(context.Background(), validatorsRequest)
+        if err != nil {
+            return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, fmt.Errorf("Could not get validator statuses: %w", err)
+        }
 
-    // Get validator statuses
-    validators, err := c.bc.ListValidators(context.Background(), validatorsRequest)
-    if err != nil {
-        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, fmt.Errorf("Could not get validator statuses: %w", err)
+        // Build status map
+        for _, valCont := range response.ValidatorList {
+
+            // Get validator status & pubkey
+            validator := valCont.Validator
+            pubkey := types.BytesToValidatorPubkey(validator.PublicKey)
+
+            // Add status
+            statuses[pubkey] = beacon.ValidatorStatus{
+                Pubkey: pubkey,
+                WithdrawalCredentials: common.BytesToHash(validator.WithdrawalCredentials),
+                EffectiveBalance: validator.EffectiveBalance,
+                Slashed: validator.Slashed,
+                ActivationEligibilityEpoch: validator.ActivationEligibilityEpoch,
+                ActivationEpoch: validator.ActivationEpoch,
+                ExitEpoch: validator.ExitEpoch,
+                WithdrawableEpoch: validator.WithdrawableEpoch,
+                Exists: true,
+            }
+
+        }
+
+        // break if no validators found
+        if len(response.NextPageToken) == 0 || len(response.ValidatorList) == 0 {
+            break;
+        }
+
+        // iterate to next page of the request
+        validatorsRequest.PageToken = response.NextPageToken
     }
-
-    // Return if no validators found
-    if len(validators.ValidatorList) == 0 {
-        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, nil
-    }
-
+    
     // Build validator balances request
     balancesRequest := &pb.ListValidatorBalancesRequest{
-        PublicKeys: make([][]byte, len(validators.ValidatorList)),
+        PublicKeys: make([][]byte, len(statuses)),
     }
-    for vi, validator := range validators.ValidatorList {
-        balancesRequest.PublicKeys[vi] = validator.Validator.PublicKey
+    vi := 0
+    for pubkey := range statuses {
+        balancesRequest.PublicKeys[vi] = pubkey.Bytes()
+        vi++
     }
     if opts != nil {
         balancesRequest.QueryFilter = &pb.ListValidatorBalancesRequest_Epoch{Epoch: opts.Epoch}
     }
 
-    // Get validator balances
-    balances, err := c.bc.ListValidatorBalances(context.Background(), balancesRequest)
-    if err != nil {
-        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, fmt.Errorf("Could not get validator balances: %w", err)
-    }
-
-    // Check validator balances count
-    if len(validators.ValidatorList) != len(balances.Balances) {
-        return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, fmt.Errorf("Validator status and balance result counts do not match")
-    }
-
-    // Build status map
-    statuses := make(map[types.ValidatorPubkey]beacon.ValidatorStatus)
-    for vi := 0; vi < len(validators.ValidatorList); vi++ {
-
-        // Get validator status, balance & pubkey
-        validator := validators.ValidatorList[vi].Validator
-        validatorBalance := balances.Balances[vi].Balance
-        pubkey := types.BytesToValidatorPubkey(validator.PublicKey)
-
-        // Add status
-        statuses[pubkey] = beacon.ValidatorStatus{
-            Pubkey: pubkey,
-            WithdrawalCredentials: common.BytesToHash(validator.WithdrawalCredentials),
-            Balance: validatorBalance,
-            EffectiveBalance: validator.EffectiveBalance,
-            Slashed: validator.Slashed,
-            ActivationEligibilityEpoch: validator.ActivationEligibilityEpoch,
-            ActivationEpoch: validator.ActivationEpoch,
-            ExitEpoch: validator.ExitEpoch,
-            WithdrawableEpoch: validator.WithdrawableEpoch,
-            Exists: true,
+    // loop for multiple page response
+    // loopIndex is for sanity to exit infinite loop
+    for loopIndex := 0; loopIndex < 10000; loopIndex++ {
+        // Get validator balances
+        response, err := c.bc.ListValidatorBalances(context.Background(), balancesRequest)
+        if err != nil {
+            return map[types.ValidatorPubkey]beacon.ValidatorStatus{}, fmt.Errorf("Could not get validator balances: %w", err)
         }
 
+
+        // Build status map
+        for _, bal := range response.Balances {
+
+            pubkey := types.BytesToValidatorPubkey(bal.PublicKey)
+            if status, ok := statuses[pubkey]; ok {
+                status.Balance = bal.Balance
+                statuses[pubkey] = status
+            }
+        }
+
+        // break if no responses left
+        if len(response.NextPageToken) == 0 || len(response.Balances) == 0 {
+            break;
+        }
+
+        // iterate to next page of the request
+        balancesRequest.PageToken = response.NextPageToken
     }
 
     // Return


### PR DESCRIPTION
Fixes rocket-pool/smartnode#80
- Prysm api response to ListValidators and ListValidatorBalances returns paged responses, so we need to make multiple requests with supplied NextPageToken until there are no more pages
- Make Lighthouse validator requests in batches as well and not iterate through the entire set of validators