### PR TITLE
764 - Adding option to sign an arbitrary message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following commands are available via the smart node client:
 - `rocketpool node deposit` - Make a deposit to create a minipool and begin staking
 - `rocketpool node send [amount] [token] [to]` - Send an amount of ETH or tokens to an address
 - `rocketpool node burn [amount] [token]` - Burn reward tokens for ETH
+- `rocketpool node sign-message` - Signs a arbitrary message using the node wallet's private key
 
 - `rocketpool minipool status` - Display the current status of all minipools run by the node
 - `rocketpool minipool refund` - Refund ETH from minipools which have had user-deposited ETH assigned to them

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following commands are available via the smart node client:
 - `rocketpool node deposit` - Make a deposit to create a minipool and begin staking
 - `rocketpool node send [amount] [token] [to]` - Send an amount of ETH or tokens to an address
 - `rocketpool node burn [amount] [token]` - Burn reward tokens for ETH
-- `rocketpool node sign-message` - Signs a arbitrary message using the node wallet's private key
+- `rocketpool node sign-message` - Signs an arbitrary message using the node wallet's private key
 
 - `rocketpool minipool status` - Display the current status of all minipools run by the node
 - `rocketpool minipool refund` - Refund ETH from minipools which have had user-deposited ETH assigned to them

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -1,8 +1,6 @@
 package node
 
 import (
-	"strings"
-
 	"github.com/urfave/cli"
 
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
@@ -561,16 +559,16 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Name:      "sign-message",
 				Aliases:   []string{"sm"},
 				Usage:     "Sign an arbitrary message with the node's private key",
-				UsageText: "rocketpool node sign-message [message]",
+				UsageText: "rocketpool node sign-message [-m message]",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "message, m",
+						Usage: "The 'quoted message' to be signed",
+					},
+				},
 				Action: func(c *cli.Context) error {
-					var message string
-					if len(c.Args()) >= 1 {
-						// A message can contain one or more words
-						message = c.Args().Get(0) + strings.Join(c.Args().Tail(), " ")
-					}
-
 					// Run
-					return signMessage(c, message)
+					return signMessage(c)
 				},
 			},
 		},

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -554,6 +554,23 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 				},
 			},
+
+			{
+				Name:      "sign-message",
+				Aliases:   []string{"sm"},
+				Usage:     "Sign an arbitrary message with the node's private key",
+				UsageText: "rocketpool node sign-message",
+				Action: func(c *cli.Context) error {
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run
+					return signMessage(c)
+				},
+			},
 		},
 	})
 }

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"strings"
+
 	"github.com/urfave/cli"
 
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
@@ -559,16 +561,16 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Name:      "sign-message",
 				Aliases:   []string{"sm"},
 				Usage:     "Sign an arbitrary message with the node's private key",
