### PR TITLE
Added 'service compose' command to print docker-compose config

### DIFF
--- a/rocketpool-cli/service/commands.go
+++ b/rocketpool-cli/service/commands.go
@@ -301,6 +301,24 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			},
 
 			{
+				Name:      "compose",
+				Usage:     "View the Rocket Pool service docker-compose config",
+				UsageText: "rocketpool service compose",
+				Action: func(c *cli.Context) error {
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run command
+					return serviceCompose(c)
+
+				},
+			},
+
+
+			{
 				Name:      "version",
 				Aliases:   []string{"v"},
 				Usage:     "View the Rocket Pool service version information",

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -936,6 +936,22 @@ func serviceStats(c *cli.Context) error {
 
 }
 
+// View the Rocket Pool service compose config
+func serviceCompose(c *cli.Context) error {
+
+	// Get RP client
+	rp, err := rocketpool.NewClientFromCtx(c)
+	if err != nil {
+		return err
+	}
+	defer rp.Close()
+
+	// Print service compose config
+	return rp.PrintServiceCompose(getComposeFiles(c))
+
+}
+
+
 // View the Rocket Pool service version information
 func serviceVersion(c *cli.Context) error {
 

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -639,6 +639,15 @@ func (c *Client) PrintServiceStats(composeFiles []string) error {
 
 }
 
+// Print the Rocket Pool service compose config
+func (c *Client) PrintServiceCompose(composeFiles []string) error {
+	cmd, err := c.compose(composeFiles, "config")
+	if err != nil {
+		return err
+	}
+	return c.printOutput(cmd)
+}
+
 // Get the Rocket Pool service version
 func (c *Client) GetServiceVersion() (string, error) {
 


### PR DESCRIPTION
Since v1.3.0 allows users to make `override` files, I wanted to have an easy way to debug these.
This PR adds the output of `docker-compose config` to the `rocketpool service compose` command.

For example my custom network and port mapping in `override/node.yml`:
```
version: "3.7"
services:
  node:
    x-rp-comment: Add your customizations below this line
    environment:
      - ENABLE_METRICS=true
    ports:
      - "127.0.0.1:9102:9102"

networks:
  net:
    external: true
    name: openethereum_ethereum
```

Can now be found by using:
```
rpl@rplhost:~$ rocketpool service compose
networks:
  net:
    external: true
    name: openethereum_ethereum
services:
<snip>
  node:
    cap_add:
    - dac_override
    cap_drop:
    - all
    command: -m 0.0.0.0 -r 9102 node
    container_name: rocketpool_node
    environment:
      ENABLE_METRICS: "true"
    image: rocketpool/smartnode:v1.3.0
    networks:
      net: {}
    ports:
    - 127.0.0.1:9102:9102/tcp
    restart: unless-stopped
```