### PR TITLE
chore: update url for checkpoint sync docs

### DIFF
--- a/rocketpool-cli/service/config/step-checkpoint-sync.go
+++ b/rocketpool-cli/service/config/step-checkpoint-sync.go
@@ -12,7 +12,7 @@ func createCheckpointSyncStep(wiz *wizard, currentStep int, totalSteps int) *tex
 	// Create the labels and args
 	checkpointSyncLabel := wiz.md.Config.ConsensusCommon.CheckpointSyncProvider.Name
 
-	helperText := "Your client supports Checkpoint Sync. This powerful feature allows it to copy the most recent state from a separate Consensus client that you trust, so you don't have to wait for it to sync from scratch - you can start using it instantly!\n\nTake a look at our documentation for an example of how to use it:\nhttps://docs.rocketpool.net/guides/node/config-docker.html#beacon-chain-checkpoint-syncing-with-infura\n\nIf you would like to use Checkpoint Sync, please provide the provider URL here. If you don't want to use it, leave it blank."
+	helperText := "Your client supports Checkpoint Sync. This powerful feature allows it to copy the most recent state from a separate Consensus client that you trust, so you don't have to wait for it to sync from scratch - you can start using it instantly!\n\nTake a look at our documentation for an example of how to use it:\nhttps://docs.rocketpool.net/guides/node/config-docker.html#beacon-chain-checkpoint-syncing\n\nIf you would like to use Checkpoint Sync, please provide the provider URL here. If you don't want to use it, leave it blank."
 
 	show := func(modal *textBoxModalLayout) {
 		wiz.md.setPage(modal.page)


### PR DESCRIPTION
Seems like the url in the docs have been updated to:
https://docs.rocketpool.net/guides/node/config-docker.html#beacon-chain-checkpoint-syncing

Not sure if there's already a duplicate commit, please feel free to close if so.