### PR TITLE
Ignore sync check when signing messages.

### DIFF
--- a/rocketpool/api/node/sign-message.go
+++ b/rocketpool/api/node/sign-message.go
@@ -13,10 +13,6 @@ import (
 )
 
 func signMessage(c *cli.Context, message string) (*api.NodeSignResponse, error) {
-	// Get services
-	if err := services.RequireNodeRegistered(c); err != nil {
-		return nil, err
-	}
 	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err

--- a/shared/services/rocketpool/node.go
+++ b/shared/services/rocketpool/node.go
@@ -908,6 +908,8 @@ func (c *Client) ReverseResolveEnsName(name string) (api.ResolveEnsNameResponse,
 
 // Use the node private key to sign an arbitrary message
 func (c *Client) SignMessage(message string) (api.NodeSignResponse, error) {
+	// Ignore sync status so we can sign messages even without ready clients
+	c.ignoreSyncCheck = true
 	responseBytes, err := c.callAPI("node sign-message", message)
 	if err != nil {
 		return api.NodeSignResponse{}, fmt.Errorf("Could not sign message: %w", err)


### PR DESCRIPTION
The rescue node will use a signed message to identify the user requesting access has a Rocket Pool node and will require a signed message from the node wallet.

Currently, the signMessage function is checking the client sync state. This is a problem as users of the rescue node would not always have synced clients.

Closes #295 
