### PR TITLE
Re-set the gas settings for iterated client calls, fixing a bug with several activation paths

### DIFF
--- a/rocketpool-cli/auction/claim-lot.go
+++ b/rocketpool-cli/auction/claim-lot.go
@@ -108,8 +108,8 @@ func claimFromLot(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -122,6 +122,7 @@ func claimFromLot(c *cli.Context) error {
 
 	// Claim RPL from lots
 	for _, lot := range selectedLots {
+		g.Assign(rp)
 		response, err := rp.ClaimFromLot(lot.Details.Index)
 		if err != nil {
 			fmt.Printf("Could not claim RPL from lot %d: %s.\n", lot.Details.Index, err)

--- a/rocketpool-cli/auction/recover-lot.go
+++ b/rocketpool-cli/auction/recover-lot.go
@@ -108,8 +108,8 @@ func recoverRplFromLot(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -122,6 +122,7 @@ func recoverRplFromLot(c *cli.Context) error {
 
 	// Claim RPL from lots
 	for _, lot := range selectedLots {
+		g.Assign(rp)
 		response, err := rp.RecoverUnclaimedRPLFromLot(lot.Details.Index)
 		if err != nil {
 			fmt.Printf("Could not recover unclaimed RPL from lot %d: %s.\n", lot.Details.Index, err)

--- a/rocketpool-cli/minipool/delegate.go
+++ b/rocketpool-cli/minipool/delegate.go
@@ -81,8 +81,8 @@ func delegateUpgradeMinipools(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -95,6 +95,7 @@ func delegateUpgradeMinipools(c *cli.Context) error {
 
 	// Upgrade minipools
 	for _, minipool := range selectedMinipools {
+		g.Assign(rp)
 		response, err := rp.DelegateUpgradeMinipool(minipool)
 		if err != nil {
 			fmt.Printf("Could not upgrade minipool %s: %s.\n", minipool.Hex(), err)
@@ -184,8 +185,8 @@ func delegateRollbackMinipools(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -198,6 +199,7 @@ func delegateRollbackMinipools(c *cli.Context) error {
 
 	// Rollback minipools
 	for _, minipool := range selectedMinipools {
+		g.Assign(rp)
 		response, err := rp.DelegateRollbackMinipool(minipool)
 		if err != nil {
 			fmt.Printf("Could not rollback minipool %s: %s.\n", minipool.Hex(), err)
@@ -286,8 +288,8 @@ func setUseLatestDelegateMinipools(c *cli.Context, setting bool) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -300,6 +302,7 @@ func setUseLatestDelegateMinipools(c *cli.Context, setting bool) error {
 
 	// Update minipools
 	for _, minipool := range selectedMinipools {
+		g.Assign(rp)
 		response, err := rp.SetUseLatestDelegateMinipool(minipool, setting)
 		if err != nil {
 			fmt.Printf("Could not update the auto-upgrade setting for minipool %s: %s.\n", minipool.Hex(), err)

--- a/rocketpool-cli/minipool/dissolve.go
+++ b/rocketpool-cli/minipool/dissolve.go
@@ -103,8 +103,8 @@ func dissolveMinipools(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -117,6 +117,7 @@ func dissolveMinipools(c *cli.Context) error {
 
 	// Dissolve and close minipools
 	for _, minipool := range selectedMinipools {
+		g.Assign(rp)
 		response, err := rp.DissolveMinipool(minipool.Address)
 		if err != nil {
 			fmt.Printf("Could not dissolve minipool %s: %s.\n", minipool.Address.Hex(), err)

--- a/rocketpool-cli/minipool/refund.go
+++ b/rocketpool-cli/minipool/refund.go
@@ -102,8 +102,8 @@ func refundMinipools(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -116,6 +116,7 @@ func refundMinipools(c *cli.Context) error {
 
 	// Refund minipools
 	for _, minipool := range selectedMinipools {
+		g.Assign(rp)
 		response, err := rp.RefundMinipool(minipool.Address)
 		if err != nil {
 			fmt.Printf("Could not refund ETH from minipool %s: %s.\n", minipool.Address.Hex(), err)

--- a/rocketpool-cli/minipool/stake.go
+++ b/rocketpool-cli/minipool/stake.go
@@ -100,8 +100,8 @@ func stakeMinipools(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -114,6 +114,7 @@ func stakeMinipools(c *cli.Context) error {
 
 	// Stake minipools
 	for _, minipool := range selectedMinipools {
+		g.Assign(rp)
 		response, err := rp.StakeMinipool(minipool.Address)
 		if err != nil {
 			fmt.Printf("Could not stake minipool %s: %s.\n", minipool.Address.Hex(), err)

--- a/rocketpool-cli/odao/execute-proposal.go
+++ b/rocketpool-cli/odao/execute-proposal.go
@@ -108,8 +108,8 @@ func executeProposal(c *cli.Context) error {
 	gasInfo.EstGasLimit = totalGas
 	gasInfo.SafeGasLimit = totalSafeGas
 
-	// Assign max fees
-	err = gas.AssignMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
+	// Get max fees
+	g, err := gas.GetMaxFeeAndLimit(gasInfo, rp, c.Bool("yes"))
 	if err != nil {
 		return err
 	}
@@ -122,6 +122,7 @@ func executeProposal(c *cli.Context) error {
 
 	// Execute proposals
 	for _, proposal := range selectedProposals {
+		g.Assign(rp)
 		response, err := rp.ExecuteTNDAOProposal(proposal.ID)
 		if err != nil {
 			fmt.Printf("Could not execute proposal %d: %s.\n", proposal.ID, err)


### PR DESCRIPTION
This is a less-than-optimal but quick solution to https://github.com/rocket-pool/smartnode/issues/194

Optimally, the Client struct should be made less stateful. Users of the client interface should be required to pass the gas settings in at time of invocation, providing a compile-time enforcement that the settings are correctly derived.

I have only minimally tested this code.