### PR TITLE
Added config support for graffitiVersion

### DIFF
--- a/shared/services/config/config.go
+++ b/shared/services/config/config.go
@@ -23,6 +23,7 @@ type RocketPoolConfig struct {
     }                                   `yaml:"rocketpool,omitempty"`
     Smartnode struct {
         ProjectName string              `yaml:"projectName,omitempty"`
+        GraffitiVersion string          `yaml:"graffitiVersion,omitempty"`
         Image string                    `yaml:"image,omitempty"`
         PasswordPath string             `yaml:"passwordPath,omitempty"`
         WalletPath string               `yaml:"walletPath,omitempty"`

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -343,6 +343,7 @@ func (c *Client) compose(composeFiles []string, args string) (string, error) {
     // Set environment variables from config
     env := []string{
         fmt.Sprintf("COMPOSE_PROJECT_NAME='%s'",    cfg.Smartnode.ProjectName),
+        fmt.Sprintf("ROCKET_POOL_VERSION='%s'",     cfg.Smartnode.GraffitiVersion),
         fmt.Sprintf("SMARTNODE_IMAGE='%s'",         cfg.Smartnode.Image),
         fmt.Sprintf("ETH1_CLIENT='%s'",             cfg.GetSelectedEth1Client().ID),
         fmt.Sprintf("ETH1_IMAGE='%s'",              cfg.GetSelectedEth1Client().Image),


### PR DESCRIPTION
This is a partner to https://github.com/rocket-pool/smartnode-install/pull/39 - it just adds a `graffitiVersion` to `config.yml` which replaces the old `ROCKET_POOL_VERSION` in `start-validator.sh` so it's easier to update and propagate to various files.