### PR TITLE
Prefer external IPv4 discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/ferranbt/fastssz v0.0.0-20220103083642-bc5fefefa28b
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
-	github.com/glendc/go-external-ip v0.0.0-20200601212049-c872357d968e
+	github.com/glendc/go-external-ip v0.1.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/herumi/bls-eth-go-binary v0.0.0-20211108015406-b5186ba08dc7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
-github.com/glendc/go-external-ip v0.0.0-20200601212049-c872357d968e h1:gLpAlmoGqnW3a3GCkOe+Ic8hZoSCfi0PdA0B8j7d6uw=
-github.com/glendc/go-external-ip v0.0.0-20200601212049-c872357d968e/go.mod h1:o9OoDQyE1WHvYVUH1FdFapy1/rCZHHq3O5wS4VA83ig=
+github.com/glendc/go-external-ip v0.1.0 h1:iX3xQ2Q26atAmLTbd++nUce2P5ht5P4uD4V7caSY/xg=
+github.com/glendc/go-external-ip v0.1.0/go.mod h1:CNx312s2FLAJoWNdJWZ2Fpf5O4oLsMFwuYviHjS4uJE=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -65,8 +65,6 @@ const (
 // * Improve peer discovery and node performance
 // * Avoid unnecessary container restarts caused by switching between IPv4 and IPv6
 func getExternalIP() (net.IP, error) {
-	var err error
-
 	// Try IPv4 first
 	ip4Consensus := externalip.DefaultConsensus(nil, nil)
 	ip4Consensus.UseIPProtocol(4)
@@ -77,11 +75,7 @@ func getExternalIP() (net.IP, error) {
 	// Try IPv6 as fallback
 	ip6Consensus := externalip.DefaultConsensus(nil, nil)
 	ip6Consensus.UseIPProtocol(6)
-	if ip, err := ip6Consensus.ExternalIP(); err == nil {
-		return ip, nil
-	}
-
-	return nil, err
+	return ip6Consensus.ExternalIP()
 }
 
 // Rocket Pool client

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -1170,6 +1170,7 @@ func (c *Client) compose(composeFiles []string, args string) (string, error) {
 		return "", errors.New("No Consensus (ETH2) client selected. Please run 'rocketpool service config' before running this command.")
 	}
 
+	// Get the external IP address
 	var externalIP string
 	ip, err := getExternalIP()
 	if err != nil {


### PR DESCRIPTION
In `#support`, we're seeing node operators with two distinct, but related issues:

  * Bad peering with Nimbus/Besu. This is because on dual-stack (IPv4 and IPv6) nodes, the external IP detection code sometimes finds the IPv4, other times the IPv6. Using IPv6 is not ideal, and will cause peering / network issues.
  * Mysterious container restarts. For example, sometimes a user will update the docker image tag for Grafana or a consensus client. When starting the rocketpool service (e.g. `rocketpool s s`) the `rocketpool_eth1` container will unexpectedly be recreated. We've managed to track this down to the same issue: the external IP detection code switching between IPv4 and IPv6. Every time it changes, the containers will be recreated and restarted.

A potential solution is, when discovering the external IP address, to try IPv4 first. This should improve peering and promote a more consistent view of what the external IP is.
