### PR TITLE
Update mnemonic user input flow to be word-at-a-time and tolerant of partial words (minimum 4 letters)

### DIFF
--- a/rocketpool-cli/wallet/bip39/mnemonic-validator.go
+++ b/rocketpool-cli/wallet/bip39/mnemonic-validator.go
@@ -1,0 +1,60 @@
+package bip39
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/tyler-smith/go-bip39"
+)
+
+type MnemonicValidator struct {
+	mnemonic []string
+}
+
+func Create(length int) *MnemonicValidator {
+
+	if length <= 0 {
+		return nil
+	}
+
+	out := &MnemonicValidator{}
+
+	out.mnemonic = make([]string, 0, length)
+
+	return out
+}
+
+func (mv *MnemonicValidator) AddWord(input string) error {
+	wordList := bip39.GetWordList()
+
+	idx := sort.SearchStrings(wordList, input)
+	if idx >= len(wordList) {
+		return errors.New("Invalid word")
+	}
+
+	if wordList[idx] != input && (len(input) < 4 || wordList[idx][:4] != input[:4]) {
+		return errors.New("Invalid word")
+	}
+
+	mv.mnemonic = append(mv.mnemonic, wordList[idx])
+	return nil
+}
+
+func (mv *MnemonicValidator) Filled() bool {
+	return len(mv.mnemonic) == cap(mv.mnemonic)
+}
+
+func (mv *MnemonicValidator) Finalize() (string, error) {
+
+	if mv.Filled() == false {
+		return "", errors.New("Not enough words were entered.")
+	}
+
+	mnemonic := strings.Join(mv.mnemonic, " ")
+	if bip39.IsMnemonicValid(mnemonic) {
+		return mnemonic, nil
+	}
+
+	return "", errors.New("Invalid mnemonic")
+}

--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -2,9 +2,10 @@ package wallet
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
-	"github.com/tyler-smith/go-bip39"
-
+	"github.com/rocket-pool/smartnode/rocketpool-cli/wallet/bip39"
 	"github.com/rocket-pool/smartnode/shared/services/passwords"
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
@@ -30,20 +31,53 @@ func promptPassword() string {
 // Prompt for a recovery mnemonic phrase
 func promptMnemonic() string {
 	for {
-		mnemonic := cliutils.PromptPassword("Please enter your recovery mnemonic phrase:", "^.*$", "")
-		if bip39.IsMnemonicValid(mnemonic) {
-			return mnemonic
-		} else {
-			fmt.Println("Invalid mnemonic phrase.")
-			fmt.Println("")
+		lengthInput := cliutils.Prompt(
+			"Please enter the number of words in your mnemonic phrase (24 by default):",
+			"^[1-9][0-9]*$",
+			"Please enter a valid number.")
+
+		length, err := strconv.Atoi(lengthInput)
+		if err != nil {
+			fmt.Println("Please enter a valid number.")
+			continue
 		}
+
+		mv := bip39.Create(length)
+		if mv == nil {
+			fmt.Println("Please enter a valid mnemonic length.")
+			continue
+		}
+
+		i := 0
+		for mv.Filled() == false {
+			prompt := fmt.Sprintf("Enter Word Number %d of your mnemonic:", i+1)
+			word := cliutils.PromptPassword(prompt, "^[a-zA-Z]+$", "Please enter a single word only.")
+
+			if err := mv.AddWord(strings.ToLower(word)); err != nil {
+				fmt.Println("Inputted word not valid, please retry.")
+				continue
+			}
+
+			i++
+		}
+
+		mnemonic, err := mv.Finalize()
+		if err != nil {
+			fmt.Printf("Error validating mnemonic: %s\n", err)
+			fmt.Println("Please try again.")
+			fmt.Println("")
+			continue
+		}
+
+		return mnemonic
 	}
 }
 
 // Confirm a recovery mnemonic phrase
 func confirmMnemonic(mnemonic string) {
 	for {
-		confirmation := cliutils.Prompt("Please enter your recorded mnemonic phrase to confirm it is correct:", "^.*$", "")
+		fmt.Println("Please enter your mnemonic phrase to confirm.")
+		confirmation := promptMnemonic()
 		if mnemonic == confirmation {
 			return
 		} else {


### PR DESCRIPTION
Addresses https://github.com/rocket-pool/smartnode/issues/200

Tested on `wallet init` `wallet recover` and `wallet test-menmonic`