### PR TITLE
Pass DataPath to install script for upgrades

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -75,10 +75,14 @@ func installService(c *cli.Context) error {
 	// Attempt to load the config to see if any settings need to be passed along to the install script
 	cfg, isNew, err := rp.LoadConfig()
 	if err != nil {
-		return fmt.Errorf("error loading new configuration: %w", err)
+		return fmt.Errorf("error loading old configuration: %w", err)
 	}
-	if isNew == false {
+	if !isNew {
 		dataPath = cfg.Smartnode.DataPath.Value.(string)
+		dataPath, err = homedir.Expand(dataPath)
+		if err != nil {
+			return fmt.Errorf("error getting data path from old configuration: %w", err)
+		}
 	}
 
 	// Install service
@@ -92,6 +96,12 @@ func installService(c *cli.Context) error {
 	fmt.Println("The Rocket Pool service was successfully installed!")
 
 	printPatchNotes(c)
+
+	// Reload the config after installation
+	_, isNew, err = rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading new configuration: %w", err)
+	}
 
 	// Check if this is a migration
 	isMigration := false

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -453,7 +453,7 @@ func (c *Client) MigrateLegacyConfig(legacyConfigFilePath string, legacySettings
 }
 
 // Install the Rocket Pool service
-func (c *Client) InstallService(verbose, noDeps bool, network, version, path string) error {
+func (c *Client) InstallService(verbose, noDeps bool, network, version, path string, dataPath string) error {
 
 	// Get installation script downloader type
 	downloader, err := c.getDownloader()
@@ -471,6 +471,9 @@ func (c *Client) InstallService(verbose, noDeps bool, network, version, path str
 	}
 	if noDeps {
 		flags = append(flags, "-d")
+	}
+	if dataPath != "" {
+		flags = append(flags, fmt.Sprintf("-u %s", dataPath))
 	}
 
 	// Initialize installation command

--- a/shared/utils/rp/config.go
+++ b/shared/utils/rp/config.go
@@ -20,14 +20,14 @@ func LoadConfigFromFile(path string) (*config.RocketPoolConfig, error) {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil
-	} else {
-		cfg, err := config.LoadFromFile(path)
-		if err != nil {
-			return nil, err
-		}
-
-		return cfg, nil
 	}
+
+	cfg, err := config.LoadFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
 }
 
 // Saves a config and removes the upgrade flag file


### PR DESCRIPTION
Uses the flag added in https://github.com/rocket-pool/smartnode-install/pull/74

I believe the logic reordering is safe- the LoadConfig call doesn't seem to have side-effects, and I don't _think_ it will cause errors when run on a fresh install, but I haven't tested it.