### PR TITLE
Removed unused composeFiles from client.go

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -214,7 +214,7 @@ func serviceStatus(c *cli.Context) error {
 	}
 
 	// Print service status
-	return rp.PrintServiceStatus(getComposeFiles(c))
+	return rp.PrintServiceStatus()
 
 }
 
@@ -447,7 +447,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 
 	// Stop all of the containers
 	fmt.Print("Stopping containers... ")
-	err := rp.PauseService(getComposeFiles(c))
+	err := rp.PauseService()
 	if err != nil {
 		return fmt.Errorf("error stopping service: %w", err)
 	}
@@ -482,7 +482,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 
 	// Terminate the current setup
 	fmt.Print("Removing old installation... ")
-	err = rp.StopService(getComposeFiles(c))
+	err = rp.StopService()
 	if err != nil {
 		return fmt.Errorf("error terminating old installation: %w", err)
 	}
@@ -497,7 +497,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 
 	// Start the service
 	fmt.Print("Starting Rocket Pool... ")
-	err = rp.StartService(getComposeFiles(c))
+	err = rp.StartService()
 	if err != nil {
 		return fmt.Errorf("error starting service: %w", err)
 	}
@@ -655,7 +655,7 @@ func startService(c *cli.Context, ignoreConfigSuggestion bool) error {
 	}
 
 	// Start service
-	err = rp.StartService(getComposeFiles(c))
+	err = rp.StartService()
 	if err != nil {
 		return err
 	}
@@ -1073,7 +1073,7 @@ func pauseService(c *cli.Context) error {
 	}
 
 	// Pause service
-	return rp.PauseService(getComposeFiles(c))
+	return rp.PauseService()
 
 }
 
@@ -1094,7 +1094,7 @@ func stopService(c *cli.Context) error {
 	defer rp.Close()
 
 	// Stop service
-	return rp.StopService(getComposeFiles(c))
+	return rp.StopService()
 
 }
 
@@ -1109,7 +1109,7 @@ func serviceLogs(c *cli.Context, serviceNames ...string) error {
 	defer rp.Close()
 
 	// Print service logs
-	return rp.PrintServiceLogs(getComposeFiles(c), c.String("tail"), serviceNames...)
+	return rp.PrintServiceLogs(c.String("tail"), serviceNames...)
 
 }
 
@@ -1124,7 +1124,7 @@ func serviceStats(c *cli.Context) error {
 	defer rp.Close()
 
 	// Print service stats
-	return rp.PrintServiceStats(getComposeFiles(c))
+	return rp.PrintServiceStats()
 
 }
 
@@ -1139,7 +1139,7 @@ func serviceCompose(c *cli.Context) error {
 	defer rp.Close()
 
 	// Print service compose config
-	return rp.PrintServiceCompose(getComposeFiles(c))
+	return rp.PrintServiceCompose()
 
 }
 
@@ -1253,11 +1253,6 @@ func serviceVersion(c *cli.Context) error {
 	fmt.Printf("Selected Eth 2.0 client: %s\n", eth2ClientString)
 	return nil
 
-}
-
-// Get the compose file paths for a CLI context
-func getComposeFiles(c *cli.Context) []string {
-	return c.Parent().StringSlice("compose-file")
 }
 
 // Destroy and resync the eth1 client from scratch

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -608,10 +608,10 @@ func (c *Client) InstallUpdateTracker(verbose bool, version string) error {
 }
 
 // Start the Rocket Pool service