-				UsageText: "rocketpool node sign-message",
+				UsageText: "rocketpool node sign-message [message]",
 				Action: func(c *cli.Context) error {
-
-					// Validate args
-					if err := cliutils.ValidateArgCount(c, 0); err != nil {
-						return err
+					var message string
+					if len(c.Args()) >= 1 {
+						// A message can contain one or more words
+						message = c.Args().Get(0) + strings.Join(c.Args().Tail(), " ")
 					}
 
 					// Run
-					return signMessage(c)
+					return signMessage(c, message)
 				},
 			},
 		},

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -43,7 +43,7 @@ func signMessage(c *cli.Context) error {
 	fmt.Printf("Message: %s\n", message)
 	fmt.Printf("Signed data: %s\n\n", response.SignedData)
 
-	if cliutils.Confirm("Do you want to use this message on beaconcha.in?") {
+	if cliutils.Confirm("Do you want to use this message on beaconcha.in? (Prints the message in the expected format)") {
 		fmt.Printf(`{ 
     "address": "%s",
     "msg": "%s",

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -52,17 +52,18 @@ func signMessage(c *cli.Context) error {
 	}
 
 	// Print the signature
-	fmt.Printf("Message: %s\n", message)
-	fmt.Printf("Signed data: %s\n\n", response.SignedData)
-
-	if cliutils.Confirm("Do you want to use this message on beaconcha.in? (Prints the message in the expected format)") {
-		bytes, err := json.MarshalIndent(PersonalSignature{status.AccountAddress, message, response.SignedData, fmt.Sprint(signatureVersion)}, "", "  ")
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(string(bytes))
+	formattedSignature := PersonalSignature{
+		Address:   status.AccountAddress,
+		Message:   message,
+		Signature: response.SignedData,
+		Version:   fmt.Sprint(signatureVersion),
 	}
+	bytes, err := json.MarshalIndent(formattedSignature, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Signed Message:\n\n%s\n", string(bytes))
 
 	return nil
 

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -9,7 +9,7 @@ import (
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
 
-func signMessage(c *cli.Context, message string) error {
+func signMessage(c *cli.Context) error {
 
 	// Get RP client
 	rp, err := rocketpool.NewClientFromCtx(c)
@@ -29,6 +29,7 @@ func signMessage(c *cli.Context, message string) error {
 		return nil
 	}
 
+	message := c.String("message")
 	if message == "" {
 		message = cliutils.Prompt("Please enter the message you want to sign: (EIP-191 personal_sign)", "^.+$", "Please enter the message you want to sign: (EIP-191 personal_sign)")
 	}
@@ -38,12 +39,18 @@ func signMessage(c *cli.Context, message string) error {
 		return err
 	}
 
-	fmt.Printf(`{ 
+	// Print the signature
+	fmt.Printf("Message: %s\n", message)
+	fmt.Printf("Signed data: %s\n\n", response.SignedData)
+
+	if cliutils.Confirm("Do you want to use this message on beaconcha.in?") {
+		fmt.Printf(`{ 
     "address": "%s",
     "msg": "%s",
     "sig": "%s",
     "version": "2"
 }`, status.AccountAddress, message, response.SignedData)
+	}
 
 	return nil
 

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -9,6 +9,8 @@ import (
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
 
+const signatureVersion = 1
+
 func signMessage(c *cli.Context) error {
 
 	// Get RP client
@@ -30,7 +32,7 @@ func signMessage(c *cli.Context) error {
 	}
 
 	message := c.String("message")
-	if message == "" {
+	for message == "" {
 		message = cliutils.Prompt("Please enter the message you want to sign: (EIP-191 personal_sign)", "^.+$", "Please enter the message you want to sign: (EIP-191 personal_sign)")
 	}
 
@@ -48,8 +50,8 @@ func signMessage(c *cli.Context) error {
     "address": "%s",
     "msg": "%s",
     "sig": "%s",
-    "version": "2"
-}`, status.AccountAddress, message, response.SignedData)
+    "version": "%d"
+}`, status.AccountAddress, message, response.SignedData, signatureVersion)
 	}
 
 	return nil

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -3,6 +3,9 @@ package node
 import (
 	"fmt"
 
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"
 
 	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
@@ -10,6 +13,13 @@ import (
 )
 
 const signatureVersion = 1
+
+type PersonalSignature struct {
+	Address   common.Address `json:"address"`
+	Message   string         `json:"msg"`
+	Signature string         `json:"sig"`
+	Version   string         `json:"version"` // beaconcha.in expects a string
+}
 
 func signMessage(c *cli.Context) error {
 
@@ -46,12 +56,12 @@ func signMessage(c *cli.Context) error {
 	fmt.Printf("Signed data: %s\n\n", response.SignedData)
 
 	if cliutils.Confirm("Do you want to use this message on beaconcha.in? (Prints the message in the expected format)") {
-		fmt.Printf(`{ 
-    "address": "%s",
-    "msg": "%s",
-    "sig": "%s",
-    "version": "%d"
-}`, status.AccountAddress, message, response.SignedData, signatureVersion)
+		bytes, err := json.MarshalIndent(PersonalSignature{status.AccountAddress, message, response.SignedData, fmt.Sprint(signatureVersion)}, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(bytes))
 	}
 
 	return nil

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -9,7 +9,7 @@ import (
 	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 )
 
-func signMessage(c *cli.Context) error {
+func signMessage(c *cli.Context, message string) error {
 
 	// Get RP client
 	rp, err := rocketpool.NewClientFromCtx(c)
@@ -29,7 +29,9 @@ func signMessage(c *cli.Context) error {
 		return nil
 	}
 
-	message := cliutils.Prompt("Please enter the message you want to sign: (EIP-191 personal_sign)", "^.+$", "Please enter the message you want to sign: (EIP-191 personal_sign)")
+	if message == "" {
+		message = cliutils.Prompt("Please enter the message you want to sign: (EIP-191 personal_sign)", "^.+$", "Please enter the message you want to sign: (EIP-191 personal_sign)")
+	}
 
 	response, err := rp.SignMessage(message)
 	if err != nil {

--- a/rocketpool-cli/node/sign-message.go
+++ b/rocketpool-cli/node/sign-message.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+
+	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
+	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
+)
+
+func signMessage(c *cli.Context) error {
+
+	// Get RP client
+	rp, err := rocketpool.NewClientFromCtx(c)
+	if err != nil {
+		return err
+	}
+	defer rp.Close()
+
+	// Get & check wallet status
+	status, err := rp.WalletStatus()
+	if err != nil {
+		return err
+	}
+
+	if !status.WalletInitialized {
+		fmt.Println("The node wallet is not initialized.")
+		return nil
+	}
+
+	message := cliutils.Prompt("Please enter the message you want to sign: (EIP-191 personal_sign)", "^.+$", "Please enter the message you want to sign: (EIP-191 personal_sign)")
+
+	response, err := rp.SignMessage(message)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf(`{ 
+    "address": "%s",
+    "msg": "%s",
+    "sig": "%s",
+    "version": "2"
+}`, status.AccountAddress, message, response.SignedData)
+
+	return nil
+
+}

--- a/rocketpool/api/node/commands.go
+++ b/rocketpool/api/node/commands.go
@@ -1,6 +1,9 @@
 package node
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/urfave/cli"
 
 	"github.com/rocket-pool/smartnode/shared/utils/api"
@@ -788,6 +791,29 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 
 					// Run
 					api.PrintResponse(sign(c, data))
+					return nil
+
+				},
+			},
+
+			{
+				Name:      "sign-message",
+				Usage:     "Signs an arbitrary message with the node's private key.",
+				UsageText: "rocketpool api node sign-message message",
+				Action: func(c *cli.Context) error {
+					// Validate args
+					lenArgs := len(c.Args())
+					var message string
+					if lenArgs < 1 {
+						return fmt.Errorf("Incorrect argument count; usage: %s", c.Command.UsageText)
+					} else if lenArgs == 1 {
+						message = c.Args().Get(0)
+					} else {
+						message = c.Args().Get(0) + strings.Join(c.Args().Tail(), " ")
+					}
+
+					// Run
+					api.PrintResponse(signMessage(c, message))
 					return nil
 
 				},

--- a/rocketpool/api/node/commands.go
+++ b/rocketpool/api/node/commands.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/urfave/cli"
 
@@ -799,19 +798,21 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 			{
 				Name:      "sign-message",
 				Usage:     "Signs an arbitrary message with the node's private key.",
-				UsageText: "rocketpool api node sign-message message",
+				UsageText: "rocketpool api node sign-message -m message",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "message, m",
+						Usage: "The 'quoted message' to be signed",
+					},
+				},
 				Action: func(c *cli.Context) error {
-					// Validate args
-					lenArgs := len(c.Args())
-					var message string
-					if lenArgs == 0 {
+					// Validate flags
+					if c.String("message") == "" {
 						return fmt.Errorf("Incorrect argument count; usage: %s", c.Command.UsageText)
-					} else {
-						message = c.Args().Get(0) + strings.Join(c.Args().Tail(), " ")
 					}
 
 					// Run
-					api.PrintResponse(signMessage(c, message))
+					api.PrintResponse(signMessage(c))
 					return nil
 
 				},

--- a/rocketpool/api/node/commands.go
+++ b/rocketpool/api/node/commands.go
@@ -1,8 +1,6 @@
 package node
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli"
 
 	"github.com/rocket-pool/smartnode/shared/utils/api"
@@ -798,21 +796,18 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 			{
 				Name:      "sign-message",
 				Usage:     "Signs an arbitrary message with the node's private key.",
-				UsageText: "rocketpool api node sign-message -m message",
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "message, m",
-						Usage: "The 'quoted message' to be signed",
-					},
-				},
+				UsageText: "rocketpool api node sign-message 'message'",
 				Action: func(c *cli.Context) error {
-					// Validate flags
-					if c.String("message") == "" {
-						return fmt.Errorf("Incorrect argument count; usage: %s", c.Command.UsageText)
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 1); err != nil {
+						return err
 					}
 
+					message := c.Args().Get(0)
+
 					// Run
-					api.PrintResponse(signMessage(c))
+					api.PrintResponse(signMessage(c, message))
 					return nil
 
 				},

--- a/rocketpool/api/node/commands.go
+++ b/rocketpool/api/node/commands.go
@@ -804,10 +804,8 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 					// Validate args
 					lenArgs := len(c.Args())
 					var message string
-					if lenArgs < 1 {
+					if lenArgs == 0 {
 						return fmt.Errorf("Incorrect argument count; usage: %s", c.Command.UsageText)
-					} else if lenArgs == 1 {
-						message = c.Args().Get(0)
 					} else {
 						message = c.Args().Get(0) + strings.Join(c.Args().Tail(), " ")
 					}

--- a/rocketpool/api/node/sign-message.go
+++ b/rocketpool/api/node/sign-message.go
@@ -24,7 +24,8 @@ func signMessage(c *cli.Context) (*api.NodeSignResponse, error) {
 
 	// Response
 	response := api.NodeSignResponse{}
-	signedBytes, err := w.SignMessage(c.String("message"))
+	message := c.String("message")
+	signedBytes, err := w.SignMessage(message)
 	if err != nil {
 		return nil, fmt.Errorf("Error signing message [%s]: %w", message, err)
 	}

--- a/rocketpool/api/node/sign-message.go
+++ b/rocketpool/api/node/sign-message.go
@@ -12,7 +12,7 @@ import (
 	hexutils "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
-func signMessage(c *cli.Context) (*api.NodeSignResponse, error) {
+func signMessage(c *cli.Context, message string) (*api.NodeSignResponse, error) {
 	// Get services
 	if err := services.RequireNodeRegistered(c); err != nil {
 		return nil, err
@@ -24,7 +24,6 @@ func signMessage(c *cli.Context) (*api.NodeSignResponse, error) {
 
 	// Response
 	response := api.NodeSignResponse{}
-	message := c.String("message")
 	signedBytes, err := w.SignMessage(message)
 	if err != nil {
 		return nil, fmt.Errorf("Error signing message [%s]: %w", message, err)

--- a/rocketpool/api/node/sign-message.go
+++ b/rocketpool/api/node/sign-message.go
@@ -12,7 +12,7 @@ import (
 	hexutils "github.com/rocket-pool/smartnode/shared/utils/hex"
 )
 
-func signMessage(c *cli.Context, message string) (*api.NodeSignResponse, error) {
+func signMessage(c *cli.Context) (*api.NodeSignResponse, error) {
 	// Get services
 	if err := services.RequireNodeRegistered(c); err != nil {
 		return nil, err
@@ -24,8 +24,7 @@ func signMessage(c *cli.Context, message string) (*api.NodeSignResponse, error) 
 
 	// Response
 	response := api.NodeSignResponse{}
-
-	signedBytes, err := w.SignMessage(message)
+	signedBytes, err := w.SignMessage(c.String("message"))
 	if err != nil {
 		return nil, fmt.Errorf("Error signing message [%s]: %w", message, err)
 	}

--- a/rocketpool/api/node/sign-message.go
+++ b/rocketpool/api/node/sign-message.go
@@ -1,0 +1,37 @@
+package node
+
+import (
+	"encoding/hex"
+	"fmt"
+	_ "time/tzdata"
+
+	"github.com/urfave/cli"
+
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+	hexutils "github.com/rocket-pool/smartnode/shared/utils/hex"
+)
+
+func signMessage(c *cli.Context, message string) (*api.NodeSignResponse, error) {
+	// Get services
+	if err := services.RequireNodeRegistered(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Response
+	response := api.NodeSignResponse{}
+
+	signedBytes, err := w.SignMessage(message)
+	if err != nil {
+		return nil, fmt.Errorf("Error signing message [%s]: %w", message, err)
+	}
+	response.SignedData = hexutils.AddPrefix(hex.EncodeToString(signedBytes))
+
+	// Return response
+	return &response, nil
+
+}

--- a/shared/services/rocketpool/node.go
+++ b/shared/services/rocketpool/node.go
@@ -879,7 +879,7 @@ func (c *Client) NodeSetSmoothingPoolStatus(status bool) (api.SetSmoothingPoolRe
 
 // Use the node private key to sign an arbitrary message
 func (c *Client) SignMessage(message string) (api.NodeSignResponse, error) {
-	responseBytes, err := c.callAPI(fmt.Sprintf("node sign-message %s", message))
+	responseBytes, err := c.callAPI(fmt.Sprintf("node sign-message -m %s", message))
 	if err != nil {
 		return api.NodeSignResponse{}, fmt.Errorf("Could not sign message: %w", err)
 	}

--- a/shared/services/rocketpool/node.go
+++ b/shared/services/rocketpool/node.go
@@ -879,7 +879,7 @@ func (c *Client) NodeSetSmoothingPoolStatus(status bool) (api.SetSmoothingPoolRe
 
 // Use the node private key to sign an arbitrary message
 func (c *Client) SignMessage(message string) (api.NodeSignResponse, error) {
-	responseBytes, err := c.callAPI(fmt.Sprintf("node sign-message -m %s", message))
+	responseBytes, err := c.callAPI("node sign-message", message)
 	if err != nil {
 		return api.NodeSignResponse{}, fmt.Errorf("Could not sign message: %w", err)
 	}

--- a/shared/services/rocketpool/node.go
+++ b/shared/services/rocketpool/node.go
@@ -876,3 +876,20 @@ func (c *Client) NodeSetSmoothingPoolStatus(status bool) (api.SetSmoothingPoolRe
 	}
 	return response, nil
 }
+
+// Use the node private key to sign an arbitrary message
+func (c *Client) SignMessage(message string) (api.NodeSignResponse, error) {
+	responseBytes, err := c.callAPI(fmt.Sprintf("node sign-message %s", message))
+	if err != nil {
+		return api.NodeSignResponse{}, fmt.Errorf("Could not sign message: %w", err)
+	}
+
+	var response api.NodeSignResponse
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return api.NodeSignResponse{}, fmt.Errorf("Could not decode node sign response: %w", err)
+	}
+	if response.Error != "" {
+		return api.NodeSignResponse{}, fmt.Errorf("Could not sign message: %s", response.Error)
+	}
+	return response, nil
+}

--- a/shared/services/wallet/wallet.go
+++ b/shared/services/wallet/wallet.go
@@ -294,7 +294,7 @@ func (w *Wallet) Sign(serializedTx []byte) ([]byte, error) {
 
 // Signs an arbitrary message using the wallet's private key
 func (w *Wallet) SignMessage(message string) ([]byte, error) {
-	// Get private key
+	// Get the wallet's private key
 	privateKey, _, err := w.getNodePrivateKey()
 	if err != nil {
 		return nil, err
@@ -308,7 +308,7 @@ func (w *Wallet) SignMessage(message string) ([]byte, error) {
 		return nil, fmt.Errorf("Error signing message: %w", err)
 	}
 
-	// fix the ECDSA 'v' (see https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v/38909#38909)
+	// fix the ECDSA 'v' (see https://medium.com/mycrypto/the-magic-of-digital-signatures-on-ethereum-98fe184dc9c7#:~:text=The%20version%20number,2%E2%80%9D%20was%20introduced)
 	signedMessage[64] += 27
 	return signedMessage, nil
 }

--- a/shared/services/wallet/wallet.go
+++ b/shared/services/wallet/wallet.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
@@ -300,16 +301,14 @@ func (w *Wallet) SignMessage(message string) ([]byte, error) {
 		return nil, err
 	}
 
-	fullMessage := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)
-	hash := crypto.Keccak256Hash([]byte(fullMessage))
-
-	signedMessage, err := crypto.Sign(hash.Bytes(), privateKey)
+	messageHash := accounts.TextHash([]byte(message))
+	signedMessage, err := crypto.Sign(messageHash, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("Error signing message: %w", err)
 	}
 
 	// fix the ECDSA 'v' (see https://medium.com/mycrypto/the-magic-of-digital-signatures-on-ethereum-98fe184dc9c7#:~:text=The%20version%20number,2%E2%80%9D%20was%20introduced)
-	signedMessage[64] += 27
+	signedMessage[crypto.RecoveryIDOffset] += 27
 	return signedMessage, nil
 }
 


### PR DESCRIPTION
Adding option to sign an arbitrary message using the node's private key. (EIP-191 personal_sign)
Prints the result in a format that can be directly used on beaconcha.in, but could also be used to sign messages for other use cases.