### PR TITLE
Make LoadFromFile sane and return an error when load fails.

### DIFF
--- a/shared/services/config/rocket-pool-config.go
+++ b/shared/services/config/rocket-pool-config.go
@@ -111,7 +111,7 @@ func LoadFromFile(path string) (*RocketPoolConfig, error) {
 	// Return nil if the file doesn't exist
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		return nil, nil
+		return nil, fmt.Errorf("could not read Rocket Pool settings file at %s: file does not exist", shellescape.Quote(path))
 	}
 
 	// Read the file

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -128,16 +128,20 @@ func (c *Client) LoadConfig() (*config.RocketPoolConfig, bool, error) {
 		return nil, false, fmt.Errorf("error expanding settings file path: %w", err)
 	}
 
-	cfg, err := rp.LoadConfigFromFile(expandedPath)
-	if err != nil {
-		return nil, false, err
-	}
-
+	var cfg *config.RocketPoolConfig
 	isNew := false
-	if cfg == nil {
+
+	_, err = os.Stat(expandedPath)
+	if os.IsNotExist(err) {
 		cfg = config.NewRocketPoolConfig(c.configPath, c.daemonPath != "")
 		isNew = true
+	} else {
+		cfg, err = rp.LoadConfigFromFile(expandedPath)
+		if err != nil {
+			return nil, false, err
+		}
 	}
+
 	return cfg, isNew, nil
 }
 

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -156,9 +156,6 @@ func getConfig(c *cli.Context) (*config.RocketPoolConfig, error) {
 	initCfg.Do(func() {
 		settingsFile := os.ExpandEnv(c.GlobalString("settings"))
 		cfg, err = rp.LoadConfigFromFile(settingsFile)
-		if cfg == nil && err == nil {
-			err = fmt.Errorf("Settings file [%s] not found.", settingsFile)
-		}
 	})
 	return cfg, err
 }

--- a/shared/utils/rp/config.go
+++ b/shared/utils/rp/config.go
@@ -17,17 +17,11 @@ const (
 
 // Loads a config without updating it if it exists
 func LoadConfigFromFile(path string) (*config.RocketPoolConfig, error) {
-	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return nil, nil
-	} else {
-		cfg, err := config.LoadFromFile(path)
-		if err != nil {
-			return nil, err
-		}
-
-		return cfg, nil
+	cfg, err := config.LoadFromFile(path)
+	if err != nil {
+		return nil, err
 	}
+	return cfg, nil
 }
 
 // Saves a config and removes the upgrade flag file


### PR DESCRIPTION
While trying to use the shared library in a different golang project I found out the hard way that `shared/services/config/rocket-pool-config.go`'s `LoadFromFile` function (and `LoadConfigFromFile`) will happily return me a nil pointer when the config file does not exist without returning an error.
This PR makes these functions return an error as I would expect based on the function name (and lacking documentation), and updates the consumers of this function to not break anything.

Tested locally with a blank rocketpool directory, seems to behave as expected.