### PR TITLE
Set treegen v5 r.opts

### DIFF
--- a/shared/services/rewards/generator-impl-v5.go
+++ b/shared/services/rewards/generator-impl-v5.go
@@ -124,6 +124,11 @@ func (r *treeGeneratorImpl_v5) generateTree(rp *rocketpool.RocketPool, cfg *conf
 	r.beaconConfig = r.networkState.BeaconConfig
 	r.slotsPerEpoch = r.beaconConfig.SlotsPerEpoch
 
+	// Set the EL client call opts
+	r.opts = &bind.CallOpts{
+		BlockNumber: r.elSnapshotHeader.Number,
+	}
+
 	r.log.Printlnf("%s Creating tree for %d nodes", r.logPrefix, len(r.networkState.NodeDetails))
 
 	// Get the minipool count - this will be used for an error epsilon due to division truncation
@@ -181,6 +186,11 @@ func (r *treeGeneratorImpl_v5) approximateStakerShareOfSmoothingPool(rp *rocketp
 	// Get the Beacon config
 	r.beaconConfig = r.networkState.BeaconConfig
 	r.slotsPerEpoch = r.beaconConfig.SlotsPerEpoch
+
+	// Set the EL client call opts
+	r.opts = &bind.CallOpts{
+		BlockNumber: r.elSnapshotHeader.Number,
+	}
 
 	r.log.Printlnf("%s Creating tree for %d nodes", r.logPrefix, len(r.networkState.NodeDetails))
 


### PR DESCRIPTION
Without this little line we run the risk of including odao members added after the interval ends:
```go
        oDaoAddresses, err := trustednode.GetMemberAddresses(r.rp, r.opts)
        if err != nil {
                return err
        }
```
or, using the wrong sp contract if it was updated tightly after the interval ends:
```go
        // Get the Smoothing Pool contract's balance
        smoothingPoolContract, err := r.rp.GetContract("rocketSmoothingPool", r.opts)
```
or, using an illegal network
```go
// Validates that the provided network is legal
func (r *treeGeneratorImpl_v5) validateNetwork(network uint64) (bool, error) {
        valid, exists := r.validNetworkCache[network]
        if !exists {
                var err error
                valid, err = tnsettings.GetNetworkEnabled(r.rp, big.NewInt(int64(network)), r.opts)
                if err != nil {
                        return false, err
                }
                r.validNetworkCache[network] = valid
        }

        return valid, nil
}
```

Besides which, it makes preview tree reproduction impossible every time someone joins the odao.