### PR TITLE
Run goimports to format the code, add a github action to prevent it from falling out of format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,16 @@
+name: Code Formatting
+on: [push]
+jobs:
+  goimports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.15'
+      - name: Install goimports
+        run: go get golang.org/x/tools/cmd/goimports@latest
+      - name: Run goimports
+        run: if [ "$(goimports -l . | wc -l)" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
If unformatted code is put up in a PR, an error will appear:
![image](https://user-images.githubusercontent.com/116244/148454135-c40321e2-59dc-4db6-a14e-4c9226bcc511.png)
someone from the org can decide whether to make it prevent merging, and update the settings in github accordingly

Closes #172 
Replaces https://github.com/rocket-pool/smartnode/pull/176