### PR TITLE
Add prometheus metrics

### DIFF
--- a/rocketpool/api/node/smoothing-pool.go
+++ b/rocketpool/api/node/smoothing-pool.go
@@ -1,11 +1,13 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/rocket-pool/rocketpool-go/node"
 	"github.com/rocket-pool/rocketpool-go/rewards"
+	rpGo "github.com/rocket-pool/rocketpool-go/rocketpool"
 	"github.com/rocket-pool/smartnode/shared/services"
 	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
 	"github.com/rocket-pool/smartnode/shared/types/api"
@@ -206,4 +208,21 @@ func setSmoothingPoolStatus(c *cli.Context, status bool) (*api.SetSmoothingPoolR
 	// Return response
 	return &response, nil
 
+}
+
+func GetSmoothingPoolBalance(rp *rpGo.RocketPool, ec *services.ExecutionClientManager) (*api.SmoothingRewardsResponse, error) {
+	smoothingPoolContract, err := rp.GetContract("rocketSmoothingPool", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := api.SmoothingRewardsResponse{}
+
+	balanceWei, err := ec.BalanceAt(context.Background(), *smoothingPoolContract.Address, nil)
+	if err != nil {
+		return nil, err
+	}
+	response.EthBalance = balanceWei
+
+	return &response, nil
 }

--- a/rocketpool/api/node/voting.go
+++ b/rocketpool/api/node/voting.go
@@ -286,7 +286,7 @@ func GetSnapshotVotedProposals(apiDomain string, space string, nodeAddress commo
 func GetSnapshotProposals(apiDomain string, space string, state string) (*api.SnapshotResponse, error) {
 	stateFilter := ""
 	if state != "" {
-		stateFilter = fmt.Sprintf(", state: %s", state)
+		stateFilter = fmt.Sprintf(`, state: "%s"`, state)
 	}
 	query := fmt.Sprintf(`query Proposals {
 	proposals(where: {space: "%s"%s}, orderBy: "created", orderDirection: desc) {

--- a/rocketpool/api/node/voting.go
+++ b/rocketpool/api/node/voting.go
@@ -243,6 +243,41 @@ func clearSnapshotDelegate(c *cli.Context) (*api.ClearSnapshotDelegateResponse, 
 
 }
 
+func GetSnapshotVotingPower(apiDomain string, space string, nodeAddress common.Address) (*api.SnapshotVotingPower, error) {
+	query := fmt.Sprintf(`query Vp{
+		vp(
+			space: "%s",
+			voter: "%s",
+		) {
+			vp
+		}
+	}
+	`, space, nodeAddress)
+	url := fmt.Sprintf("https://%s/graphql?operationName=Vp&query=%s", apiDomain, url.PathEscape(query))
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	// Check the response code
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with code %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	// Get response
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var votingPower api.SnapshotVotingPower
+	if err := json.Unmarshal(body, &votingPower); err != nil {
+		return nil, fmt.Errorf("could not decode snapshot response: %w", err)
+
+	}
+
+	return &votingPower, nil
+}
+
 func GetSnapshotVotedProposals(apiDomain string, space string, nodeAddress common.Address, delegate common.Address) (*api.SnapshotVotedProposals, error) {
 	query := fmt.Sprintf(`query Votes{
 		votes(

--- a/rocketpool/api/node/voting.go
+++ b/rocketpool/api/node/voting.go
@@ -255,7 +255,7 @@ func GetSnapshotVotedProposals(apiDomain string, space string, nodeAddress commo
 		) {
 		  choice
 		  voter
-		  proposal {id}
+		  proposal {id, state}
 		}
 	  }`, space, nodeAddress, delegate)
 	url := fmt.Sprintf("https://%s/graphql?operationName=Votes&query=%s", apiDomain, url.PathEscape(query))
@@ -284,8 +284,12 @@ func GetSnapshotVotedProposals(apiDomain string, space string, nodeAddress commo
 }
 
 func GetSnapshotProposals(apiDomain string, space string, state string) (*api.SnapshotResponse, error) {
+	stateFilter := ""
+	if state != "" {
+		stateFilter = fmt.Sprintf(", state: %s", state)
+	}
 	query := fmt.Sprintf(`query Proposals {
-	proposals(where: {space: "%s", state: "%s"}, orderBy: "created", orderDirection: desc) {
+	proposals(where: {space: "%s"%s}, orderBy: "created", orderDirection: desc) {
 	    id
 	    title
 	    choices
@@ -300,7 +304,7 @@ func GetSnapshotProposals(apiDomain string, space string, state string) (*api.Sn
 		quorum
 		link
 	  }
-    }`, space, state)
+    }`, space, stateFilter)
 
 	url := fmt.Sprintf("https://%s/graphql?operationName=Proposals&query=%s", apiDomain, url.PathEscape(query))
 	resp, err := http.Get(url)

--- a/rocketpool/node/collectors/beacon-collector.go
+++ b/rocketpool/node/collectors/beacon-collector.go
@@ -37,7 +37,7 @@ type BeaconCollector struct {
 	nodeAddress common.Address
 }
 
-// Create a new PerformanceCollector instance
+// Create a new BeaconCollector instance
 func NewBeaconCollector(rp *rocketpool.RocketPool, bc beacon.Client, ec rocketpool.ExecutionClient, nodeAddress common.Address) *BeaconCollector {
 	subsystem := "beacon"
 	return &BeaconCollector{

--- a/rocketpool/node/collectors/node-collector.go
+++ b/rocketpool/node/collectors/node-collector.go
@@ -295,8 +295,8 @@ func (collector *NodeCollector) Collect(channel chan<- prometheus.Metric) {
 
 		collector.cumulativeRewards += eth.WeiToEth(newRewards)
 		unclaimedRewards += eth.WeiToEth(unclaimedRewardsWei)
-		claimedEthRewards = eth.WeiToEth(newClaimedEthRewards)
-		unclaimedEthRewards = eth.WeiToEth(newUnclaimedEthRewards)
+		claimedEthRewards += eth.WeiToEth(newClaimedEthRewards)
+		unclaimedEthRewards += eth.WeiToEth(newUnclaimedEthRewards)
 		collector.nextRewardsStartBlock = big.NewInt(0).Add(header.Number, big.NewInt(1))
 
 		return nil

--- a/rocketpool/node/collectors/rpl-collector.go
+++ b/rocketpool/node/collectors/rpl-collector.go
@@ -32,7 +32,7 @@ type RplCollector struct {
 	rp *rocketpool.RocketPool
 }
 
-// Create a new DemandCollector instance
+// Create a new RplCollector instance
 func NewRplCollector(rp *rocketpool.RocketPool) *RplCollector {
 	subsystem := "rpl"
 	return &RplCollector{

--- a/rocketpool/node/collectors/smoothing-pool-collector.go
+++ b/rocketpool/node/collectors/smoothing-pool-collector.go
@@ -29,16 +29,15 @@ type SmoothingPoolCollector struct {
 }
 
 // Create a new SmoothingPoolCollector instance
-func NewSmoothingPoolCollector(rp *rocketpool.RocketPool, ec *services.ExecutionClientManager, nodeAddress common.Address) *SmoothingPoolCollector {
+func NewSmoothingPoolCollector(rp *rocketpool.RocketPool, ec *services.ExecutionClientManager) *SmoothingPoolCollector {
 	subsystem := "smoothing_pool"
 	return &SmoothingPoolCollector{
 		ethBalanceOnSmoothingPool: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "eth_balance"),
 			"The ETH balance on the smoothing pool",
 			nil, nil,
 		),
-		rp:          rp,
-		ec:          ec,
-		nodeAddress: nodeAddress,
+		rp: rp,
+		ec: ec,
 	}
 }
 

--- a/rocketpool/node/collectors/smoothing-pool-collector.go
+++ b/rocketpool/node/collectors/smoothing-pool-collector.go
@@ -1,0 +1,94 @@
+package collectors
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/smartnode/rocketpool/api/node"
+	"github.com/rocket-pool/smartnode/shared/services"
+	"golang.org/x/sync/errgroup"
+)
+
+// Represents the collector for Smoothing Pool metrics
+type SmoothingPoolCollector struct {
+	// the total amount of ETH rewards the user received from the Smoothing Pool
+	ethFromPoolReceived *prometheus.Desc
+
+	// the amount of ETH rewards from the Smoothing Pool the user has pending
+	ethFromPoolPending *prometheus.Desc
+
+	// the ETH balance on the smoothing pool
+	ethBalanceOnSmoothingPool *prometheus.Desc
+
+	// The Rocket Pool contract manager
+	rp *rocketpool.RocketPool
+
+	// The EC client
+	ec *services.ExecutionClientManager
+}
+
+// Create a new SmoothingPoolCollector instance
+func NewSmoothingPoolCollector(rp *rocketpool.RocketPool, ec *services.ExecutionClientManager) *SmoothingPoolCollector {
+	subsystem := "smoothing_pool"
+	return &SmoothingPoolCollector{
+		ethFromPoolReceived: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "eth_received"),
+			"The total amount of ETH rewards the user received from the Smoothing Pool",
+			nil, nil,
+		),
+		ethFromPoolPending: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "eth_pending"),
+			"The amount of ETH rewards from the Smoothing Pool the user has pending",
+			nil, nil,
+		),
+		ethBalanceOnSmoothingPool: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "eth_balance"),
+			"The ETH balance on the smoothing pool",
+			nil, nil,
+		),
+		rp: rp,
+		ec: ec,
+	}
+}
+
+// Write metric descriptions to the Prometheus channel
+func (collector *SmoothingPoolCollector) Describe(channel chan<- *prometheus.Desc) {
+	channel <- collector.ethFromPoolReceived
+	channel <- collector.ethFromPoolPending
+	channel <- collector.ethBalanceOnSmoothingPool
+}
+
+// Collect the latest metric values and pass them to Prometheus
+func (collector *SmoothingPoolCollector) Collect(channel chan<- prometheus.Metric) {
+
+	// Sync
+	var wg errgroup.Group
+	// ethFromPoolReceived := float64(0)
+	// ethFromPoolPending := float64(0)
+	ethBalanceOnSmoothingPool := float64(0)
+
+	// Get the number of votes on Snapshot proposals
+	wg.Go(func() error {
+		balanceResponse, err := node.GetSmoothingPoolBalance(collector.rp, collector.ec)
+		if err != nil {
+			return fmt.Errorf("Error getting smoothing pool balance: %w", err)
+		}
+		ethBalanceOnSmoothingPool = eth.WeiToEth(balanceResponse.EthBalance)
+
+		return nil
+	})
+
+	// Get the number of live Snapshot proposals
+	wg.Go(func() error {
+		return nil
+	})
+
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		log.Printf("%s\n", err.Error())
+		return
+	}
+
+	channel <- prometheus.MustNewConstMetric(
+		collector.ethBalanceOnSmoothingPool, prometheus.GaugeValue, ethBalanceOnSmoothingPool)
+}

--- a/rocketpool/node/collectors/snapshot-collector.go
+++ b/rocketpool/node/collectors/snapshot-collector.go
@@ -88,10 +88,10 @@ func (collector *SnapshotCollector) Collect(channel chan<- prometheus.Metric) {
 		}
 
 		for _, votedProposal := range votedProposals.Data.Votes {
-			if votedProposal.Proposal.State != "closed" {
-				votesClosedProposals += 1
-			} else {
+			if votedProposal.Proposal.State == "open" {
 				votesOpenProposals += 1
+			} else {
+				votesClosedProposals += 1
 			}
 		}
 

--- a/rocketpool/node/collectors/snapshot-collector.go
+++ b/rocketpool/node/collectors/snapshot-collector.go
@@ -1,0 +1,133 @@
+package collectors
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/smartnode/rocketpool/api/node"
+	"github.com/rocket-pool/smartnode/shared/services/config"
+	"golang.org/x/sync/errgroup"
+)
+
+// Represents the collector for Snapshot metrics
+type SnapshotCollector struct {
+	// the number of open Snashot proposals
+	openProposals *prometheus.Desc
+
+	// the number of past Snapshot proposals
+	closedProposals *prometheus.Desc
+
+	// the number of votes on open Snapshot proposals
+	votesOpenProposals *prometheus.Desc
+
+	// the number of votes on closed Snapshot proposals
+	votesClosedProposals *prometheus.Desc
+
+	// The Rocket Pool config
+	cfg *config.RocketPoolConfig
+
+	// the node wallet address
+	nodeAddress common.Address
+
+	// the delegate address
+	delegateAddress common.Address
+}
+
+// Create a new SnapshotCollector instance
+func NewSnapshotCollector(rp *rocketpool.RocketPool, cfg *config.RocketPoolConfig, nodeAddress common.Address, delegateAddres common.Address) *SnapshotCollector {
+	subsystem := "snapshot"
+	return &SnapshotCollector{
+		openProposals: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "proposals_open"),
+			"The number of open Snapshot proposals",
+			nil, nil,
+		),
+		closedProposals: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "proposals_closed"),
+			"The number of close Snapshot proposals",
+			nil, nil,
+		),
+		votesOpenProposals: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "votes_open"),
+			"The number of votes on open Snapshot proposals",
+			nil, nil,
+		),
+		votesClosedProposals: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "votes_closed"),
+			"The number of votes on closed Snapshot proposals",
+			nil, nil,
+		),
+		cfg:             cfg,
+		nodeAddress:     nodeAddress,
+		delegateAddress: delegateAddres,
+	}
+}
+
+// Write metric descriptions to the Prometheus channel
+func (collector *SnapshotCollector) Describe(channel chan<- *prometheus.Desc) {
+	channel <- collector.openProposals
+	channel <- collector.closedProposals
+	channel <- collector.votesOpenProposals
+	channel <- collector.votesClosedProposals
+}
+
+// Collect the latest metric values and pass them to Prometheus
+func (collector *SnapshotCollector) Collect(channel chan<- prometheus.Metric) {
+
+	// Sync
+	var wg errgroup.Group
+	openProposals := float64(0)
+	closedProposals := float64(0)
+	votesOpenProposals := float64(0)
+	votesClosedProposals := float64(0)
+
+	// Get the number of votes on Snapshot proposals
+	wg.Go(func() error {
+		votedProposals, err := node.GetSnapshotVotedProposals(collector.cfg.Smartnode.GetSnapshotApiDomain(), collector.cfg.Smartnode.GetSnapshotID(), collector.nodeAddress, collector.delegateAddress)
+		if err != nil {
+			return fmt.Errorf("Error getting Snapshot voted proposals: %w", err)
+		}
+
+		for _, votedProposal := range votedProposals.Data.Votes {
+			if votedProposal.Proposal.State != "closed" {
+				votesClosedProposals += 1
+			} else {
+				votesOpenProposals += 1
+			}
+		}
+
+		return nil
+	})
+
+	// Get the number of live Snapshot proposals
+	wg.Go(func() error {
+		proposals, err := node.GetSnapshotProposals(collector.cfg.Smartnode.GetSnapshotApiDomain(), collector.cfg.Smartnode.GetSnapshotID(), "")
+		if err != nil {
+			return fmt.Errorf("Error getting Snapshot voted proposals: %w", err)
+		}
+
+		for _, proposal := range proposals.Data.Proposals {
+			if proposal.State == "open" {
+				openProposals += 1
+			} else {
+				closedProposals += 1
+			}
+		}
+
+		return nil
+	})
+
+	// Wait for data
+	if err := wg.Wait(); err != nil {
+		log.Printf("%s\n", err.Error())
+		return
+	}
+
+	channel <- prometheus.MustNewConstMetric(
+		collector.votesOpenProposals, prometheus.GaugeValue, votesOpenProposals)
+	channel <- prometheus.MustNewConstMetric(
+		collector.votesClosedProposals, prometheus.GaugeValue, votesClosedProposals)
+	channel <- prometheus.MustNewConstMetric(
+		collector.openProposals, prometheus.GaugeValue, openProposals)
+	channel <- prometheus.MustNewConstMetric(
+		collector.closedProposals, prometheus.GaugeValue, closedProposals)
+}

