### PR TITLE
Make daemon sending deposit transaction optional

### DIFF
--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -254,7 +254,7 @@ func nodeDeposit(c *cli.Context) error {
 	}
 
 	// Make deposit
-	response, err := rp.NodeDeposit(amountWei, minNodeFee, salt)
+	response, err := rp.NodeDeposit(amountWei, minNodeFee, salt, true)
 	if err != nil {
 		return err
 	}

--- a/rocketpool/api/node/commands.go
+++ b/rocketpool/api/node/commands.go
@@ -566,12 +566,12 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 			{
 				Name:      "deposit",
 				Aliases:   []string{"d"},
-				Usage:     "Make a deposit and create a minipool",
-				UsageText: "rocketpool api node deposit amount min-fee salt",
+				Usage:     "Make a deposit and create a minipool, or just make and sign the transaction (when submit = false)",
+				UsageText: "rocketpool api node deposit amount min-fee salt submit",
 				Action: func(c *cli.Context) error {
 
 					// Validate args
-					if err := cliutils.ValidateArgCount(c, 3); err != nil {
+					if err := cliutils.ValidateArgCount(c, 4); err != nil {
 						return err
 					}
 					amountWei, err := cliutils.ValidateDepositWeiAmount("deposit amount", c.Args().Get(0))
@@ -586,9 +586,16 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 					if err != nil {
 						return err
 					}
+					submit, err := cliutils.ValidateBool("submit", c.Args().Get(3))
+					if err != nil {
+						return err
+					}
 
 					// Run
-					api.PrintResponse(nodeDeposit(c, amountWei, minNodeFee, salt))
+					response, err := nodeDeposit(c, amountWei, minNodeFee, salt, submit)
+					if submit {
+						api.PrintResponse(response, err)
+					} // else nodeDeposit already printed the encoded transaction
 					return nil
 
 				},

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -513,13 +513,13 @@ func (t *submitRplPrice) submitOptimismPrice() error {
 		t.log.Println("Submitting rate to Optimism...")
 
 		// Submit rates
-		hash, err := priceMessenger.Transact(opts, "submitRate")
+		tx, err := priceMessenger.Transact(opts, "submitRate")
 		if err != nil {
 			return fmt.Errorf("Failed to submit rate: %q", err)
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, hash, t.rp.Client, t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}

--- a/shared/services/rocketpool/node.go
+++ b/shared/services/rocketpool/node.go
@@ -430,8 +430,8 @@ func (c *Client) CanNodeDeposit(amountWei *big.Int, minFee float64, salt *big.In
 }
 
 // Make a node deposit
-func (c *Client) NodeDeposit(amountWei *big.Int, minFee float64, salt *big.Int) (api.NodeDepositResponse, error) {
-	responseBytes, err := c.callAPI(fmt.Sprintf("node deposit %s %f %s", amountWei.String(), minFee, salt.String()))
+func (c *Client) NodeDeposit(amountWei *big.Int, minFee float64, salt *big.Int, submit bool) (api.NodeDepositResponse, error) {
+	responseBytes, err := c.callAPI(fmt.Sprintf("node deposit %s %f %s %t", amountWei.String(), minFee, salt.String(), submit))
 	if err != nil {
 		return api.NodeDepositResponse{}, fmt.Errorf("Could not make node deposit: %w", err)
 	}


### PR DESCRIPTION
If the transaction is not sent, its RLP encoding is printed out instead.
Depends on https://github.com/rocket-pool/rocketpool-go/pull/10.