### PR TITLE
Migrate deprecated `ioutil.ReadDir` method calls

### DIFF
--- a/rocketpool-cli/wallet/utils.go
+++ b/rocketpool-cli/wallet/utils.go
@@ -3,7 +3,6 @@ package wallet
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -114,7 +113,7 @@ func promptForCustomKeyPasswords(rp *rocketpool.Client, cfg *config.RocketPoolCo
 	}
 
 	// Get the custom keystore files
-	files, err := ioutil.ReadDir(customKeyDir)
+	files, err := os.ReadDir(customKeyDir)
 	if err != nil {
 		return "", fmt.Errorf("error enumerating custom keystores: %w", err)
 	}

--- a/rocketpool/api/service/terminate.go
+++ b/rocketpool/api/service/terminate.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,7 +28,7 @@ func terminateDataFolder(c *cli.Context) (*api.TerminateDataFolderResponse, erro
 	response.FolderExisted = true
 
 	// Traverse it
-	files, err := ioutil.ReadDir(dataFolder)
+	files, err := os.ReadDir(dataFolder)
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating files: %w", err)
 	}
@@ -52,7 +51,7 @@ func terminateDataFolder(c *cli.Context) (*api.TerminateDataFolderResponse, erro
 
 	// Traverse the validators dir
 	validatorsDir := filepath.Join(dataFolder, "validators")
-	files, err = ioutil.ReadDir(validatorsDir)
+	files, err = os.ReadDir(validatorsDir)
 	if err != nil {
 		return nil, fmt.Errorf("error enumerating validator files: %w", err)
 	}

--- a/rocketpool/watchtower/generate-rewards-tree.go
+++ b/rocketpool/watchtower/generate-rewards-tree.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -92,7 +91,7 @@ func (t *generateRewardsTree) run() error {
 
 	// Check for requests
 	requestDir := t.cfg.Smartnode.GetWatchtowerFolder(true)
-	files, err := ioutil.ReadDir(requestDir)
+	files, err := os.ReadDir(requestDir)
 	if os.IsNotExist(err) {
 		t.log.Println("Watchtower storage directory doesn't exist, creating...")
 		err = os.Mkdir(requestDir, 0755)

--- a/shared/utils/wallet/recover-keys.go
+++ b/shared/utils/wallet/recover-keys.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,7 +61,7 @@ func RecoverMinipoolKeys(c *cli.Context, rp *rocketpool.RocketPool, address comm
 	if !os.IsNotExist(err) && info.IsDir() {
 
 		// Get the custom keystore files
-		files, err := ioutil.ReadDir(customKeyDir)
+		files, err := os.ReadDir(customKeyDir)
 		if err != nil {
 			return nil, fmt.Errorf("error enumerating custom keystores: %w", err)
 		}


### PR DESCRIPTION
Migrate all `ioutil.ReadDir` -> `os.ReadDir` as recommended per the deprecation note. Note that `os.ReadDir` returns a different struct than the deprecated method. Both structs support `Name()` and `IsDir()` methods, so this should be a drop-in replacement based on a read of the code.