### PR TITLE
Change formatted API error response to use API response instead of a nil error

### DIFF
--- a/shared/services/rocketpool/odao.go
+++ b/shared/services/rocketpool/odao.go
@@ -446,7 +446,7 @@ func (c *Client) ProposeTNDAOSettingMembersQuorum(quorum float64) (api.ProposeTN
         return api.ProposeTNDAOSettingMembersQuorumResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting members.quorum response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingMembersQuorumResponse{}, fmt.Errorf("Could not propose oracle DAO setting members.quorum %w", err)
+        return api.ProposeTNDAOSettingMembersQuorumResponse{}, fmt.Errorf("Could not propose oracle DAO setting members.quorum: %s", response.Error)
     }
     return response, nil
 }
@@ -460,7 +460,7 @@ func (c *Client) ProposeTNDAOSettingMembersRplBond(bondAmountWei *big.Int) (api.
         return api.ProposeTNDAOSettingMembersRplBondResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting members.rplbond response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingMembersRplBondResponse{}, fmt.Errorf("Could not propose oracle DAO setting members.rplbond %w", err)
+        return api.ProposeTNDAOSettingMembersRplBondResponse{}, fmt.Errorf("Could not propose oracle DAO setting members.rplbond: %s", response.Error)
     }
     return response, nil
 }
@@ -474,7 +474,7 @@ func (c *Client) ProposeTNDAOSettingMinipoolUnbondedMax(unbondedMinipoolMax uint
         return api.ProposeTNDAOSettingMinipoolUnbondedMaxResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting members.minipool.unbonded.max response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingMinipoolUnbondedMaxResponse{}, fmt.Errorf("Could not propose oracle DAO setting members.minipool.unbonded.max %w", err)
+        return api.ProposeTNDAOSettingMinipoolUnbondedMaxResponse{}, fmt.Errorf("Could not propose oracle DAO setting members.minipool.unbonded.max: %s", response.Error)
     }
     return response, nil
 }
@@ -488,7 +488,7 @@ func (c *Client) ProposeTNDAOSettingProposalCooldown(proposalCooldownBlocks uint
         return api.ProposeTNDAOSettingProposalCooldownResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting proposal.cooldown response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingProposalCooldownResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.cooldown %w", err)
+        return api.ProposeTNDAOSettingProposalCooldownResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.cooldown: %s", response.Error)
     }
     return response, nil
 }
@@ -502,7 +502,7 @@ func (c *Client) ProposeTNDAOSettingProposalVoteBlocks(proposalVoteBlocks uint64
         return api.ProposeTNDAOSettingProposalVoteBlocksResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting proposal.vote.blocks response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingProposalVoteBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.vote.blocks %w", err)
+        return api.ProposeTNDAOSettingProposalVoteBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.vote.blocks: %s", response.Error)
     }
     return response, nil
 }
@@ -516,7 +516,7 @@ func (c *Client) ProposeTNDAOSettingProposalVoteDelayBlocks(proposalDelayBlocks 
         return api.ProposeTNDAOSettingProposalVoteDelayBlocksResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting proposal.vote.delay.blocks response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingProposalVoteDelayBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.vote.delay.blocks %w", err)
+        return api.ProposeTNDAOSettingProposalVoteDelayBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.vote.delay.blocks: %s", response.Error)
     }
     return response, nil
 }
@@ -530,7 +530,7 @@ func (c *Client) ProposeTNDAOSettingProposalExecuteBlocks(proposalExecuteBlocks 
         return api.ProposeTNDAOSettingProposalExecuteBlocksResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting proposal.execute.blocks response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingProposalExecuteBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.execute.blocks %w", err)
+        return api.ProposeTNDAOSettingProposalExecuteBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.execute.blocks: %s", response.Error)
     }
     return response, nil
 }
@@ -544,7 +544,7 @@ func (c *Client) ProposeTNDAOSettingProposalActionBlocks(proposalActionBlocks ui
         return api.ProposeTNDAOSettingProposalActionBlocksResponse{}, fmt.Errorf("Could not decode propose oracle DAO setting proposal.action.blocks response: %w", err)
     }
     if response.Error != "" {
-        return api.ProposeTNDAOSettingProposalActionBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.action.blocks %w", err)
+        return api.ProposeTNDAOSettingProposalActionBlocksResponse{}, fmt.Errorf("Could not propose oracle DAO setting proposal.action.blocks: %s", response.Error)
     }
     return response, nil
 }
@@ -561,7 +561,7 @@ func (c *Client) GetTNDAOMemberSettings() (api.GetTNDAOMemberSettingsResponse, e
         return api.GetTNDAOMemberSettingsResponse{}, fmt.Errorf("Could not decode oracle DAO member settings response: %w", err)
     }
     if response.Error != "" {
-        return api.GetTNDAOMemberSettingsResponse{}, fmt.Errorf("Could not get oracle DAO member settings: %w", err)
+        return api.GetTNDAOMemberSettingsResponse{}, fmt.Errorf("Could not get oracle DAO member settings: %s", response.Error)
     }
     if response.RPLBond == nil { response.RPLBond = big.NewInt(0) }
     if response.ChallengeCost == nil { response.ChallengeCost = big.NewInt(0) }
@@ -580,7 +580,7 @@ func (c *Client) GetTNDAOProposalSettings() (api.GetTNDAOProposalSettingsRespons
         return api.GetTNDAOProposalSettingsResponse{}, fmt.Errorf("Could not decode oracle DAO proposal settings response: %w", err)
     }
     if response.Error != "" {
-        return api.GetTNDAOProposalSettingsResponse{}, fmt.Errorf("Could not get oracle DAO proposal settings: %w", err)
+        return api.GetTNDAOProposalSettingsResponse{}, fmt.Errorf("Could not get oracle DAO proposal settings: %s", response.Error)
     }
     return response, nil
 }


### PR DESCRIPTION
Error messages from API calls were not formatted with the correct variable.

```
nii236 at ethstaker in ~ 
$ rocketpool odao member-settings

Could not get oracle DAO member settings: %!w(<nil>)
```

This pull request changes the `fmt.Errorf` from using `err`, which is the error from the HTTP client, to `Response.Error` which is the error message from the HTTP response.