### PR TITLE
Enable lodestar beaconcha.in node metrics support

### DIFF
--- a/rocketpool-cli/service/config/settings-metrics.go
+++ b/rocketpool-cli/service/config/settings-metrics.go
@@ -136,7 +136,7 @@ func (configPage *MetricsConfigPage) handleLayoutChanged() {
 	}
 
 	switch configPage.masterConfig.ConsensusClient.Value.(cfgtypes.ConsensusClient) {
-	case cfgtypes.ConsensusClient_Teku, cfgtypes.ConsensusClient_Lighthouse:
+	case cfgtypes.ConsensusClient_Teku, cfgtypes.ConsensusClient_Lighthouse, cfgtypes.ConsensusClient_Lodestar:
 		configPage.layout.form.AddFormItem(configPage.enableBitflyNodeMetricsBox.item)
 		if configPage.masterConfig.EnableBitflyNodeMetrics.Value == true {
 			configPage.layout.addFormItems(configPage.bitflyNodeMetricsItems)


### PR DESCRIPTION
This enables lodestar beaconcha.in node metrics support, depends on https://github.com/rocket-pool/smartnode-install/pull/93 to work


Related https://github.com/rocket-pool/smartnode/pull/204

Requires Lodestar v1.8.0 (release date 17/18 Apr.)