### PR TITLE
Require user to type 'I agree' to exit minipools.

### DIFF
--- a/rocketpool-cli/minipool/exit.go
+++ b/rocketpool-cli/minipool/exit.go
@@ -94,14 +94,8 @@ func exitMinipools(c *cli.Context) error {
 		fmt.Printf("You will no longer receive any rewards or penalties, but your validator's balance will be LOCKED on the Beacon Chain!\n")
 		fmt.Printf("You will NOT have access to your ETH until after the ETH1-ETH2 merge, when withdrawals are implemented!\n\n%s", colorReset)
 
-		// Prompt for confirmation
-		if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("Are you sure you want to exit %d minipool(s)? This action cannot be undone!", len(selectedMinipools)))) {
-			fmt.Println("Cancelled.")
-			return nil
-		}
-
-		// Prompt for confirmation
-		if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sPlease confirm again that you understand you will no longer earn staking rewards, but your ETH balance will remain locked on the Beacon Chain until withdrawals are implemented by the Ethereum core developers.%s", colorRed, colorReset))) {
+		// Prompt for an 'I agree' confirmation
+		if !(c.Bool("yes") || cliutils.ConfirmWithIAgree(fmt.Sprintf("%sAre you sure you want to exit %d minipool(s)? This action cannot be undone!%s", colorRed, len(selectedMinipools), colorReset))) {
 			fmt.Println("Cancelled.")
 			return nil
 		}
@@ -114,7 +108,7 @@ func exitMinipools(c *cli.Context) error {
 		fmt.Printf("Once your funds have been withdrawn, you can run `rocketpool minipool close` to distribute them to your withdrawal address and close the minipool.\n\n%s", colorReset)
 
 		// Prompt for confirmation
-		if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("Are you sure you want to exit %d minipool(s)? This action cannot be undone!", len(selectedMinipools)))) {
+		if !(c.Bool("yes") || cliutils.ConfirmWithIAgree(fmt.Sprintf("Are you sure you want to exit %d minipool(s)? This action cannot be undone!", len(selectedMinipools)))) {
 			fmt.Println("Cancelled.")
 			return nil
 		}

--- a/shared/utils/cli/prompt.go
+++ b/shared/utils/cli/prompt.go
@@ -34,6 +34,12 @@ func Confirm(initialPrompt string) bool {
 	return (strings.ToLower(response[:1]) == "y")
 }
 
+// Prompt for 'I agree' confirmation (used on important questions to avoid a quick 'y' response from the user)
+func ConfirmWithIAgree(initialPrompt string) bool {
+	response := Prompt(fmt.Sprintf("%s [Type 'I agree' or 'n']", initialPrompt), "(?i)^(i agree|n|no)$", "Please answer 'I agree' or 'n'")
+	return (len(response) == 7 && strings.ToLower(response[:7]) == "i agree")
+}
+
 // Prompt for user selection
 func Select(initialPrompt string, options []string) (int, string) {
 


### PR DESCRIPTION
NOs will need to type a "I agree" instead of 'y' on important commands like `rp m e`. 

This would avoid a quick 'y' answer when a user thought they were using another command.

Closes #329 