### PR TITLE
Fix a couple staticcheck revealed issues

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -241,6 +241,10 @@ func checkForValidatorChange(rp *rocketpool.Client, userConfig config.RocketPool
 
     // Get the current validator client
     currentValidatorImageString, err := rp.GetDockerImage(prefix + ValidatorContainerSuffix)
+    if err != nil {
+        return fmt.Errorf("Error getting current validator image: %w", err)
+    }
+
     currentValidatorName, err := getDockerImageName(currentValidatorImageString)
     if err != nil {
         return fmt.Errorf("Error getting current validator image name: %w", err)


### PR DESCRIPTION
1- random client selection allows supermajority clients, even when
includeSupermajority is false.
2- one ignored Error

The random selection is a bit more complex now. I didn't want to open the possibility of an infinite loop if both `Fallback == true` and `includeSupermajority == false` and no clients fit the criteria. Instead, the loop iterates the client list once, collecting eligible clients into a slice, and erroring if resulting vector is empty. Otherwise, it randomly picks a client from the new slice.

N.B. This is untested, as I'm not currently set up on prater