### PR TITLE
estimate gas cost before proceeding - tokenomics

### DIFF
--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -143,6 +143,9 @@ func nodeDeposit(c *cli.Context) error {
         }
     }
 
+    // Display gas estimate
+    rp.PrintGasInfo(canDeposit.GasInfo)
+
     // Prompt for confirmation
     if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf(
         "Are you sure you want to deposit %.6f ETH to create a minipool with a minimum possible commission rate of %f%%? Running a minipool is a long-term commitment.",

--- a/rocketpool/api/node/deposit.go
+++ b/rocketpool/api/node/deposit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rocket-pool/rocketpool-go/settings/protocol"
 	tnsettings "github.com/rocket-pool/rocketpool-go/settings/trustednode"
 	"github.com/rocket-pool/rocketpool-go/utils"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/errgroup"
 
@@ -90,6 +91,17 @@ func canNodeDeposit(c *cli.Context, amountWei *big.Int) (*api.CanNodeDepositResp
     wg1.Go(func() error {
         var err error
         minipoolLimit, err = node.GetNodeMinipoolLimit(rp, nodeAccount.Address, nil)
+        return err
+    })
+
+    wg1.Go(func() error {
+        opts, err := w.GetNodeAccountTransactor()
+        if err != nil { return err }
+        opts.Value = amountWei
+        gasInfo, err := services.GetGasInfo(rp, opts, "rocketNodeDeposit", "deposit", eth.EthToWei(0.1))
+        if err == nil {
+            response.GasInfo = gasInfo
+        }
         return err
     })
 

--- a/shared/services/gas.go
+++ b/shared/services/gas.go
@@ -15,6 +15,6 @@ func GetGasInfo(rp *rocketpool.RocketPool, opts *bind.TransactOpts, contractName
         return rocketpool.GasInfo{}, err
     }
 
-    return contract.GetGasInfo(methodName, opts, params...)
+    return contract.GetTransactionGasInfo(opts, methodName, params...)
 }
 

--- a/shared/services/gas.go
+++ b/shared/services/gas.go
@@ -1,0 +1,20 @@
+package services
+
+import (
+    "github.com/ethereum/go-ethereum/accounts/abi/bind"
+
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
+)
+
+
+// Get Gas Price and Gas Limit for transaction
+func GetGasInfo(rp *rocketpool.RocketPool, opts *bind.TransactOpts, contractName, methodName string, params ...interface{}) (rocketpool.GasInfo, error) {
+
+    contract, err := rp.GetContract(contractName)
+    if err != nil { 
+        return rocketpool.GasInfo{}, err
+    }
+
+    return contract.GetGasInfo(methodName, opts, params...)
+}
+

--- a/shared/services/rocketpool/gas.go
+++ b/shared/services/rocketpool/gas.go
@@ -1,0 +1,55 @@
+package rocketpool
+
+import (
+    "fmt"
+    "math/big"
+
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
+    "github.com/rocket-pool/rocketpool-go/utils/eth"
+    "github.com/rocket-pool/smartnode/shared/utils/math"
+)
+
+
+// Print estimated gas cost and any requested gas parameters
+func (rp *Client) PrintGasInfo(gasInfo rocketpool.GasInfo) {
+
+    // Print gas price, gas limit and total eth cost as estimated by the network
+    gas := new(big.Int).SetUint64(gasInfo.EstGasLimit)
+    var gasPrice *big.Int
+    if gasInfo.EstGasPrice != nil {
+        gasPrice = gasInfo.EstGasPrice
+    } else {
+        gasPrice = big.NewInt(0)
+    }
+    totalGasWei := new(big.Int).Mul(gasPrice, gas)
+    fmt.Printf("Estimate gas price: %.6f Gwei, Estimate gas: %d, Estimate gas cost: %.6f ETH\n", 
+               eth.WeiToGwei(gasPrice), 
+               gasInfo.EstGasLimit, 
+               math.RoundDown(eth.WeiToEth(totalGasWei), 6))
+    
+    // Print gas price, gas limit and max gas cost as requested by the user
+    var userGasMessage string
+    if gasInfo.ReqGasPrice != nil {
+        userGasMessage += fmt.Sprintf("Requested gas price: %.6f Gwei", eth.WeiToGwei(gasInfo.ReqGasPrice))
+    }
+    if gasInfo.ReqGasLimit != 0 {
+        if len(userGasMessage) > 0 {
+            userGasMessage += ", "
+        }
+        userGasMessage += fmt.Sprintf("Requested gas limit: %d", gasInfo.ReqGasLimit)
+    }
+
+    // Only print out maximum requested gas cost if either gas price or gas limit has been specified
+    if len(userGasMessage) > 0 {
+        if gasInfo.ReqGasLimit != 0 {
+            gas = new(big.Int).SetUint64(gasInfo.ReqGasLimit)
+        }
+        if gasInfo.ReqGasPrice != nil {
+            gasPrice = gasInfo.ReqGasPrice
+        }
+        totalGasWei = new(big.Int).Mul(gasPrice, gas)
+        userGasMessage += fmt.Sprintf(", Maximum requested gas cost: %.6f ETH\n", math.RoundDown(eth.WeiToEth(totalGasWei), 6))
+    }
+    fmt.Println(userGasMessage)
+}
+

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+    "github.com/rocket-pool/rocketpool-go/rocketpool"
 	"github.com/rocket-pool/rocketpool-go/tokens"
 )
 
