### PR TITLE
Merkeltree upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/wealdtech/go-eth2-types/v2 v2.7.0
 	github.com/wealdtech/go-eth2-util v1.7.0
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.3.0
-	github.com/wealdtech/go-merkletree v1.0.1-0.20190605192610-2bb163c2ea2a
+	github.com/wealdtech/go-merkletree v1.0.1-0.20230205101955-ec7a95ea11ca
 	github.com/web3-storage/go-w3s-client v0.0.7
 	golang.org/x/crypto v0.4.0
 	golang.org/x/sync v0.1.0
@@ -181,7 +181,5 @@ require (
 	lukechampine.com/blake3 v1.1.7 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-replace github.com/wealdtech/go-merkletree v1.0.1-0.20190605192610-2bb163c2ea2a => github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd
 
 // replace github.com/rocket-pool/rocketpool-go => ../rocketpool-go

--- a/go.sum
+++ b/go.sum
@@ -1624,8 +1624,6 @@ github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeCE=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
-github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
-github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
 github.com/rocket-pool/rocketpool-go v1.4.2 h1:Jp1X4hkaRthVu7YMXgip+n2K8tvLwPjlGEutpti658I=
 github.com/rocket-pool/rocketpool-go v1.4.2/go.mod h1:+7kSXEvMUCEqstio3PBVTnaGoI2lSTwNUJ8/D4D91gM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1817,6 +1815,8 @@ github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.3.0 h1:3Kx2QvKU/4PP0
 github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.3.0/go.mod h1:qqIU42c9sXcNYsiEjUQoOOWYZfZDL1zmyLtz3t+wN2s=
 github.com/wealdtech/go-eth2-wallet-types/v2 v2.9.0 h1:XqWgsONVqsPvciuEXxM/QU4hYouBVk0+5/pGqDMGUHQ=
 github.com/wealdtech/go-eth2-wallet-types/v2 v2.9.0/go.mod h1:7Ad2xp27vOQRQWQsIeHBdU/YiyEt6klBeh5gwnNnlwE=
+github.com/wealdtech/go-merkletree v1.0.1-0.20230205101955-ec7a95ea11ca h1:oK35INPN4CiubFw7ZPQkbxm2AsSU6Tjeb9YhciZnvIM=
+github.com/wealdtech/go-merkletree v1.0.1-0.20230205101955-ec7a95ea11ca/go.mod h1:bM9mDSjsti+gkjl8FjovMoUH3MPR5bwJ3+ucaYFY0Jk=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=
 github.com/wealdtech/go-multicodec v1.4.0/go.mod h1:aedGMaTeYkIqi/KCPre1ho5rTb3hGpu/snBOS3GQLw4=
 github.com/wealdtech/go-string2eth v1.1.0 h1:USJQmysUrBYYmZs7d45pMb90hRSyEwizP7lZaOZLDAw=

--- a/shared/services/rewards/generator-impl-v1.go
+++ b/shared/services/rewards/generator-impl-v1.go
@@ -247,7 +247,11 @@ func (r *treeGeneratorImpl_v1) generateMerkleTree() error {
 	}
 
 	// Generate the tree
-	tree, err := merkletree.NewUsing(totalData, keccak256.New(), false, true)
+	tree, err := merkletree.NewTree(
+		merkletree.WithData(totalData),
+		merkletree.WithHashType(keccak256.New()),
+		merkletree.WithSorted(true),
+	)
 	if err != nil {
 		return fmt.Errorf("error generating Merkle Tree: %w", err)
 	}

--- a/shared/services/rewards/generator-impl-v2.go
+++ b/shared/services/rewards/generator-impl-v2.go
@@ -251,7 +251,11 @@ func (r *treeGeneratorImpl_v2) generateMerkleTree() error {
 	}
 
 	// Generate the tree
-	tree, err := merkletree.NewUsing(totalData, keccak256.New(), false, true)
+	tree, err := merkletree.NewTree(
+		merkletree.WithData(totalData),
+		merkletree.WithHashType(keccak256.New()),
+		merkletree.WithSorted(true),
+	)
 	if err != nil {
 		return fmt.Errorf("error generating Merkle Tree: %w", err)
 	}

--- a/shared/services/rewards/generator-impl-v3.go
+++ b/shared/services/rewards/generator-impl-v3.go
@@ -247,7 +247,11 @@ func (r *treeGeneratorImpl_v3) generateMerkleTree() error {
 	}
 
 	// Generate the tree
-	tree, err := merkletree.NewUsing(totalData, keccak256.New(), false, true)
+	tree, err := merkletree.NewTree(
+		merkletree.WithData(totalData),
+		merkletree.WithHashType(keccak256.New()),
+		merkletree.WithSorted(true),
+	)
 	if err != nil {
 		return fmt.Errorf("error generating Merkle Tree: %w", err)
 	}

--- a/shared/services/rewards/generator-impl-v4.go
+++ b/shared/services/rewards/generator-impl-v4.go
@@ -286,7 +286,11 @@ func (r *treeGeneratorImpl_v4) generateMerkleTree() error {
 	}
 
 	// Generate the tree
-	tree, err := merkletree.NewUsing(totalData, keccak256.New(), false, true)
+	tree, err := merkletree.NewTree(
+		merkletree.WithData(totalData),
+		merkletree.WithHashType(keccak256.New()),
+		merkletree.WithSorted(true),
+	)
 	if err != nil {
 		return fmt.Errorf("error generating Merkle Tree: %w", err)
 	}


### PR DESCRIPTION
Hi.

I upstreamed your changes to go-merkletree. I tried my best to verify that everything still worked the same, but I don't have an archive node, and the new multicaller setup takes too long to use Alchemy because the API timeout is 5 seconds, and at least getting the node addresses takes longer than that. A bit unfortunate.

I thought maybe you are still doing this kind of testing, so it would be easy for you to verify a previous interval. If you want me to test it, I guess I can ask to use someones archive node on the Discord.

I see no reason that it wouldn't work because there's really good test coverage in go-merkletree, but still, anything is possible and I don't want to break everything.