### PR TITLE
Prysm has renamed their JSON-RPC API to gRPC, so we should use the new language in the TUI

### DIFF
--- a/rocketpool-cli/service/config/step-external-prysm.go
+++ b/rocketpool-cli/service/config/step-external-prysm.go
@@ -10,7 +10,7 @@ func createExternalPrysmStep(wiz *wizard, currentStep int, totalSteps int) *text
 	httpUrlLabel := wiz.md.Config.ExternalPrysm.HttpUrl.Name
 	jsonRpcUrlLabel := wiz.md.Config.ExternalPrysm.JsonRpcUrl.Name
 
-	helperText := "Please provide the URL of your Prysm client's HTTP API (for example: `http://192.168.1.40:5052`) and the URL of its JSON RPC API (e.g., `http://192.168.1.40:5053`).\n\nNote that if you're running it on the same machine as the Smartnode, you cannot use `localhost` or `127.0.0.1`; you must use your machine's LAN IP address."
+	helperText := "Please provide the URL of your Prysm client's HTTP API (for example: `http://192.168.1.40:5052`) and the URL of its JSON RPC API (e.g., `192.168.1.40:5053`).\n\nNote that if you're running it on the same machine as the Smartnode, you cannot use `localhost` or `127.0.0.1`; you must use your machine's LAN IP address."
 
 	show := func(modal *textBoxModalLayout) {
 		wiz.md.setPage(modal.page)

--- a/shared/services/config/external-configs.go
+++ b/shared/services/config/external-configs.go
@@ -197,8 +197,8 @@ func NewExternalPrysmConfig(cfg *RocketPoolConfig) *ExternalPrysmConfig {
 
 		JsonRpcUrl: config.Parameter{
 			ID:                   "jsonRpcUrl",
-			Name:                 "JSON-RPC URL",
-			Description:          "The URL of the JSON-RPC API endpoint for your external client. Prysm's validator client will need this in order to connect to it.\nNOTE: If you are running it on the same machine as the Smartnode, addresses like `localhost` and `127.0.0.1` will not work due to Docker limitations. Enter your machine's LAN IP address instead.",
+			Name:                 "gRPC URL",
+			Description:          "The URL of the gRPC API endpoint for your external client. Prysm's validator client will need this in order to connect to it.\nNOTE: If you are running it on the same machine as the Smartnode, addresses like `localhost` and `127.0.0.1` will not work due to Docker limitations. Enter your machine's LAN IP address instead.",
 			Type:                 config.ParameterType_String,
 			Default:              map[config.Network]interface{}{config.Network_All: ""},
 			AffectsContainers:    []config.ContainerID{config.ContainerID_Eth1},


### PR DESCRIPTION
Can't change the config key name easily, due to migration issues.

Also trim the `http://` prefix as it is explicitly verboten