### PR TITLE
Print a warning when the externalip library returns ipv6

### DIFF
--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -739,6 +739,9 @@ func (c *Client) compose(composeFiles []string, args string) (string, error) {
 		fmt.Println("Warning: couldn't get external IP address; if you're using Nimbus, it may have trouble finding peers:")
 		fmt.Println(err.Error())
 	} else {
+		if ip.To4() == nil {
+			fmt.Println("Warning: external IP address is v6; if you're using Nimbus, it may have trouble finding peers:")
+		}
 		externalIP = ip.String()
 	}
 


### PR DESCRIPTION
Nimbus's extip field will silently accept ipv6, but per the nimbus team, it is not currently supported.

From the `net` docs:
> To4 converts the IPv4 address ip to a 4-byte representation. If ip is not an IPv4 address, To4 returns nil.