@@ -125,6 +126,7 @@ type CanNodeDepositResponse struct {
     InvalidAmount bool                  `json:"invalidAmount"`
     UnbondedMinipoolsAtMax bool         `json:"unbondedMinipoolsAtMax"`
     DepositDisabled bool                `json:"depositDisabled"`
+    GasInfo rocketpool.GasInfo          `json:"gasInfo"`
 }
 type NodeDepositResponse struct {
     Status string                       `json:"status"`


### PR DESCRIPTION
This PR is same as #98 but merged to https://github.com/rocket-pool/smartnode/tree/beta-3

Example output from `rocketpool node deposit`

```
Please choose an amount of ETH to deposit:
1: 32 ETH (minipool begins staking immediately)
2: 16 ETH (minipool begins staking after ETH is assigned)
2

The current network node commission rate that your minipool should receive is 20.000000%.
The suggested maximum commission rate slippage for your deposit transaction is 1.000000%.
This will result in your minipool receiving a minimum possible commission rate of 19.000000%.
Do you want to use the suggested maximum commission rate slippage? [y/n]
y

Estimate gas price: 1.000000 Gwei, Estimate gas: 1394257, Estimate gas cost: 0.001394 ETH

Are you sure you want to deposit 16.000000 ETH to create a minipool with a minimum possible commission rate of 19.000000%? Running a minipool is a long-term commitment. [y/n]
```

Example output when specifying gas price: `rocketpool -g 50 node deposit`
```
Please choose an amount of ETH to deposit:
1: 32 ETH (minipool begins staking immediately)
2: 16 ETH (minipool begins staking after ETH is assigned)
2

The current network node commission rate that your minipool should receive is 20.000000%.
The suggested maximum commission rate slippage for your deposit transaction is 1.000000%.
This will result in your minipool receiving a minimum possible commission rate of 19.000000%.
Do you want to use the suggested maximum commission rate slippage? [y/n]
y

Estimate gas price: 1.000000 Gwei, Estimate gas: 1394257, Estimate gas cost: 0.001394 ETH
Requested gas price: 50.000000 Gwei, Maximum requested gas cost: 0.069712 ETH

Are you sure you want to deposit 16.000000 ETH to create a minipool with a minimum possible commission rate of 19.000000%? Running a minipool is a long-term commitment. [y/n]
```


