### PR TITLE
Teku Archive Mode default to false

### DIFF
--- a/shared/services/config/teku-config.go
+++ b/shared/services/config/teku-config.go
@@ -74,7 +74,7 @@ func NewTekuConfig(cfg *RocketPoolConfig) *TekuConfig {
 			Name:                 "Enable Archive Mode",
 			Description:          "When enabled, Teku will run in \"archive\" mode which means it can recreate the state of the Beacon chain for a previous block. This is required for manually generating the Merkle rewards tree.\n\nIf you are sure you will never be manually generating a tree, you can disable archive mode.",
 			Type:                 config.ParameterType_Bool,
-			Default:              map[config.Network]interface{}{config.Network_All: true},
+			Default:              map[config.Network]interface{}{config.Network_All: false},
 			AffectsContainers:    []config.ContainerID{config.ContainerID_Eth2},
 			EnvironmentVariables: []string{"TEKU_ARCHIVE_MODE"},
 			CanBeBlank:           false,


### PR DESCRIPTION
Changing the default value to false for the "Enable Teku Archive Mode" option.
Reasoning: It is only needed for tree generation, which most users don't need to do. I'm also helping lots of users who were complaining about disk space for using the archive mode.