### PR TITLE
Prompt for user input before printing sensitive data in wallet exports

### DIFF
--- a/rocketpool-cli/rocketpool-cli.go
+++ b/rocketpool-cli/rocketpool-cli.go
@@ -116,12 +116,17 @@ ______           _        _    ______           _
             Usage: "Desired gas limit",
         },
         cli.StringFlag{
-            Name: "nonce",
+            Name:  "nonce",
             Usage: "Use this flag to explicitly specify the nonce that this transaction should use, so it can override an existing 'stuck' transaction",
         },
         cli.BoolFlag{
-            Name:"debug",
+            Name:  "debug",
             Usage: "Enable debug printing of API commands",
+        },
+        cli.BoolFlag{
+            Name:  "secure-session, s",
+            Usage: "Some commands may print sensitive information to your terminal. " +
+                   "Use this flag when nobody can see your screen to allow sensitive data to be printed without prompting",
         },
     }
 
@@ -175,19 +180,20 @@ ______           _        _    ______           _
      service.RegisterCommands(app, "service",  []string{"s"})
       wallet.RegisterCommands(app, "wallet",   []string{"w"})
 
-    // Check user ID
     app.Before = func(c *cli.Context) error {
+        // Check user ID
         if os.Getuid() == 0 && !c.GlobalBool("allow-root") {
             fmt.Fprintln(os.Stderr, "rocketpool should not be run as root. Please try again without 'sudo'.")
             fmt.Fprintln(os.Stderr, "If you want to run rocketpool as root anyway, use the '--allow-root' option to override this warning.")
             os.Exit(1)
         }
 
+        // Check for deprecated flags
         if c.String("gasPrice") != "" {
             fmt.Fprintln(os.Stderr, "The `gasPrice` flag is deprecated - please use `--maxFee` and optionally `--maxPrioFee` instead.")
             os.Exit(1)
         }
-        
+
         return nil
     }
 

--- a/rocketpool-cli/wallet/commands.go
+++ b/rocketpool-cli/wallet/commands.go
@@ -1,9 +1,6 @@
 package wallet
 
 import (
-    "fmt"
-    "os"
-
     "github.com/urfave/cli"
 
     cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
@@ -120,38 +117,10 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
                 Aliases:   []string{"e"},
                 Usage:     "Export the node wallet in JSON format",
                 UsageText: "rocketpool wallet export",
-                Flags: []cli.Flag{
-                    cli.BoolFlag{
-                        Name:  "force, f",
-                        Usage: "Skips warnings about printing sensitive information",
-                    },
-                },
                 Action: func(c *cli.Context) error {
-                    colorYellow := "\033[33m"
-		    colorReset := "\033[0m"
 
                     // Validate args
                     if err := cliutils.ValidateArgCount(c, 0); err != nil { return err }
-
-                    // Prompt for user confirmation
-                    if !c.Bool("force") {
-                        stat, err := os.Stdout.Stat()
-                        if err != nil {
-                            fmt.Fprintf(os.Stderr, "Error checking stdout stat: %w.\nUse --force to export wallet.\n", err)
-			    return nil
-                        }
-
-                        if (stat.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
-                            fmt.Fprintln(os.Stderr, "Call wallet export with --force to export wallet to non-interactive terminal.")
-			    return nil
-                        }
-
-                        if !cliutils.Confirm(fmt.Sprintf("%sExporting a wallet will print sensitive information to your screen.%s\n" +
-                            "Are you sure you want to continue?", colorYellow, colorReset)) {
-                                fmt.Println("Cancelled.")
-                                return nil
-                        }
-                    }
 
                     // Run
                     return exportWallet(c)

--- a/rocketpool-cli/wallet/commands.go
+++ b/rocketpool-cli/wallet/commands.go
@@ -1,6 +1,9 @@
 package wallet
 
 import (
+    "fmt"
+    "os"
+
     "github.com/urfave/cli"
 
     cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
@@ -117,10 +120,38 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
                 Aliases:   []string{"e"},
                 Usage:     "Export the node wallet in JSON format",
                 UsageText: "rocketpool wallet export",
+                Flags: []cli.Flag{
+                    cli.BoolFlag{
+                        Name:  "force, f",
+                        Usage: "Skips warnings about printing sensitive information",
+                    },
+                },
                 Action: func(c *cli.Context) error {
+                    colorYellow := "\033[33m"
+		    colorReset := "\033[0m"
 
                     // Validate args
                     if err := cliutils.ValidateArgCount(c, 0); err != nil { return err }
+
+                    // Prompt for user confirmation
+                    if !c.Bool("force") {
+                        stat, err := os.Stdout.Stat()
+                        if err != nil {
+                            fmt.Fprintf(os.Stderr, "Error checking stdout stat: %w.\nUse --force to export wallet.\n", err)
+			    return nil
+                        }
+
+                        if (stat.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
+                            fmt.Fprintln(os.Stderr, "Call wallet export with --force to export wallet to non-interactive terminal.")
+			    return nil
+                        }
+
+                        if !cliutils.Confirm(fmt.Sprintf("%sExporting a wallet will print sensitive information to your screen.%s\n" +
+                            "Are you sure you want to continue?", colorYellow, colorReset)) {
+                                fmt.Println("Cancelled.")
+                                return nil
+                        }
+                    }
 
                     // Run
                     return exportWallet(c)

--- a/rocketpool-cli/wallet/init.go
+++ b/rocketpool-cli/wallet/init.go
@@ -7,6 +7,7 @@ import (
 
     "github.com/rocket-pool/smartnode/shared/services/rocketpool"
     "github.com/rocket-pool/smartnode/shared/utils/term"
+    cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
 
 
@@ -24,6 +25,12 @@ func initWallet(c *cli.Context) error {
     }
     if status.WalletInitialized {
         fmt.Println("The node wallet is already initialized.")
+        return nil
+    }
+
+    // Prompt for user confirmation before printing sensitive information
+    if !(c.GlobalBool("secure-session") ||
+         cliutils.ConfirmSecureSession("Creating a wallet will print sensitive information to your screen.")) {
         return nil
     }
 

--- a/shared/utils/cli/prompt.go
+++ b/shared/utils/cli/prompt.go
@@ -65,3 +65,12 @@ func Select(initialPrompt string, options []string) (int, string) {
 
 }
 
+// Prompts the user to verify that there is nobody looking over their shoulder before printing sensitive information.
+func ConfirmSecureSession(warning string) bool {
+    if !Confirm(fmt.Sprintf("%s%s%s\nAre you sure you want to continue?", colorYellow, warning, colorReset)) {
+        fmt.Println("Cancelled.")
+        return false
+    }
+
+    return true
+}


### PR DESCRIPTION
Closes #167 

Y'all have some interesting code style for golang

NB- the printing is to stderr. Two things: urfave cli should default to stderr but appears to be printing to stdout. I can't figure out why. It does provide a package-level override, and it's possible some other import is overriding it. Additionally, most of the error reporting in this project appears to print to stdout. This is fine for most use cases, but since `wallet export` intuitively will be redirected to a regular file, the errors should be printed to stderr. This avoids situations where the regular file is created, but contains an error message, and the user thinks they have successfully exported the wallet when they actually have not.

I also noticed that when the app exits with an error, it has exit code 0. Not ideal, as i could imagine a bash script that wants to call something like `wallet export`, ignore stderr, and check the return code.