-func (c *Client) StartService(composeFiles []string) error {
+func (c *Client) StartService() error {
 
 	// Start the API container first
-	cmd, err := c.compose([]string{}, "up -d")
+	cmd, err := c.compose("up -d")
 	if err != nil {
 		return fmt.Errorf("error creating compose command for API container: %w", err)
 	}
@@ -621,7 +621,7 @@ func (c *Client) StartService(composeFiles []string) error {
 	}
 
 	// Start all of the containers
-	cmd, err = c.compose(composeFiles, "up -d --remove-orphans")
+	cmd, err = c.compose("up -d --remove-orphans")
 	if err != nil {
 		return err
 	}
@@ -629,8 +629,8 @@ func (c *Client) StartService(composeFiles []string) error {
 }
 
 // Pause the Rocket Pool service
-func (c *Client) PauseService(composeFiles []string) error {
-	cmd, err := c.compose(composeFiles, "stop")
+func (c *Client) PauseService() error {
+	cmd, err := c.compose("stop")
 	if err != nil {
 		return err
 	}
@@ -638,8 +638,8 @@ func (c *Client) PauseService(composeFiles []string) error {
 }
 
 // Stop the Rocket Pool service
-func (c *Client) StopService(composeFiles []string) error {
-	cmd, err := c.compose(composeFiles, "down -v")
+func (c *Client) StopService() error {
+	cmd, err := c.compose("down -v")
 	if err != nil {
 		return err
 	}
@@ -647,8 +647,8 @@ func (c *Client) StopService(composeFiles []string) error {
 }
 
 // Print the Rocket Pool service status
-func (c *Client) PrintServiceStatus(composeFiles []string) error {
-	cmd, err := c.compose(composeFiles, "ps")
+func (c *Client) PrintServiceStatus() error {
+	cmd, err := c.compose("ps")
 	if err != nil {
 		return err
 	}
@@ -656,12 +656,12 @@ func (c *Client) PrintServiceStatus(composeFiles []string) error {
 }
 
 // Print the Rocket Pool service logs
-func (c *Client) PrintServiceLogs(composeFiles []string, tail string, serviceNames ...string) error {
+func (c *Client) PrintServiceLogs(tail string, serviceNames ...string) error {
 	sanitizedStrings := make([]string, len(serviceNames))
 	for i, serviceName := range serviceNames {
 		sanitizedStrings[i] = fmt.Sprintf("%s", shellescape.Quote(serviceName))
 	}
-	cmd, err := c.compose(composeFiles, fmt.Sprintf("logs -f --tail %s %s", shellescape.Quote(tail), strings.Join(sanitizedStrings, " ")))
+	cmd, err := c.compose(fmt.Sprintf("logs -f --tail %s %s", shellescape.Quote(tail), strings.Join(sanitizedStrings, " ")))
 	if err != nil {
 		return err
 	}
@@ -669,10 +669,10 @@ func (c *Client) PrintServiceLogs(composeFiles []string, tail string, serviceNam
 }
 
 // Print the Rocket Pool service stats
-func (c *Client) PrintServiceStats(composeFiles []string) error {
+func (c *Client) PrintServiceStats() error {
 
 	// Get service container IDs
-	cmd, err := c.compose(composeFiles, "ps -q")
+	cmd, err := c.compose("ps -q")
 	if err != nil {
 		return err
 	}
@@ -688,8 +688,8 @@ func (c *Client) PrintServiceStats(composeFiles []string) error {
 }
 
 // Print the Rocket Pool service compose config
-func (c *Client) PrintServiceCompose(composeFiles []string) error {
-	cmd, err := c.compose(composeFiles, "config")
+func (c *Client) PrintServiceCompose() error {
+	cmd, err := c.compose("config")
 	if err != nil {
 		return err
 	}
@@ -1139,7 +1139,7 @@ func convertUintParam(oldParam config.UserParam, newParam *cfgtypes.Parameter, n
 }
 
 // Build a docker compose command
-func (c *Client) compose(composeFiles []string, args string) (string, error) {
+func (c *Client) compose(args string) (string, error) {
 
 	// Cancel if running in non-docker mode
 	if c.daemonPath != "" {


### PR DESCRIPTION
This PR removes the `composeFiles` variable from `compose()` and its use in all the calling functions.

I liked how the CLI used a directory structure for instrumenting the docker-compose files, and knew that Compose itself didn't support that, so was curious what it was doing under the hood. In looking over the code, I saw that the `composeFiles` variable was never used, so figured I'd remove it and clean it up.