### PR TITLE
Give option to generate wallet password

### DIFF
--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -24,8 +26,28 @@ import (
 const bold string = "\033[1m"
 const unbold string = "\033[0m"
 
+// Generate a secure password with 32 bytes of entropy, encoded as a base64 string.
+func generatePassword() string {
+	randomBytes := make([]byte, 32)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		panic("failed to generate random bytes")
+	}
+
+	return base64.RawStdEncoding.EncodeToString(randomBytes)
+}
+
 // Prompt for a wallet password
 func promptPassword() string {
+	fmt.Println("Your keystore will be encrypted on disk using a password.")
+	fmt.Println("You do not need to store or remember this password.")
+	fmt.Print("You only need the seed phrase (from the next step) to recover your wallet.\n\n")
+
+	if cliutils.Confirm("Would you like the password to be automatically generated?") {
+		fmt.Print("Using randomly-generated password.\n\n")
+		return generatePassword()
+	}
+
 	for {
 		password := cliutils.PromptPassword(
 			"Please enter a password to secure your wallet with:",
@@ -36,8 +58,7 @@ func promptPassword() string {
 		if password == confirmation {
 			return password
 		}
-		fmt.Println("Password confirmation does not match.")
-		fmt.Println("")
+		fmt.Print("Password confirmation does not match.\n\n")
 	}
 }
 


### PR DESCRIPTION
Closes #248 

As pointed out in the issue, and from my understanding, the password is not used for any purpose other than during `wallet init`, and `wallet restore`, so giving the user an automatic way to generate the password would be nice.

I've added the functionality in a way that is least intrusive to the current flow, but I see no reason to prompt the user at all for the password. So if we want to remove the prompt completely, I will update the PR with that.