### PR TITLE
Fix terminal resize

### DIFF
--- a/rocketpool-cli/service/config/main-display.go
+++ b/rocketpool-cli/service/config/main-display.go
@@ -93,10 +93,10 @@ func NewMainDisplay(app *tview.Application, previousConfig *config.RocketPoolCon
 	md.dockerWizard = newWizard(md)
 
 	// Set up the resize warning
-	md.app.SetAfterDrawFunc(func(screen tcell.Screen) {
+	md.app.SetBeforeDrawFunc(func(screen tcell.Screen) bool {
 		x, y := screen.Size()
 		if x == md.previousWidth && y == md.previousHeight {
-			return
+			return false
 		}
 		if x < 112 || y < 32 {
 			grid.RemoveItem(pages)
@@ -107,6 +107,8 @@ func NewMainDisplay(app *tview.Application, previousConfig *config.RocketPoolCon
 		}
 		md.previousWidth = x
 		md.previousHeight = y
+
+		return false
 	})
 
 	if isNew || isMigration {


### PR DESCRIPTION
Fixes a bug where if you start the config wizard with a small terminal, and you get the message that the terminal is too small, and then you maximize the terminal, it won't redraw, so you have to Ctrl+C and run the configuration again.

Using `BeforeDraw`, fixes this problem because it's deciding to render the "too small" message or wizard when the terminal has been resized, so you don't need to trigger another render to get this to update.