### PR TITLE
Fix subprocess writing to stdout/err

### DIFF
--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"log"
 	"math/big"
 	"net"
 	"net/url"
@@ -1623,28 +1621,6 @@ func (c *Client) getDownloader() (string, error) {
 
 }
 
-// pipeToStdOut pipes cmdOut to stdout
-func pipeToStdOut(cmdOut io.Reader) {
-	_, err := io.Copy(os.Stdout, cmdOut)
-	if err != nil {
-		log.Printf("Error piping stdout: %v", err)
-	}
-}
-
-// pipeToStdErr pipes cmdErr to stderr
-func pipeToStdErr(cmdErr io.Reader) {
-	_, err := io.Copy(os.Stderr, cmdErr)
-	if err != nil {
-		log.Printf("Error piping stderr: %v", err)
-	}
-}
-
-// pipeOutput pipes cmdOut and cmdErr to stdout and stderr
-func pipeOutput(cmdOut, cmdErr io.Reader) {
-	go pipeToStdOut(cmdOut)
-	go pipeToStdErr(cmdErr)
-}
-
 // Run a command and print its output
 func (c *Client) printOutput(cmdText string) error {
 
@@ -1655,13 +1631,8 @@ func (c *Client) printOutput(cmdText string) error {
 	}
 	defer cmd.Close()
 
-	cmdOut, cmdErr, err := cmd.OutputPipes()
-	if err != nil {
-		return err
-	}
-
-	// Begin piping before the command is started
-	pipeOutput(cmdOut, cmdErr)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
 
 	// Start the command
 	if err := cmd.Start(); err != nil {

--- a/shared/services/rocketpool/command.go
+++ b/shared/services/rocketpool/command.go
@@ -68,6 +68,22 @@ func (c *command) Wait() error {
 	return c.session.Wait()
 }
 
+func (c *command) SetStdout(w io.Writer) {
+	if c.cmd != nil {
+		c.cmd.Stdout = w
+	} else {
+		c.session.Stdout = w
+	}
+}
+
+func (c *command) SetStderr(w io.Writer) {
+	if c.cmd != nil {
+		c.cmd.Stderr = w
+	} else {
+		c.session.Stderr = w
+	}
+}
+
 // Run the command and return its output
 func (c *command) Output() ([]byte, error) {
 	if c.cmd != nil {


### PR DESCRIPTION
Hopefully this is the last time we do this lol.

The problem with `io.Copy` is that when the `cmd` is not given an `io.Writer` to write to, it will create it's own, and it will close this when it exits, and the `Read` function does not like this.

So in this case, the proper thing to do is to give it an `io.Writer` to write to, and we can use `os.Stdout/err` for this. When we set the writers, the `cmd` does not not close them on exit, which is what we want in the case for `os.Stdout/err`.