### PR TITLE
Adapt snapshot struct to receive a response of type "Any"

### DIFF
--- a/rocketpool-cli/network/dao-proposals.go
+++ b/rocketpool-cli/network/dao-proposals.go
@@ -100,6 +100,9 @@ func getActiveDAOProposals(c *cli.Context) error {
 					case map[string]interface{}:
 						choice := proposalVote.Choice.(map[string]interface{})
 						for index, weight := range choice {
+							if votedChoices != "" {
+								votedChoices += ", "
+							}
 							votedChoices += fmt.Sprintf("%s: %.2f", proposal.Choices[int(choice[index].(float64))], weight)
 						}
 

--- a/rocketpool-cli/network/dao-proposals.go
+++ b/rocketpool-cli/network/dao-proposals.go
@@ -85,7 +85,29 @@ func getActiveDAOProposals(c *cli.Context) error {
 					if proposalVote.Voter == proposalsResponse.AccountAddress {
 						voter = "YOU"
 					}
-					fmt.Printf("%s%s voted [%s] on this proposal\n%s", colorGreen, voter, proposal.Choices[proposalVote.Choice-1], colorReset)
+					votedChoices := ""
+					switch proposalVote.Choice.(type) {
+					case float64:
+						votedChoices = proposal.Choices[int(proposalVote.Choice.(float64))-1]
+					case []interface{}:
+						choicesArray := proposalVote.Choice.([]interface{})
+						for i := 0; i < len(choicesArray); i++ {
+							if votedChoices != "" {
+								votedChoices += ", "
+							}
+							votedChoices += proposal.Choices[int(choicesArray[i].(float64))]
+						}
+					case map[string]interface{}:
+						choice := proposalVote.Choice.(map[string]interface{})
+						for index, weight := range choice {
+							votedChoices += fmt.Sprintf("%s: %.2f", proposal.Choices[int(choice[index].(float64))], weight)
+						}
+
+					default:
+						votedChoices = fmt.Sprintf("%v", proposalVote.Choice)
+					}
+
+					fmt.Printf("%s%s voted [%s] on this proposal\n%s", colorGreen, voter, votedChoices, colorReset)
 					voted = true
 				}
 			}

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -421,7 +421,7 @@ type SnapshotResponse struct {
 	}
 }
 type SnapshotProposalVote struct {
-	Choice   int            `json:"choice"`
+	Choice   interface{}    `json:"choice"`
 	Voter    common.Address `json:"voter"`
 	Proposal struct {
 		Id string `json:"id"`


### PR DESCRIPTION
Snapshot Choice has a type "Any", so it needs to be treated as an interface{} in Go.

To parse and show results, so far I've seen that interface can be either float64, []interface{} (which is actually []float64), or a map[string] interface{} (which becomes map[string] float64). All these cases should work correctly now.

Fix #265 