--- a/rocketpool/node/collectors/snapshot-collector.go
+++ b/rocketpool/node/collectors/snapshot-collector.go
@@ -79,6 +79,7 @@ func (collector *SnapshotCollector) Collect(channel chan<- prometheus.Metric) {
 	closedProposals := float64(0)
 	votesActiveProposals := float64(0)
 	votesClosedProposals := float64(0)
+	handledProposals := map[string]bool{}
 
 	// Get the number of votes on Snapshot proposals
 	wg.Go(func() error {
@@ -88,10 +89,14 @@ func (collector *SnapshotCollector) Collect(channel chan<- prometheus.Metric) {
 		}
 
 		for _, votedProposal := range votedProposals.Data.Votes {
-			if votedProposal.Proposal.State == "active" {
-				votesActiveProposals += 1
-			} else {
-				votesClosedProposals += 1
+			_, exists := handledProposals[votedProposal.Proposal.Id]
+			if !exists {
+				if votedProposal.Proposal.State == "active" {
+					votesActiveProposals += 1
+				} else {
+					votesClosedProposals += 1
+				}
+				handledProposals[votedProposal.Proposal.Id] = true
 			}
 		}
 

--- a/rocketpool/node/metrics-exporter.go
+++ b/rocketpool/node/metrics-exporter.go
@@ -37,6 +37,10 @@ func runMetricsServer(c *cli.Context, logger log.ColorLogger) error {
 	if err != nil {
 		return err
 	}
+	s, err := services.GetSnapshotDelegation(c)
+	if err != nil {
+		return err
+	}
 
 	// Return if metrics are disabled
 	if cfg.EnableMetrics.Value == false {
@@ -51,7 +55,11 @@ func runMetricsServer(c *cli.Context, logger log.ColorLogger) error {
 	if err != nil {
 		return fmt.Errorf("Error getting node account: %w", err)
 	}
-
+	idHash := cfg.Smartnode.GetVotingSnapshotID()
+	votingDelegate, err := s.Delegation(nil, nodeAccount.Address, idHash)
+	if err != nil {
+		return fmt.Errorf("Error getting node delegate: %w", err)
+	}
 	// Create the collectors
 	demandCollector := collectors.NewDemandCollector(rp)
 	performanceCollector := collectors.NewPerformanceCollector(rp)
@@ -61,6 +69,8 @@ func runMetricsServer(c *cli.Context, logger log.ColorLogger) error {
 	nodeCollector := collectors.NewNodeCollector(rp, bc, nodeAccount.Address, cfg)
 	trustedNodeCollector := collectors.NewTrustedNodeCollector(rp, bc, nodeAccount.Address, cfg)
 	beaconCollector := collectors.NewBeaconCollector(rp, bc, ec, nodeAccount.Address)
+	snapshotCollector := collectors.NewSnapshotCollector(rp, cfg, nodeAccount.Address, votingDelegate)
+	smoothingPoolCollector := collectors.NewSmoothingPoolCollector(rp, ec)
 
 	// Set up Prometheus
 	registry := prometheus.NewRegistry()
@@ -72,6 +82,8 @@ func runMetricsServer(c *cli.Context, logger log.ColorLogger) error {
 	registry.MustRegister(nodeCollector)
 	registry.MustRegister(trustedNodeCollector)
 	registry.MustRegister(beaconCollector)
+	registry.MustRegister(snapshotCollector)
+	registry.MustRegister(smoothingPoolCollector)
 	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 
 	// Start the HTTP server

--- a/shared/services/ec-manager.go
+++ b/shared/services/ec-manager.go
@@ -166,6 +166,16 @@ func (p *ExecutionClientManager) PendingNonceAt(ctx context.Context, account com
 	return result.(uint64), err
 }
 
+func (p *ExecutionClientManager) GetPeerCount(ctx context.Context) (int, error) {
+	result, err := p.runFunction(func(client *ethclient.Client) (interface{}, error) {
+		return client.PeerCount(ctx)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return result.(int), err
+}
+
 // SuggestGasPrice retrieves the currently suggested gas price to allow a timely
 // execution of a transaction.
 func (p *ExecutionClientManager) SuggestGasPrice(ctx context.Context) (*big.Int, error) {

--- a/shared/services/ec-manager.go
+++ b/shared/services/ec-manager.go
@@ -166,16 +166,6 @@ func (p *ExecutionClientManager) PendingNonceAt(ctx context.Context, account com
 	return result.(uint64), err
 }
 
-func (p *ExecutionClientManager) GetPeerCount(ctx context.Context) (int, error) {
-	result, err := p.runFunction(func(client *ethclient.Client) (interface{}, error) {
-		return client.PeerCount(ctx)
-	})
-	if err != nil {
-		return 0, err
-	}
-	return result.(int), err
-}
-
 // SuggestGasPrice retrieves the currently suggested gas price to allow a timely
 // execution of a transaction.
 func (p *ExecutionClientManager) SuggestGasPrice(ctx context.Context) (*big.Int, error) {

--- a/shared/services/rocketpool/smoothing-pool.go
+++ b/shared/services/rocketpool/smoothing-pool.go
@@ -1,0 +1,26 @@
+package rocketpool
+
+import (
+	"context"
+
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+func GetSmoothingPoolBalance(rp rocketpool.RocketPool, ec *services.ExecutionClientManager) (*api.SmoothingRewardsResponse, error) {
+	smoothingPoolContract, err := rp.GetContract("rocketSmoothingPool", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := api.SmoothingRewardsResponse{}
+
+	balanceWei, err := ec.BalanceAt(context.Background(), *smoothingPoolContract.Address, nil)
+	if err != nil {
+		return nil, err
+	}
+	response.EthBalance = balanceWei
+
+	return &response, nil
+}

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -434,7 +434,8 @@ type SnapshotProposalVote struct {
 	Choice   interface{}    `json:"choice"`
 	Voter    common.Address `json:"voter"`
 	Proposal struct {
-		Id string `json:"id"`
+		Id    string `json:"id"`
+		State string `json:"state"`
 	} `json:"proposal"`
 }
 type SnapshotVotedProposals struct {

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -445,3 +445,8 @@ type SnapshotVotedProposals struct {
 		Votes []SnapshotProposalVote `json:"votes"`
 	} `json:"data"`
 }
+type SmoothingRewardsResponse struct {
+	Status     string   `json:"status"`
+	Error      string   `json:"error"`
+	EthBalance *big.Int `json:"eth_balance"`
+}

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -430,6 +430,13 @@ type SnapshotResponse struct {
 		Proposals []SnapshotProposal `json:"proposals"`
 	}
 }
+type SnapshotVotingPower struct {
+	Data struct {
+		Vp struct {
+			Vp float64 `json:"vp"`
+		} `json:"vp"`
+	} `json:"data"`
+}
 type SnapshotProposalVote struct {
 	Choice   interface{}    `json:"choice"`
 	Voter    common.Address `json:"voter"`


### PR DESCRIPTION
Adding the following metrics:
- Active Snapshot proposals
- Closed Snapshot proposals
- Votes from user/delegate on active Snapshot proposals
- Votes from user/delegate on closed Snapshot proposals
- ETH balance on the smoothing pool contract
- Claimed ETH from the smoothing pool rewards
- Unclaimed ETH available from the smoothing pool rewards

Closes #259 
