### PR TITLE
[rfc] Add simple snapcraft.yaml to package CLI

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: rocketpool
+version: git
+description: |
+  Rocket Pool is a next generation Ethereum proof of stake (PoS) infrastructure
+  service designed to be highly decentralised, distributed and compatible with
+  Ethereum 2.0. This package contains the Rocket Pool smart node.
+summary: The Rocket Pool smart node
+base: core18
+confinement: classic
+grade: devel
+parts:
+  rocketpool:
+    plugin: go
+    source: .
+    go-packages:
+      - github.com/rocket-pool/smartnode/rocketpool
+      - github.com/rocket-pool/smartnode/rocketpool-cli
+      - github.com/rocket-pool/smartnode/shared
+      - github.com/rocket-pool/smartnode/rocketpool-pow-proxy
+    go-importpath: github.com/rocket-pool/smartnode
+    stage-packages:
+      - curl
+apps:
+  rocketpool:
+    command: bin/rocketpool-cli
+    plugs:
+    - docker
+    - network


### PR DESCRIPTION
This PR adds a build config for [snapcraft](https://snapcraft.io). The package contains the three binaries (CLI, service, pow proxy) plus a curl binary. To build, run `snapcraft` from the repo root on a box with `snapcraft` installed. This will produce a developer mode `.snap` file that can be installed with `sudo snap install rocketpool_1.0.0-beta.1+git39.5596c3d_amd64.snap --classic --dangerous`, which puts the CLI at `/snap/bin/rocketpool`.

The main benefit of this approach is that users don't have to manually download binaries from github, make sure checksums match, and set up their environment with `$HOME/bin` etc.

There are two ways we can proceed:
1. Keep it simple and just package the CLI and its dependencies (`curl` and `tar` with `xz` support as far as i can tell). If we go this route, I'll remove the pow-proxy and service binaries, and add `tar`.
2. Package the CLI and all the stuff it downloads during `service install`: `docker`, `docker-compose`, and the config files. Doing this would mean the entire install/upgrade process can be handled by `snap` - later on we can isolate the entire rocketpool installation so it can only access certain system resources (like the docker socket)