### PR TITLE
Update wallet init mnemonic flow

### DIFF
--- a/rocketpool-cli/wallet/commands.go
+++ b/rocketpool-cli/wallet/commands.go
@@ -42,10 +42,6 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 						Name:  "password, p",
 						Usage: "The password to secure the wallet with (if not already set)",
 					},
-					cli.BoolFlag{
-						Name:  "confirm-mnemonic, c",
-						Usage: "Automatically confirm the mnemonic phrase",
-					},
 				},
 				Action: func(c *cli.Context) error {
 

--- a/rocketpool-cli/wallet/init.go
+++ b/rocketpool-cli/wallet/init.go
@@ -55,14 +55,7 @@ func initWallet(c *cli.Context) error {
 	}
 
 	// Print mnemonic
-	fmt.Println("Your mnemonic phrase to recover your wallet is printed below. It can be used to recover your node account and validator keys if they are lost.")
-	fmt.Println("Record this phrase somewhere secure and private. Do not share it with anyone as it will give them control of your node account and validators.")
-	fmt.Println("==============================================================================================================================================")
-	fmt.Println("")
 	printMnemonic(response.Mnemonic)
-	fmt.Println("")
-	fmt.Println("==============================================================================================================================================")
-	fmt.Println("")
 
 	// Confirm mnemonic
 	if !c.Bool("confirm-mnemonic") {

--- a/rocketpool-cli/wallet/init.go
+++ b/rocketpool-cli/wallet/init.go
@@ -57,8 +57,19 @@ func initWallet(c *cli.Context) error {
 	// Print mnemonic
 	printMnemonic(response.Mnemonic)
 
+	// Clear terminal output
+	_ = term.Clear()
+
 	// Confirm mnemonic
-	confirmMnemonic(response.Mnemonic)
+	if !confirmMnemonic(response.Mnemonic) {
+		// The user was unable to confirm the mnemonic, so remove the wallet and force them to restart the process.
+		if err := rp.RemoveWallet(); err != nil {
+			return err
+		}
+
+		fmt.Println("Wallet not initialized. Please try again.")
+		return nil
+	}
 
 	// Clear terminal output
 	_ = term.Clear()

--- a/rocketpool-cli/wallet/init.go
+++ b/rocketpool-cli/wallet/init.go
@@ -58,9 +58,7 @@ func initWallet(c *cli.Context) error {
 	printMnemonic(response.Mnemonic)
 
 	// Confirm mnemonic
-	if !c.Bool("confirm-mnemonic") {
-		confirmMnemonic(response.Mnemonic)
-	}
+	confirmMnemonic(response.Mnemonic)
 
 	// Clear terminal output
 	_ = term.Clear()

--- a/rocketpool-cli/wallet/init.go
+++ b/rocketpool-cli/wallet/init.go
@@ -59,7 +59,7 @@ func initWallet(c *cli.Context) error {
 	fmt.Println("Record this phrase somewhere secure and private. Do not share it with anyone as it will give them control of your node account and validators.")
 	fmt.Println("==============================================================================================================================================")
 	fmt.Println("")
-	fmt.Println(response.Mnemonic)
+	printMnemonic(response.Mnemonic)
 	fmt.Println("")
 	fmt.Println("==============================================================================================================================================")
 	fmt.Println("")

--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -11,7 +11,9 @@ import (
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
 
-var UTF8_EMPTY_SPACE string = "\xE2\x80\x8B"
+const UTF8_EMPTY_SPACE string = "\xE2\x80\x8B"
+const colorYellow string = "\033[33m"
+const colorReset string = "\033[0m"
 
 // Prompt for a wallet password
 func promptPassword() string {
@@ -48,14 +50,20 @@ func promptMnemonic() string {
 
 // Print a mnemonic
 func printMnemonic(mnemonic string) {
-	utf8Var, _ := os.LookupEnv("LANG")
-	utf8 := strings.Contains(utf8Var, "UTF-8")
-	if !utf8 {
-		fmt.Println(mnemonic)
-		return
-	}
+	utf8, _ := os.LookupEnv("LANG")
 
-	fmt.Println(strings.ReplaceAll(mnemonic, " ", " "+UTF8_EMPTY_SPACE))
+	fmt.Println(colorYellow + "Your mnemonic phrase to recover your wallet is printed below. It can be used to recover your node account and validator keys if they are lost." + colorReset)
+	fmt.Println(colorYellow + "Record this phrase somewhere secure and private. Do not share it with anyone as it will give them control of your node account and validators." + colorReset)
+	fmt.Println("==============================================================================================================================================")
+	fmt.Println("")
+	if strings.Contains(utf8, "UTF-8") {
+		fmt.Println(strings.ReplaceAll(mnemonic, " ", " "+UTF8_EMPTY_SPACE))
+	} else {
+		fmt.Println(mnemonic)
+	}
+	fmt.Println("")
+	fmt.Println("==============================================================================================================================================")
+	fmt.Println("")
 }
 
 // Confirm a recovery mnemonic phrase
@@ -67,7 +75,7 @@ func confirmMnemonic(mnemonic string) {
 		}
 
 		if strings.Contains(confirmation, UTF8_EMPTY_SPACE) {
-			fmt.Println("It seems like you copy pasted your mnemonic phrase. Please write it down and enter it by hand.")
+			fmt.Println(colorYellow + "It seems like you copy pasted your mnemonic phrase. Please write it down and enter it by hand." + colorReset)
 		} else {
 			fmt.Println("The mnemonic phrase you entered does not match your recovery phrase. Please try again.")
 		}

--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -64,20 +64,26 @@ func printMnemonic(mnemonic string) {
 	fmt.Println("")
 	fmt.Println("==============================================================================================================================================")
 	fmt.Println("")
+	for !cliutils.Confirm("Have you written down your mnemonic? The screen will be cleared if you continue.") {
+	}
 }
 
 // Confirm a recovery mnemonic phrase
-func confirmMnemonic(mnemonic string) {
+func confirmMnemonic(mnemonic string) bool {
 	for {
 		confirmation := cliutils.Prompt("Please enter your recorded mnemonic phrase to confirm it is correct:", "^.*$", "")
 		if mnemonic == confirmation {
-			return
+			return true
 		}
 
 		if strings.Contains(confirmation, UTF8_EMPTY_SPACE) {
 			fmt.Println(colorYellow + "It seems like you copy pasted your mnemonic phrase. Please write it down and enter it by hand." + colorReset)
-		} else {
-			fmt.Println("The mnemonic phrase you entered does not match your recovery phrase. Please try again.")
+			fmt.Println("")
+			continue
+		}
+
+		if !cliutils.Confirm("The mnemonic phrase you entered does not match your recovery phrase. Would you like to try again?") {
+			return false
 		}
 		fmt.Println("")
 	}

--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -2,12 +2,16 @@ package wallet
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/tyler-smith/go-bip39"
 
 	"github.com/rocket-pool/smartnode/shared/services/passwords"
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
+
+var UTF8_EMPTY_SPACE string = "\xE2\x80\x8B"
 
 // Prompt for a wallet password
 func promptPassword() string {
@@ -20,10 +24,10 @@ func promptPassword() string {
 		confirmation := cliutils.PromptPassword("Please confirm your password:", "^.*$", "")
 		if password == confirmation {
 			return password
-		} else {
-			fmt.Println("Password confirmation does not match.")
-			fmt.Println("")
 		}
+
+		fmt.Println("Password confirmation does not match.")
+		fmt.Println("")
 	}
 }
 
@@ -31,13 +35,27 @@ func promptPassword() string {
 func promptMnemonic() string {
 	for {
 		mnemonic := cliutils.PromptPassword("Please enter your recovery mnemonic phrase:", "^.*$", "")
+		// If the user copy-pasted their mnemonic, don't make them panic by failing on the UTF8 guardians
+		mnemonic = strings.ReplaceAll(mnemonic, UTF8_EMPTY_SPACE, "")
 		if bip39.IsMnemonicValid(mnemonic) {
 			return mnemonic
-		} else {
-			fmt.Println("Invalid mnemonic phrase.")
-			fmt.Println("")
 		}
+
+		fmt.Println("Invalid mnemonic phrase.")
+		fmt.Println("")
 	}
+}
+
+// Print a mnemonic
+func printMnemonic(mnemonic string) {
+	utf8Var, _ := os.LookupEnv("LANG")
+	utf8 := strings.Contains(utf8Var, "UTF-8")
+	if !utf8 {
+		fmt.Println(mnemonic)
+		return
+	}
+
+	fmt.Println(strings.ReplaceAll(mnemonic, " ", " "+UTF8_EMPTY_SPACE))
 }
 
 // Confirm a recovery mnemonic phrase
@@ -46,9 +64,13 @@ func confirmMnemonic(mnemonic string) {
 		confirmation := cliutils.Prompt("Please enter your recorded mnemonic phrase to confirm it is correct:", "^.*$", "")
 		if mnemonic == confirmation {
 			return
+		}
+
+		if strings.Contains(confirmation, UTF8_EMPTY_SPACE) {
+			fmt.Println("It seems like you copy pasted your mnemonic phrase. Please write it down and enter it by hand.")
 		} else {
 			fmt.Println("The mnemonic phrase you entered does not match your recovery phrase. Please try again.")
-			fmt.Println("")
 		}
+		fmt.Println("")
 	}
 }

--- a/rocketpool/api/debug/commands.go
+++ b/rocketpool/api/debug/commands.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"fmt"
+
 	"github.com/urfave/cli"
 
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"

--- a/rocketpool/api/wallet/commands.go
+++ b/rocketpool/api/wallet/commands.go
@@ -136,6 +136,24 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 
 				},
 			},
+
+			{
+				Name:      "remove",
+				Aliases:   []string{"rm"},
+				Usage:     "Deletes existing node wallet",
+				UsageText: "rocketpool api wallet remove",
+				Action: func(c *cli.Context) error {
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run
+					api.PrintResponse(removeWallet(c))
+					return nil
+				},
+			},
 		},
 	})
 }

--- a/rocketpool/api/wallet/remove.go
+++ b/rocketpool/api/wallet/remove.go
@@ -1,0 +1,35 @@
+package wallet
+
+import (
+	"errors"
+
+	"github.com/urfave/cli"
+
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+func removeWallet(c *cli.Context) (*api.RemoveWalletResponse, error) {
+
+	// Get services
+	if err := services.RequireNodePassword(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if wallet is already initialized
+	if !w.IsInitialized() {
+		return nil, errors.New("The wallet is not initialized")
+	}
+
+	if err = w.Remove(); err != nil {
+		return nil, err
+	}
+
+	// Return response
+	return &api.RemoveWalletResponse{}, nil
+
+}

--- a/shared/services/rocketpool/wallet.go
+++ b/shared/services/rocketpool/wallet.go
@@ -39,6 +39,25 @@ func (c *Client) SetPassword(password string) (api.SetPasswordResponse, error) {
 	return response, nil
 }
 
+// Remove wallet
+func (c *Client) RemoveWallet() error {
+	responseBytes, err := c.callAPI("wallet remove")
+	if err != nil {
+		return fmt.Errorf("Could not remove wallet: %w", err)
+	}
+
+	var response api.RemoveWalletResponse
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return fmt.Errorf("Could not decode remove wallet response: %w", err)
+	}
+
+	if response.Error != "" {
+		return fmt.Errorf("Could not remove wallet: %s", response.Error)
+	}
+
+	return nil
+}
+
 // Initialize wallet
 func (c *Client) InitWallet() (api.InitWalletResponse, error) {
 	responseBytes, err := c.callAPI("wallet init")

--- a/shared/services/wallet/wallet.go
+++ b/shared/services/wallet/wallet.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
+	"os"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/hdkeychain"
@@ -224,6 +225,11 @@ func (w *Wallet) Save() error {
 func (w *Wallet) Reload() error {
 	_, err := w.loadStore()
 	return err
+}
+
+// Remove the wallet store from disk
+func (w *Wallet) Remove() error {
+	return os.Remove(w.walletPath)
 }
 
 // Load the wallet store from disk and decrypt it

--- a/shared/types/api/wallet.go
+++ b/shared/types/api/wallet.go
@@ -25,6 +25,11 @@ type InitWalletResponse struct {
 	AccountAddress common.Address `json:"accountAddress"`
 }
 
+type RemoveWalletResponse struct {
+	Status         string         `json:"status"`
+	Error          string         `json:"error"`
+}
+
 type RecoverWalletResponse struct {
 	Status         string                  `json:"status"`
 	Error          string                  `json:"error"`


### PR DESCRIPTION
5 discrete commits

1) Use sneaky unicode to prevent users from copy-pasting their mnemonic into the confirm dialog
2) Colorize the warnings about mnemonic security
3) Remove troubled --confirm-mnemonic flag
4) Update rocketpool_api to allow the smartnode to delete a wallet file. This command is not exposed outside the api.
5) Clear the terminal after the mnemonic is displayed, and before the user enters it to confirm. Allow the user to seamlessly start over by removing the old wallet if they fail the confirmation flow.