### PR TITLE
Use Start/Wait instead of Run to handle stdin/stdout better

### DIFF
--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	osUser "os/user"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/a8m/envsubst"
@@ -970,37 +971,65 @@ func (c *Client) getDownloader() (string, error) {
 
 }
 
+// pipeToStdOut pipes cmdOut to stdout
+// Adds to WaitGroup and calls Done
+func pipeToStdOut(cmdOut io.Reader, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	_, err := io.Copy(os.Stdout, cmdOut)
+	if err != nil {
+		log.Printf("Error piping stdout: %v", err)
+	}
+}
+
+// pipeToStdErr pipes cmdErr to stderr
+// Adds to WaitGroup and calls Done
+func pipeToStdErr(cmdErr io.Reader, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	_, err := io.Copy(os.Stderr, cmdErr)
+	if err != nil {
+		log.Printf("Error piping stderr: %v", err)
+	}
+}
+
+// pipeOutput pipes cmdOut and cmdErr to stdout and stderr
+// Blocks until both cmdOut and cmdErr file descriptors are closed
+func pipeOutput(cmdOut, cmdErr io.Reader) {
+	var wg sync.WaitGroup
+
+	go pipeToStdOut(cmdOut, &wg)
+	go pipeToStdErr(cmdErr, &wg)
+
+	wg.Wait()
+}
 
 // Run a command and print its output
 func (c *Client) printOutput(cmdText string) error {
 
-    // Initialize command
-    cmd, err := c.newCommand(cmdText)
-    if err != nil { return err }
-    defer func() {
-        _ = cmd.Close()
-    }()
+	// Initialize command
+	cmd, err := c.newCommand(cmdText)
+	if err != nil {
+		return err
+	}
+	defer cmd.Close()
 
-    // Copy command output to stdout & stderr
-    cmdOut, err := cmd.StdoutPipe()
-    if err != nil { return err }
-    cmdErr, err := cmd.StderrPipe()
-    if err != nil { return err }
-    go func() {
-        _, err := io.Copy(os.Stdout, cmdOut)
-        if err != nil {
-        	log.Printf("Error piping stdout: %v", err)
-        }
-    }()
-    go func() {
-        _, err := io.Copy(os.Stderr, cmdErr)
-        if err != nil {
-            log.Printf("Error piping stderr: %v", err)
-        }
-    }()
+	cmdOut, cmdErr, err := cmd.OutputPipes()
+	if err != nil {
+		return err
+	}
 
-    // Run command
-    return cmd.Run()
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	pipeOutput(cmdOut, cmdErr)
+
+	// Wait for the command to exit
+	return cmd.Wait()
 
 }
 

--- a/shared/services/rocketpool/command.go
+++ b/shared/services/rocketpool/command.go
@@ -54,6 +54,23 @@ func (c *command) Run() error {
     }
 }
 
+// Start executes the command. Don't forget to call Wait
+func (c *command) Start() error {
+	if c.cmd != nil {
+		return c.cmd.Start()
+	} else {
+		return c.session.Start(c.cmdText)
+	}
+}
+
+// Wait for the command to exit
+func (c *command) Wait() error {
+	if c.cmd != nil {
+		return c.cmd.Wait()
+	} else {
+		return c.session.Wait()
+	}
+}
 
 // Run the command and return its output
 func (c *command) Output() ([]byte, error) {
@@ -84,3 +101,13 @@ func (c *command) StderrPipe() (io.Reader, error) {
     }
 }
 
+// OutputPipes pipes for stdout and stderr
+func (c *command) OutputPipes() (io.Reader, io.Reader, error) {
+	cmdOut, err := c.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	cmdErr, err := c.StderrPipe()
+
+	return cmdOut, cmdErr, err
+}


### PR DESCRIPTION
Fix for the `Error piping stdout: read |0: file already closed` bug.

From the [docs](https://pkg.go.dev/os/exec#Cmd.StderrPipe): 
> ... it is incorrect to use Run when using StderrPipe.

I tested it with a few of the standard commands and it appears to work as expected. I did not test with the SSH method. I see that has been marked as deprecated. I've never used it before, so I don't have that set up.

A kind note: It was really painful to contribute this change because `gofmt` is not being used for this project and I almost did not make a contribution because it was not used - knowing that my git stage would be a big mess. Please consider running `go fmt` over the code base. It is a standard in the industry. It will lower the barrier to entry for new contributes who have all their standard IDE setup to format on save. Thank you for this consideration.