### PR TITLE
Fix deprecated ioutil file methods

### DIFF
--- a/rocketpool-cli/node/utils.go
+++ b/rocketpool-cli/node/utils.go
@@ -3,7 +3,7 @@ package node
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -38,7 +38,7 @@ func promptTimezone() string {
 			defer func() {
 				_ = resp.Body.Close()
 			}()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err == nil {
 				message := new(ipInfoResponse)
 				err := json.Unmarshal(body, message)

--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -136,7 +136,7 @@ func promptForCustomKeyPasswords(rp *rocketpool.Client, cfg *config.RocketPoolCo
 	customPubkeys := []types.ValidatorPubkey{}
 	for _, file := range files {
 		// Read the file
-		bytes, err := ioutil.ReadFile(filepath.Join(customKeyDir, file.Name()))
+		bytes, err := os.ReadFile(filepath.Join(customKeyDir, file.Name()))
 		if err != nil {
 			return "", fmt.Errorf("error reading custom keystore %s: %w", file.Name(), err)
 		}
@@ -173,7 +173,7 @@ func promptForCustomKeyPasswords(rp *rocketpool.Client, cfg *config.RocketPoolCo
 		return "", fmt.Errorf("error serializing keystore passwords file: %w", err)
 	}
 	passwordFile := filepath.Join(datapath, "custom-key-passwords")
-	err = ioutil.WriteFile(passwordFile, fileBytes, 0600)
+	err = os.WriteFile(passwordFile, fileBytes, 0600)
 	if err != nil {
 		return "", fmt.Errorf("error writing keystore passwords file: %w", err)
 	}

--- a/rocketpool/api/node/voting.go
+++ b/rocketpool/api/node/voting.go
@@ -3,7 +3,7 @@ package node
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -273,7 +273,7 @@ func GetSnapshotVotingPower(apiDomain string, space string, nodeAddress common.A
 	}
 
 	// Get response
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func GetSnapshotVotedProposals(apiDomain string, space string, nodeAddress commo
 	}
 
 	// Get response
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func GetSnapshotProposals(apiDomain string, space string, state string) (*api.Sn
 	}
 
 	// Get response
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/node/node.go
+++ b/rocketpool/node/node.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -181,7 +180,7 @@ func deployDefaultFeeRecipientFile(c *cli.Context) error {
 			// Docker and Hybrid just need the address itself
 			defaultFeeRecipientFileContents = cfg.Smartnode.GetRethAddress().Hex()
 		}
-		err := ioutil.WriteFile(feeRecipientPath, []byte(defaultFeeRecipientFileContents), 0664)
+		err := os.WriteFile(feeRecipientPath, []byte(defaultFeeRecipientFileContents), 0664)
 		if err != nil {
 			return fmt.Errorf("could not write default fee recipient file to %s: %w", feeRecipientPath, err)
 		}

--- a/rocketpool/watchtower/generate-rewards-tree.go
+++ b/rocketpool/watchtower/generate-rewards-tree.go
@@ -252,12 +252,12 @@ func (t *generateRewardsTree) generateRewardsTreeImpl(rp *rocketpool.RocketPool,
 	// Write the files
 	path := t.cfg.Smartnode.GetRewardsTreePath(index, true)
 	minipoolPerformancePath := t.cfg.Smartnode.GetMinipoolPerformancePath(index, true)
-	err = ioutil.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
+	err = os.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
 	if err != nil {
 		t.handleError(fmt.Errorf("%s Error saving minipool performance file to %s: %w", generationPrefix, minipoolPerformancePath, err))
 		return
 	}
-	err = ioutil.WriteFile(path, wrapperBytes, 0644)
+	err = os.WriteFile(path, wrapperBytes, 0644)
 	if err != nil {
 		t.handleError(fmt.Errorf("%s Error saving rewards file to %s: %w", generationPrefix, path, err))
 		return

--- a/rocketpool/watchtower/process-penalties.go
+++ b/rocketpool/watchtower/process-penalties.go
@@ -3,7 +3,6 @@ package watchtower
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -142,7 +141,7 @@ func stateFileExists(path string) bool {
 func (s *state) loadState(path string) (*state, error) {
 
 	// Load file into memory
-	yamlFile, err := ioutil.ReadFile(path)
+	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		return s, err
 	}
@@ -170,7 +169,7 @@ func (s *state) saveState(path string) error {
 	if err != nil {
 		return fmt.Errorf("error creating watchtower directory: %w", err)
 	}
-	return ioutil.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0644)
 }
 
 // Process penalties

--- a/rocketpool/watchtower/submit-rewards-tree.go
+++ b/rocketpool/watchtower/submit-rewards-tree.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -204,7 +203,7 @@ func (t *submitRewardsTree) run() error {
 		t.log.Printlnf("Merkle rewards tree for interval %d already exists at %s, attempting to resubmit...", currentIndex, rewardsTreePath)
 
 		// Deserialize the file
-		wrapperBytes, err := ioutil.ReadFile(rewardsTreePath)
+		wrapperBytes, err := os.ReadFile(rewardsTreePath)
 		if err != nil {
 			return fmt.Errorf("Error reading rewards tree file: %w", err)
 		}
@@ -260,7 +259,7 @@ func (t *submitRewardsTree) isExistingFileValid(rewardsTreePath string, interval
 	if !os.IsNotExist(err) {
 		// The file already exists, attempt to read it
 		var proofWrapper rprewards.RewardsFile
-		fileBytes, err := ioutil.ReadFile(rewardsTreePath)
+		fileBytes, err := os.ReadFile(rewardsTreePath)
 		if err != nil {
 			t.log.Printlnf("WARNING: failed to read %s: %s\nRegenerating file...\n", rewardsTreePath, err.Error())
 			return false
@@ -343,7 +342,7 @@ func (t *submitRewardsTree) generateTreeImpl(rp *rocketpool.RocketPool, interval
 	}
 
 	// Write it to disk
-	err = ioutil.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
+	err = os.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("Error saving minipool performance file to %s: %w", minipoolPerformancePath, err)
 	}
@@ -370,7 +369,7 @@ func (t *submitRewardsTree) generateTreeImpl(rp *rocketpool.RocketPool, interval
 	t.printMessage("Generation complete! Saving tree...")
 
 	// Write the rewards tree to disk
-	err = ioutil.WriteFile(rewardsTreePath, wrapperBytes, 0644)
+	err = os.WriteFile(rewardsTreePath, wrapperBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("Error saving rewards tree file to %s: %w", rewardsTreePath, err)
 	}

--- a/shared/services/beacon/client/std-http-client.go
+++ b/shared/services/beacon/client/std-http-client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -804,7 +804,7 @@ func (c *StandardHttpClient) getRequest(requestPath string) ([]byte, int, error)
 	}()
 
 	// Get response
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return []byte{}, 0, err
 	}
@@ -834,7 +834,7 @@ func (c *StandardHttpClient) postRequest(requestPath string, requestBody interfa
 	}()
 
 	// Get response
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return []byte{}, 0, err
 	}

--- a/shared/services/config/config-legacy.go
+++ b/shared/services/config/config-legacy.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strconv"
@@ -290,7 +289,7 @@ func Load(c *cli.Context) (LegacyRocketPoolConfig, error) {
 func loadFile(path string, required bool) (LegacyRocketPoolConfig, error) {
 
 	// Read file; squelch not found errors if file is optional
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		if required {
 			return LegacyRocketPoolConfig{}, fmt.Errorf("Could not find config file at %s: %w", path, err)

--- a/shared/services/config/rocket-pool-config.go
+++ b/shared/services/config/rocket-pool-config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -133,7 +132,7 @@ func LoadFromFile(path string) (*RocketPoolConfig, error) {
 	}
 
 	// Read the file
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not read Rocket Pool settings file at %s: %w", shellescape.Quote(path), err)
 	}

--- a/shared/services/gas/etherchain/etherchain.go
+++ b/shared/services/gas/etherchain/etherchain.go
@@ -3,7 +3,7 @@ package etherchain
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 )
@@ -55,7 +55,7 @@ func GetGasPrices() (GasFeeSuggestion, error) {
 	}
 
 	// Get response
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return GasFeeSuggestion{}, err
 	}

--- a/shared/services/gas/etherscan/etherscan.go
+++ b/shared/services/gas/etherscan/etherscan.go
@@ -3,7 +3,7 @@ package etherscan
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 )
@@ -45,7 +45,7 @@ func GetGasPrices() (GasFeeSuggestion, error) {
 	}
 
 	// Get response
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return GasFeeSuggestion{}, err
 	}

--- a/shared/services/passwords/manager.go
+++ b/shared/services/passwords/manager.go
@@ -3,7 +3,6 @@ package passwords
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -27,7 +26,7 @@ func NewPasswordManager(passwordPath string) *PasswordManager {
 
 // Check if the password has been set
 func (pm *PasswordManager) IsPasswordSet() bool {
-	_, err := ioutil.ReadFile(pm.passwordPath)
+	_, err := os.ReadFile(pm.passwordPath)
 	return (err == nil)
 }
 
@@ -35,7 +34,7 @@ func (pm *PasswordManager) IsPasswordSet() bool {
 func (pm *PasswordManager) GetPassword() (string, error) {
 
 	// Read from disk
-	password, err := ioutil.ReadFile(pm.passwordPath)
+	password, err := os.ReadFile(pm.passwordPath)
 	if err != nil {
 		return "", fmt.Errorf("Could not read password from disk: %w", err)
 	}
@@ -59,7 +58,7 @@ func (pm *PasswordManager) SetPassword(password string) error {
 	}
 
 	// Write to disk
-	if err := ioutil.WriteFile(pm.passwordPath, []byte(password), FileMode); err != nil {
+	if err := os.WriteFile(pm.passwordPath, []byte(password), FileMode); err != nil {
 		return fmt.Errorf("Could not write password to disk: %w", err)
 	}
 

--- a/shared/services/rewards/manager.go
+++ b/shared/services/rewards/manager.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/big"
 	"net/http"
@@ -107,7 +107,7 @@ func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.RocketPoolConfig, no
 	info.TreeFileExists = true
 
 	// Unmarshal it
-	fileBytes, err := ioutil.ReadFile(info.TreeFilePath)
+	fileBytes, err := os.ReadFile(info.TreeFilePath)
 	if err != nil {
 		err = fmt.Errorf("error reading %s: %w", info.TreeFilePath, err)
 		return
@@ -363,7 +363,7 @@ func DownloadRewardsFile(cfg *config.RocketPoolConfig, interval uint64, cid stri
 			continue
 		} else {
 			// If we got here, we have a successful download
-			bytes, err := ioutil.ReadAll(resp.Body)
+			bytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				errBuilder.WriteString(fmt.Sprintf("Error reading response bytes from %s: %s\n", url, err.Error()))
 				continue
@@ -377,7 +377,7 @@ func DownloadRewardsFile(cfg *config.RocketPoolConfig, interval uint64, cid stri
 			}
 
 			// Write the file
-			err = ioutil.WriteFile(rewardsTreePath, decompressedBytes, 0644)
+			err = os.WriteFile(rewardsTreePath, decompressedBytes, 0644)
 			if err != nil {
 				return fmt.Errorf("error saving interval %d file to %s: %w", interval, rewardsTreePath, err)
 			}

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/url"
@@ -268,7 +267,7 @@ func (c *Client) UpdatePrometheusConfiguration(settings map[string]string) error
 	}
 
 	// Write the actual Prometheus config file
-	err = ioutil.WriteFile(prometheusConfigPath, contents, 0664)
+	err = os.WriteFile(prometheusConfigPath, contents, 0664)
 	if err != nil {
 		return fmt.Errorf("Could not write Prometheus config file to %s: %w", shellescape.Quote(prometheusConfigPath), err)
 	}
@@ -1259,7 +1258,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 		return []string{}, fmt.Errorf("error reading and substituting API container template: %w", err)
 	}
 	apiComposePath := filepath.Join(runtimeFolder, config.ApiContainerName+composeFileSuffix)
-	err = ioutil.WriteFile(apiComposePath, contents, 0664)
+	err = os.WriteFile(apiComposePath, contents, 0664)
 	if err != nil {
 		return []string{}, fmt.Errorf("could not write API container file to %s: %w", apiComposePath, err)
 	}
@@ -1272,7 +1271,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 		return []string{}, fmt.Errorf("error reading and substituting node container template: %w", err)
 	}
 	nodeComposePath := filepath.Join(runtimeFolder, config.NodeContainerName+composeFileSuffix)
-	err = ioutil.WriteFile(nodeComposePath, contents, 0664)
+	err = os.WriteFile(nodeComposePath, contents, 0664)
 	if err != nil {
 		return []string{}, fmt.Errorf("could not write node container file to %s: %w", nodeComposePath, err)
 	}
@@ -1285,7 +1284,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 		return []string{}, fmt.Errorf("error reading and substituting watchtower container template: %w", err)
 	}
 	watchtowerComposePath := filepath.Join(runtimeFolder, config.WatchtowerContainerName+composeFileSuffix)
-	err = ioutil.WriteFile(watchtowerComposePath, contents, 0664)
+	err = os.WriteFile(watchtowerComposePath, contents, 0664)
 	if err != nil {
 		return []string{}, fmt.Errorf("could not write watchtower container file to %s: %w", watchtowerComposePath, err)
 	}
@@ -1298,7 +1297,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 		return []string{}, fmt.Errorf("error reading and substituting validator container template: %w", err)
 	}
 	validatorComposePath := filepath.Join(runtimeFolder, config.ValidatorContainerName+composeFileSuffix)
-	err = ioutil.WriteFile(validatorComposePath, contents, 0664)
+	err = os.WriteFile(validatorComposePath, contents, 0664)
 	if err != nil {
 		return []string{}, fmt.Errorf("could not write validator container file to %s: %w", validatorComposePath, err)
 	}
@@ -1312,7 +1311,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 			return []string{}, fmt.Errorf("error reading and substituting execution client container template: %w", err)
 		}
 		eth1ComposePath := filepath.Join(runtimeFolder, config.Eth1ContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(eth1ComposePath, contents, 0664)
+		err = os.WriteFile(eth1ComposePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write execution client container file to %s: %w", eth1ComposePath, err)
 		}
@@ -1327,7 +1326,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 			return []string{}, fmt.Errorf("error reading and substituting consensus client container template: %w", err)
 		}
 		eth2ComposePath := filepath.Join(runtimeFolder, config.Eth2ContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(eth2ComposePath, contents, 0664)
+		err = os.WriteFile(eth2ComposePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write consensus client container file to %s: %w", eth2ComposePath, err)
 		}
@@ -1343,7 +1342,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 			return []string{}, fmt.Errorf("error reading and substituting Grafana container template: %w", err)
 		}
 		grafanaComposePath := filepath.Join(runtimeFolder, config.GrafanaContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(grafanaComposePath, contents, 0664)
+		err = os.WriteFile(grafanaComposePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write Grafana container file to %s: %w", grafanaComposePath, err)
 		}
@@ -1356,7 +1355,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 			return []string{}, fmt.Errorf("error reading and substituting Node Exporter container template: %w", err)
 		}
 		exporterComposePath := filepath.Join(runtimeFolder, config.ExporterContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(exporterComposePath, contents, 0664)
+		err = os.WriteFile(exporterComposePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write Node Exporter container file to %s: %w", exporterComposePath, err)
 		}
@@ -1369,7 +1368,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 			return []string{}, fmt.Errorf("error reading and substituting Prometheus container template: %w", err)
 		}
 		prometheusComposePath := filepath.Join(runtimeFolder, config.PrometheusContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(prometheusComposePath, contents, 0664)
+		err = os.WriteFile(prometheusComposePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write Prometheus container file to %s: %w", prometheusComposePath, err)
 		}
@@ -1384,7 +1383,7 @@ func (c *Client) deployTemplates(cfg *config.RocketPoolConfig, rocketpoolDir str
 			return []string{}, fmt.Errorf("error reading and substituting MEV-Boost container template: %w", err)
 		}
 		mevBoostComposePath := filepath.Join(runtimeFolder, config.MevBoostContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(mevBoostComposePath, contents, 0664)
+		err = os.WriteFile(mevBoostComposePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write MEV-Boost container file to %s: %w", mevBoostComposePath, err)
 		}
@@ -1439,7 +1438,7 @@ func (c *Client) composeAddons(cfg *config.RocketPoolConfig, rocketpoolDir strin
 			return []string{}, fmt.Errorf("error reading and substituting GWW addon container template: %w", err)
 		}
 		composePath := filepath.Join(runtimeFolder, graffiti_wall_writer.GraffitiWallWriterContainerName+composeFileSuffix)
-		err = ioutil.WriteFile(composePath, contents, 0664)
+		err = os.WriteFile(composePath, contents, 0664)
 		if err != nil {
 			return []string{}, fmt.Errorf("could not write GWW addon container file to %s: %w", composePath, err)
 		}

--- a/shared/services/rocketpool/fee-recipient.go
+++ b/shared/services/rocketpool/fee-recipient.go
@@ -3,7 +3,6 @@ package rocketpool
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +29,7 @@ func CheckFeeRecipientFile(feeRecipient common.Address, cfg *config.RocketPoolCo
 
 	// Compare the file contents with the expected string
 	expectedString := getFeeRecipientFileContents(feeRecipient, cfg)
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return false, false, fmt.Errorf("error reading fee recipient file: %w", err)
 	}
@@ -53,7 +52,7 @@ func UpdateFeeRecipientFile(feeRecipient common.Address, cfg *config.RocketPoolC
 
 	// Write the file
 	path := cfg.Smartnode.GetFeeRecipientFilePath()
-	err := ioutil.WriteFile(path, bytes, FileMode)
+	err := os.WriteFile(path, bytes, FileMode)
 	if err != nil {
 		return fmt.Errorf("error writing fee recipient file: %w", err)
 	}

--- a/shared/services/rocketpool/legacy-client.go
+++ b/shared/services/rocketpool/legacy-client.go
@@ -2,7 +2,7 @@ package rocketpool
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/alessio/shellescape"
 	"github.com/mitchellh/go-homedir"
@@ -47,7 +47,7 @@ func (c *Client) loadConfig_Legacy(path string) (config.LegacyRocketPoolConfig, 
 	if err != nil {
 		return config.LegacyRocketPoolConfig{}, err
 	}
-	configBytes, err := ioutil.ReadFile(expandedPath)
+	configBytes, err := os.ReadFile(expandedPath)
 	if err != nil {
 		return config.LegacyRocketPoolConfig{}, fmt.Errorf("Could not read Rocket Pool config at %s: %w", shellescape.Quote(path), err)
 	}

--- a/shared/services/wallet/keystore/lighthouse/keystore.go
+++ b/shared/services/wallet/keystore/lighthouse/keystore.go
@@ -3,7 +3,6 @@ package lighthouse
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -100,7 +99,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write secret to disk
-	if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
+	if err := os.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
 		return fmt.Errorf("Could not write validator secret to disk: %w", err)
 	}
 
@@ -113,7 +112,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write key store to disk
-	if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
+	if err := os.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
 		return fmt.Errorf("Could not write validator key to disk: %w", err)
 	}
 

--- a/shared/services/wallet/keystore/nimbus/keystore.go
+++ b/shared/services/wallet/keystore/nimbus/keystore.go
@@ -3,7 +3,6 @@ package nimbus
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -100,7 +99,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write secret to disk
-	if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
+	if err := os.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
 		return fmt.Errorf("Could not write validator secret to disk: %w", err)
 	}
 
@@ -113,7 +112,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write key store to disk
-	if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
+	if err := os.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
 		return fmt.Errorf("Could not write validator key to disk: %w", err)
 	}
 

--- a/shared/services/wallet/keystore/prysm/keystore.go
+++ b/shared/services/wallet/keystore/prysm/keystore.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -99,7 +98,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 
 	// Get the keystore account password
 	passwordFilePath := filepath.Join(ks.keystorePath, KeystoreDir, WalletDir, AccountsDir, KeystorePasswordFileName)
-	passwordBytes, err := ioutil.ReadFile(passwordFilePath)
+	passwordBytes, err := os.ReadFile(passwordFilePath)
 	if err != nil {
 		return fmt.Errorf("Error reading account password file: %w", err)
 	}
@@ -135,7 +134,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write keystore to disk
-	if err := ioutil.WriteFile(keystoreFilePath, ksBytes, FileMode); err != nil {
+	if err := os.WriteFile(keystoreFilePath, ksBytes, FileMode); err != nil {
 		return fmt.Errorf("Could not write keystore to disk: %w", err)
 	}
 
@@ -153,7 +152,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write wallet config to disk
-	if err := ioutil.WriteFile(configFilePath, configBytes, FileMode); err != nil {
+	if err := os.WriteFile(configFilePath, configBytes, FileMode); err != nil {
 		return fmt.Errorf("Could not write wallet config to disk: %w", err)
 	}
 
@@ -189,21 +188,21 @@ func (ks *Keystore) initialize() error {
 		if err != nil {
 			return fmt.Errorf("Error creating account password directory: %w", err)
 		}
-		err = ioutil.WriteFile(passwordFilePath, passwordBytes, FileMode)
+		err = os.WriteFile(passwordFilePath, passwordBytes, FileMode)
 		if err != nil {
 			return fmt.Errorf("Error writing account password file: %w", err)
 		}
 	}
 
 	// Get the random keystore password
-	passwordBytes, err := ioutil.ReadFile(passwordFilePath)
+	passwordBytes, err := os.ReadFile(passwordFilePath)
 	if err != nil {
 		return fmt.Errorf("Error opening account password file: %w", err)
 	}
 	password = string(passwordBytes)
 
 	// Read keystore file; initialize empty account store if it doesn't exist
-	ksBytes, err := ioutil.ReadFile(filepath.Join(ks.keystorePath, KeystoreDir, WalletDir, AccountsDir, KeystoreFileName))
+	ksBytes, err := os.ReadFile(filepath.Join(ks.keystorePath, KeystoreDir, WalletDir, AccountsDir, KeystoreFileName))
 	if err != nil {
 		ks.as = &accountStore{}
 		return nil

--- a/shared/services/wallet/keystore/teku/keystore.go
+++ b/shared/services/wallet/keystore/teku/keystore.go
@@ -3,7 +3,6 @@ package teku
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -99,7 +98,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write secret to disk
-	if err := ioutil.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
+	if err := os.WriteFile(secretFilePath, []byte(password), FileMode); err != nil {
 		return fmt.Errorf("Could not write validator secret to disk: %w", err)
 	}
 
@@ -112,7 +111,7 @@ func (ks *Keystore) StoreValidatorKey(key *eth2types.BLSPrivateKey, derivationPa
 	}
 
 	// Write key store to disk
-	if err := ioutil.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
+	if err := os.WriteFile(keyFilePath, keyStoreBytes, FileMode); err != nil {
 		return fmt.Errorf("Could not write validator key to disk: %w", err)
 	}
 

--- a/shared/services/wallet/wallet.go
+++ b/shared/services/wallet/wallet.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 
@@ -245,7 +244,7 @@ func (w *Wallet) Save() error {
 	}
 
 	// Write wallet store to disk
-	if err := ioutil.WriteFile(w.walletPath, wsBytes, FileMode); err != nil {
+	if err := os.WriteFile(w.walletPath, wsBytes, FileMode); err != nil {
 		return fmt.Errorf("Could not write wallet to disk: %w", err)
 	}
 
@@ -328,7 +327,7 @@ func (w *Wallet) Reload() error {
 func (w *Wallet) loadStore() (bool, error) {
 
 	// Read wallet store from disk; cancel if not found
-	wsBytes, err := ioutil.ReadFile(w.walletPath)
+	wsBytes, err := os.ReadFile(w.walletPath)
 	if err != nil {
 		return false, nil
 	}

--- a/shared/utils/rp/config.go
+++ b/shared/utils/rp/config.go
@@ -2,7 +2,6 @@ package rp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -39,7 +38,7 @@ func SaveConfig(cfg *config.RocketPoolConfig, path string) error {
 		return fmt.Errorf("could not serialize settings file: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, configBytes, 0664); err != nil {
+	if err := os.WriteFile(path, configBytes, 0664); err != nil {
 		return fmt.Errorf("could not write Rocket Pool config to %s: %w", shellescape.Quote(path), err)
 	}
 

--- a/shared/utils/wallet/recover-keys.go
+++ b/shared/utils/wallet/recover-keys.go
@@ -77,7 +77,7 @@ func RecoverMinipoolKeys(c *cli.Context, rp *rocketpool.RocketPool, address comm
 
 			// Deserialize the password file
 			passwordFile := cfg.Smartnode.GetCustomKeyPasswordFilePath()
-			fileBytes, err := ioutil.ReadFile(passwordFile)
+			fileBytes, err := os.ReadFile(passwordFile)
 			if err != nil {
 				return nil, fmt.Errorf("%d custom keystores were found but the password file could not be loaded: %w", len(files), err)
 			}
@@ -90,7 +90,7 @@ func RecoverMinipoolKeys(c *cli.Context, rp *rocketpool.RocketPool, address comm
 			// Process every custom key
 			for _, file := range files {
 				// Read the file
-				bytes, err := ioutil.ReadFile(filepath.Join(customKeyDir, file.Name()))
+				bytes, err := os.ReadFile(filepath.Join(customKeyDir, file.Name()))
 				if err != nil {
 					return nil, fmt.Errorf("error reading custom keystore %s: %w", file.Name(), err)
 				}


### PR DESCRIPTION
Applied the following changes:
* `ioutil.WriteFile` -> `os.WriteFile` ([docs](https://pkg.go.dev/io/ioutil#WriteFile))
* `ioutil.ReadFile` -> `os.ReadFile` ([docs](https://pkg.go.dev/io/ioutil#ReadFile))
* `ioutil.ReadAll` -> `io.ReadAll` ([docs](https://pkg.go.dev/io/ioutil#ReadAll))

These are all no-op changes since the deprecated methods were calling the underlying `os` and `io` methods.

Fixing deprecated `ioutil.ReadDir` is slightly more involved, so did not address that one in this PR.