### PR TITLE
Fix the PoW-Proxy for custom eth1 clients

### DIFF
--- a/rocketpool-pow-proxy/rocketpool-pow-proxy.go
+++ b/rocketpool-pow-proxy/rocketpool-pow-proxy.go
@@ -51,6 +51,11 @@ func main() {
             Value: "",
         },
         cli.StringFlag{
+            Name:  "wsURL, x",
+            Usage: "External Eth 1.0 provider `wsURL` (defaults to Infura)",
+            Value: "",
+        },
+        cli.StringFlag{
             Name:  "network, n",
             Usage: "`Network` to connect to via Infura",
             Value: "goerli",
@@ -78,7 +83,7 @@ func main() {
     
         // Websocket server
         go func() {
-            proxyServer := proxy.NewWsProxyServer(c.GlobalString("wsPort"), c.GlobalString("providerUrl"), c.GlobalString("network"), c.GlobalString("projectId"))
+            proxyServer := proxy.NewWsProxyServer(c.GlobalString("wsPort"), c.GlobalString("wsURL"), c.GlobalString("network"), c.GlobalString("projectId"))
             proxyServer.Start()
             wg.Done()
         }()

--- a/rocketpool-pow-proxy/rocketpool-pow-proxy.go
+++ b/rocketpool-pow-proxy/rocketpool-pow-proxy.go
@@ -19,7 +19,7 @@ func main() {
     // Set application info
     app.Name = "rocketpool-pow-proxy"
     app.Usage = "Rocket Pool Eth 1.0 proxy server"
-    app.Version = "0.0.1"
+    app.Version = "1.0.0-beta.4"
     app.Authors = []cli.Author{
         cli.Author{
             Name:  "David Rugendyke",

--- a/rocketpool-pow-proxy/rocketpool-pow-proxy.go
+++ b/rocketpool-pow-proxy/rocketpool-pow-proxy.go
@@ -1,15 +1,14 @@
 package main
 
 import (
-    "log"
-    "os"
-    "sync"
+	"log"
+	"os"
+	"sync"
 
-    "github.com/urfave/cli"
+	"github.com/urfave/cli"
 
-    "github.com/rocket-pool/smartnode/rocketpool-pow-proxy/proxy"
+	"github.com/rocket-pool/smartnode/rocketpool-pow-proxy/proxy"
 )
-
 
 // Run
 func main() {
@@ -30,29 +29,33 @@ func main() {
             Name:  "Jake Pospischil",
             Email: "jake@rocketpool.net",
         },
+        cli.Author{
+            Name:  "Joe Clapis",
+            Email: "joe@rocketpool.net",
+        },
     }
-    app.Copyright = "(c) 2020 Rocket Pool Pty Ltd"
+    app.Copyright = "(c) 2021 Rocket Pool Pty Ltd"
 
     // Configure application
     app.Flags = []cli.Flag{
         cli.StringFlag{
-            Name:  "port, p",
-            Usage: "HTTP port to listen on",
+            Name:  "httpPort, p",
+            Usage: "Local HTTP port to listen on",
             Value: "8545",
         },
         cli.StringFlag{
             Name:  "wsPort, w",
-            Usage: "Websocket port to listen on",
+            Usage: "Local Websocket port to listen on",
             Value: "8546",
         },
         cli.StringFlag{
-            Name:  "providerUrl, u",
-            Usage: "External Eth 1.0 provider `URL` (defaults to Infura)",
+            Name:  "httpProviderUrl, u",
+            Usage: "External Eth 1.0 provider HTTP `URL`, including the remote port (defaults to Infura)",
             Value: "",
         },
         cli.StringFlag{
-            Name:  "wsURL, x",
-            Usage: "External Eth 1.0 provider `wsURL` (defaults to Infura)",
+            Name:  "wsProviderUrl, r",
+            Usage: "External Eth 1.0 provider Websocket `URL`, including the remote port (defaults to Infura)",
             Value: "",
         },
         cli.StringFlag{
@@ -76,14 +79,14 @@ func main() {
 
         // HTTP server
         go func() {
-            proxyServer := proxy.NewHttpProxyServer(c.GlobalString("port"), c.GlobalString("providerUrl"), c.GlobalString("network"), c.GlobalString("projectId"))
+            proxyServer := proxy.NewHttpProxyServer(c.GlobalString("httpPort"), c.GlobalString("httpProviderUrl"), c.GlobalString("network"), c.GlobalString("projectId"))
             proxyServer.Start()
             wg.Done()
         }()
     
         // Websocket server
         go func() {
-            proxyServer := proxy.NewWsProxyServer(c.GlobalString("wsPort"), c.GlobalString("wsURL"), c.GlobalString("network"), c.GlobalString("projectId"))
+            proxyServer := proxy.NewWsProxyServer(c.GlobalString("wsPort"), c.GlobalString("wsProviderUrl"), c.GlobalString("network"), c.GlobalString("projectId"))
             proxyServer.Start()
             wg.Done()
         }()


### PR DESCRIPTION
This is part of a series that fixes #137. It modifies the PoW proxy to support separate arguments for the HTTP and Websocket addresses.