### PR TITLE
Ability to set gas price and limit on transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,6 @@ require (
 	google.golang.org/grpc v1.29.1
 	gopkg.in/yaml.v2 v2.3.0
 )
+
+// TODO remove this and update with proper rocket-pool/rocketpool-go version after merge
+replace github.com/rocket-pool/rocketpool-go => github.com/kidkal/rocketpool-go v0.0.0-20210308222949-0ba3d4fa4698

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM52clh5rGzTKpVctGT1lH4Dc8Jw=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/kidkal/rocketpool-go v0.0.0-20210308222949-0ba3d4fa4698 h1:G6Z+3tQ01m7O5NydiFko2bezOUV69waCcnBO6YVqAes=
+github.com/kidkal/rocketpool-go v0.0.0-20210308222949-0ba3d4fa4698/go.mod h1:MeuybBrGF9KXWlssxG6ebrtB0aKJUZK4qwjNF9X1jQg=
 github.com/kilic/bls12-381 v0.0.0-20201226121925-69dacb279461/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -99,6 +99,10 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
                         Name:  "min-fee, f",
                         Usage: "The minimum node commission rate for the deposit (or 'auto')",
                     },
+                    cli.BoolFlag{
+                        Name:  "yes, y",
+                        Usage: "Automatically confirm deposit",
+                    },
                 },
                 Action: func(c *cli.Context) error {
 

--- a/rocketpool/api/node/deposit.go
+++ b/rocketpool/api/node/deposit.go
@@ -8,6 +8,7 @@ import (
     "github.com/ethereum/go-ethereum/common"
     "github.com/rocket-pool/rocketpool-go/node"
     "github.com/rocket-pool/rocketpool-go/settings"
+    "github.com/rocket-pool/rocketpool-go/utils/eth"
     "github.com/urfave/cli"
     "golang.org/x/sync/errgroup"
 
@@ -72,6 +73,17 @@ func canNodeDeposit(c *cli.Context, amountWei *big.Int) (*api.CanNodeDepositResp
         depositEnabled, err := settings.GetNodeDepositEnabled(rp, nil)
         if err == nil {
             response.DepositDisabled = !depositEnabled
+        }
+        return err
+    })
+
+    wg.Go(func() error {
+        opts, err := w.GetNodeAccountTransactor()
+        if err != nil { return err }
+        opts.Value = amountWei
+        gasInfo, err := services.GetGasInfo(rp, opts, "rocketNodeDeposit", "deposit", eth.EthToWei(0.1))
+        if err == nil {
+            response.GasInfo = gasInfo
         }
         return err
     })

--- a/shared/services/gas.go
+++ b/shared/services/gas.go
@@ -1,0 +1,20 @@
+package services
+
+import (
+    "github.com/ethereum/go-ethereum/accounts/abi/bind"
+
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
+)
+
+
+// Get Gas Price and Gas Limit for transaction
+func GetGasInfo(rp *rocketpool.RocketPool, opts *bind.TransactOpts, contractName, methodName string, params ...interface{}) (rocketpool.GasInfo, error) {
+
+    contract, err := rp.GetContract(contractName)
+    if err != nil { 
+        return rocketpool.GasInfo{}, err
+    }
+
+    return contract.GetGasInfo(methodName, opts, params...)
+}
+

--- a/shared/services/rocketpool/gas.go
+++ b/shared/services/rocketpool/gas.go
@@ -1,0 +1,55 @@
+package rocketpool
+
+import (
+    "fmt"
+    "math/big"
+
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
+    "github.com/rocket-pool/rocketpool-go/utils/eth"
+    "github.com/rocket-pool/smartnode/shared/utils/math"
+)
+
+
+// Print estimated gas cost and any requested gas parameters
+func (rp *Client) PrintGasInfo(gasInfo rocketpool.GasInfo) {
+
+    // Print gas price, gas limit and total eth cost as estimated by the network
+    gas := new(big.Int).SetUint64(gasInfo.EstGasLimit)
+    var gasPrice *big.Int
+    if gasInfo.EstGasPrice != nil {
+        gasPrice = gasInfo.EstGasPrice
+    } else {
+        gasPrice = big.NewInt(0)
+    }
+    totalGasWei := new(big.Int).Mul(gasPrice, gas)
+    fmt.Printf("Estimate gas price: %.6f Gwei, Estimate gas: %d, Estimate gas cost: %.6f ETH\n", 
+               eth.WeiToGwei(gasPrice), 
+               gasInfo.EstGasLimit, 
+               math.RoundDown(eth.WeiToEth(totalGasWei), 6))
+    
+    // Print gas price, gas limit and max gas cost as requested by the user
+    var userGasMessage string
+    if gasInfo.ReqGasPrice != nil {
+        userGasMessage += fmt.Sprintf("Requested gas price: %.6f Gwei", eth.WeiToGwei(gasInfo.ReqGasPrice))
+    }
+    if gasInfo.ReqGasLimit != 0 {
+        if len(userGasMessage) > 0 {
+            userGasMessage += ", "
+        }
+        userGasMessage += fmt.Sprintf("Requested gas limit: %d", gasInfo.ReqGasLimit)
+    }
+
+    // Only print out maximum requested gas cost if either gas price or gas limit has been specified
+    if len(userGasMessage) > 0 {
+        if gasInfo.ReqGasLimit != 0 {
+            gas = new(big.Int).SetUint64(gasInfo.ReqGasLimit)
+        }
+        if gasInfo.ReqGasPrice != nil {
+            gasPrice = gasInfo.ReqGasPrice
+        }
+        totalGasWei = new(big.Int).Mul(gasPrice, gas)
+        userGasMessage += fmt.Sprintf(", Maximum requested gas cost: %.6f ETH\n", math.RoundDown(eth.WeiToEth(totalGasWei), 6))
+    }
+    fmt.Println(userGasMessage)
+}
+

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -3,6 +3,7 @@ package api
 import (
     "github.com/ethereum/go-ethereum/common"
 
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
     "github.com/rocket-pool/rocketpool-go/tokens"
 )
 
@@ -57,6 +58,7 @@ type CanNodeDepositResponse struct {
     InsufficientBalance bool        `json:"insufficientBalance"`
     InvalidAmount bool              `json:"invalidAmount"`
     DepositDisabled bool            `json:"depositDisabled"`
+    GasInfo rocketpool.GasInfo      `json:"gasInfo"`
 }
 type NodeDepositResponse struct {
     Status string                   `json:"status"`


### PR DESCRIPTION
Fixes rocket-pool/smartnode#78

- add gas properties to RocketPoolConfig so it can be pulled in via settings and config yml files
- add gas optional parameters to command line
- pass gas option parameters through to api service
- save gas parameters to Wallet and set to TransactOpts when GetNodeAccountTransactor is called