### PR TITLE
BN client Committees response optimizations

### DIFF
--- a/shared/services/beacon/client.go
+++ b/shared/services/beacon/client.go
@@ -65,10 +65,23 @@ type BeaconBlock struct {
 	ExecutionBlockNumber uint64
 }
 
-type Committee struct {
-	Index      uint64
-	Slot       uint64
-	Validators []string
+// Committees is an interface as an optimization- since committees responses
+// are quite large, there's a decent cpu/memory improvement to removing the
+// translation to an intermediate storage class.
+//
+// Instead, the interface provides the access pattern that smartnode (or more
+// specifically, tree-gen) wants, and the underlying format is just the format
+// of the Beacon Node response.
+type Committees interface {
+	// Index returns the index of the committee at the provided offset
+	Index(int) uint64
+	// Slot returns the slot of the committee at the provided offset
+	Slot(int) uint64
+	// Validators returns the list of validators of the committee at
+	// the provided offset
+	Validators(int) []string
+	// Count returns the number of committees in the response
+	Count() int
 }
 
 type AttestationInfo struct {
@@ -128,6 +141,6 @@ type Client interface {
 	ExitValidator(validatorIndex string, epoch uint64, signature types.ValidatorSignature) error
 	Close() error
 	GetEth1DataForEth2Block(blockId string) (Eth1Data, bool, error)
-	GetCommitteesForEpoch(epoch *uint64) ([]Committee, error)
+	GetCommitteesForEpoch(epoch *uint64) (Committees, error)
 	ChangeWithdrawalCredentials(validatorIndex string, fromBlsPubkey types.ValidatorPubkey, toExecutionAddress common.Address, signature types.ValidatorSignature) error
 }

--- a/shared/services/beacon/client.go
+++ b/shared/services/beacon/client.go
@@ -82,6 +82,10 @@ type Committees interface {
 	Validators(int) []string
 	// Count returns the number of committees in the response
 	Count() int
+	// Release returns the reused validators slice buffer to the pool for
+	// further reuse, and must be called when the user is done with this
+	// committees instance
+	Release()
 }
 
 type AttestationInfo struct {

--- a/shared/services/beacon/client/types.go
+++ b/shared/services/beacon/client/types.go
@@ -143,6 +143,22 @@ type Committee struct {
 	Validators []string `json:"validators"`
 }
 
+func (c *CommitteesResponse) Count() int {
+	return len(c.Data)
+}
+
+func (c *CommitteesResponse) Index(idx int) uint64 {
+	return uint64(c.Data[idx].Index)
+}
+
+func (c *CommitteesResponse) Slot(idx int) uint64 {
+	return uint64(c.Data[idx].Slot)
+}
+
+func (c *CommitteesResponse) Validators(idx int) []string {
+	return c.Data[idx].Validators
+}
+
 type Attestation struct {
 	AggregationBits string `json:"aggregation_bits"`
 	Data            struct {

--- a/shared/services/beacon/client/types.go
+++ b/shared/services/beacon/client/types.go
@@ -201,7 +201,7 @@ func (c *CommitteesResponse) Release() {
 	for _, committee := range c.Data {
 		// Reset the slice length to 0 (capacity stays the same)
 		committee.Validators = committee.Validators[:0]
-		// Return the slcie for reuse
+		// Return the slice for reuse
 		validatorSlicePool.Put(committee.Validators)
 	}
 }

--- a/shared/services/rewards/generator-impl-v1.go
+++ b/shared/services/rewards/generator-impl-v1.go
@@ -850,7 +850,7 @@ func (r *treeGeneratorImpl_v1) processAttestationsForInterval() error {
 func (r *treeGeneratorImpl_v1) processEpoch(getDuties bool, epoch uint64) error {
 
 	// Get the committee info and attestation records for this epoch
-	var committeeData []beacon.Committee
+	var committeeData beacon.Committees
 	attestationsPerSlot := make([][]beacon.AttestationInfo, r.slotsPerEpoch)
 	var wg errgroup.Group
 
@@ -939,20 +939,20 @@ func (r *treeGeneratorImpl_v1) checkDutiesForSlot(attestations []beacon.Attestat
 }
 
 // Maps out the attestaion duties for the given epoch
-func (r *treeGeneratorImpl_v1) getDutiesForEpoch(committees []beacon.Committee) error {
+func (r *treeGeneratorImpl_v1) getDutiesForEpoch(committees beacon.Committees) error {
 
 	// Crawl the committees
-	for _, committee := range committees {
-		slotIndex := committee.Slot
+	for idx := 0; idx < committees.Count(); idx++ {
+		slotIndex := committees.Slot(idx)
 		if slotIndex < r.rewardsFile.ConsensusStartBlock || slotIndex > r.rewardsFile.ConsensusEndBlock {
 			// Ignore slots that are out of bounds
 			continue
 		}
-		committeeIndex := committee.Index
+		committeeIndex := committees.Index(idx)
 
 		// Check if there are any RP validators in this committee
 		rpValidators := map[int]*MinipoolInfo{}
-		for position, validator := range committee.Validators {
+		for position, validator := range committees.Validators(idx) {
 			minipoolInfo, exists := r.validatorIndexMap[validator]
 			if exists {
 				rpValidators[position] = minipoolInfo

--- a/shared/services/rewards/generator-impl-v1.go
+++ b/shared/services/rewards/generator-impl-v1.go
@@ -941,6 +941,8 @@ func (r *treeGeneratorImpl_v1) checkDutiesForSlot(attestations []beacon.Attestat
 // Maps out the attestaion duties for the given epoch
 func (r *treeGeneratorImpl_v1) getDutiesForEpoch(committees beacon.Committees) error {
 
+	defer committees.Release()
+
 	// Crawl the committees
 	for idx := 0; idx < committees.Count(); idx++ {
 		slotIndex := committees.Slot(idx)

--- a/shared/services/rewards/generator-impl-v2.go
+++ b/shared/services/rewards/generator-impl-v2.go
@@ -869,7 +869,7 @@ func (r *treeGeneratorImpl_v2) processAttestationsForInterval() error {
 func (r *treeGeneratorImpl_v2) processEpoch(getDuties bool, epoch uint64) error {
 
 	// Get the committee info and attestation records for this epoch
-	var committeeData []beacon.Committee
+	var committeeData beacon.Committees
 	attestationsPerSlot := make([][]beacon.AttestationInfo, r.slotsPerEpoch)
 	var wg errgroup.Group
 
@@ -958,20 +958,20 @@ func (r *treeGeneratorImpl_v2) checkDutiesForSlot(attestations []beacon.Attestat
 }
 
 // Maps out the attestaion duties for the given epoch
-func (r *treeGeneratorImpl_v2) getDutiesForEpoch(committees []beacon.Committee) error {
+func (r *treeGeneratorImpl_v2) getDutiesForEpoch(committees beacon.Committees) error {
 
 	// Crawl the committees
-	for _, committee := range committees {
-		slotIndex := committee.Slot
+	for idx := 0; idx < committees.Count(); idx++ {
+		slotIndex := committees.Slot(idx)
 		if slotIndex < r.rewardsFile.ConsensusStartBlock || slotIndex > r.rewardsFile.ConsensusEndBlock {
 			// Ignore slots that are out of bounds
 			continue
 		}
-		committeeIndex := committee.Index
+		committeeIndex := committees.Index(idx)
 
 		// Check if there are any RP validators in this committee
 		rpValidators := map[int]*MinipoolInfo{}
-		for position, validator := range committee.Validators {
+		for position, validator := range committees.Validators(idx) {
 			minipoolInfo, exists := r.validatorIndexMap[validator]
 			if exists {
 				rpValidators[position] = minipoolInfo

--- a/shared/services/rewards/generator-impl-v2.go
+++ b/shared/services/rewards/generator-impl-v2.go
@@ -960,6 +960,8 @@ func (r *treeGeneratorImpl_v2) checkDutiesForSlot(attestations []beacon.Attestat
 // Maps out the attestaion duties for the given epoch
 func (r *treeGeneratorImpl_v2) getDutiesForEpoch(committees beacon.Committees) error {
 
+	defer committees.Release()
+
 	// Crawl the committees
 	for idx := 0; idx < committees.Count(); idx++ {
 		slotIndex := committees.Slot(idx)

--- a/shared/services/rewards/generator-impl-v3.go
+++ b/shared/services/rewards/generator-impl-v3.go
@@ -865,7 +865,7 @@ func (r *treeGeneratorImpl_v3) processAttestationsForInterval() error {
 func (r *treeGeneratorImpl_v3) processEpoch(getDuties bool, epoch uint64) error {
 
 	// Get the committee info and attestation records for this epoch
-	var committeeData []beacon.Committee
+	var committeeData beacon.Committees
 	attestationsPerSlot := make([][]beacon.AttestationInfo, r.slotsPerEpoch)
 	var wg errgroup.Group
 
@@ -954,20 +954,20 @@ func (r *treeGeneratorImpl_v3) checkDutiesForSlot(attestations []beacon.Attestat
 }
 
 // Maps out the attestaion duties for the given epoch
-func (r *treeGeneratorImpl_v3) getDutiesForEpoch(committees []beacon.Committee) error {
+func (r *treeGeneratorImpl_v3) getDutiesForEpoch(committees beacon.Committees) error {
 
 	// Crawl the committees
-	for _, committee := range committees {
-		slotIndex := committee.Slot
+	for idx := 0; idx < committees.Count(); idx++ {
+		slotIndex := committees.Slot(idx)
 		if slotIndex < r.rewardsFile.ConsensusStartBlock || slotIndex > r.rewardsFile.ConsensusEndBlock {
 			// Ignore slots that are out of bounds
 			continue
 		}
-		committeeIndex := committee.Index
+		committeeIndex := committees.Index(idx)
 
 		// Check if there are any RP validators in this committee
 		rpValidators := map[int]*MinipoolInfo{}
-		for position, validator := range committee.Validators {
+		for position, validator := range committees.Validators(idx) {
 			minipoolInfo, exists := r.validatorIndexMap[validator]
 			if exists {
 				rpValidators[position] = minipoolInfo

--- a/shared/services/rewards/generator-impl-v3.go
+++ b/shared/services/rewards/generator-impl-v3.go
@@ -956,6 +956,8 @@ func (r *treeGeneratorImpl_v3) checkDutiesForSlot(attestations []beacon.Attestat
 // Maps out the attestaion duties for the given epoch
 func (r *treeGeneratorImpl_v3) getDutiesForEpoch(committees beacon.Committees) error {
 
+	defer committees.Release()
+
 	// Crawl the committees
 	for idx := 0; idx < committees.Count(); idx++ {
 		slotIndex := committees.Slot(idx)

--- a/shared/services/rewards/generator-impl-v4.go
+++ b/shared/services/rewards/generator-impl-v4.go
@@ -922,7 +922,7 @@ func (r *treeGeneratorImpl_v4) processAttestationsForInterval() error {
 func (r *treeGeneratorImpl_v4) processEpoch(getDuties bool, epoch uint64) error {
 
 	// Get the committee info and attestation records for this epoch
-	var committeeData []beacon.Committee
+	var committeeData beacon.Committees
 	attestationsPerSlot := make([][]beacon.AttestationInfo, r.slotsPerEpoch)
 	var wg errgroup.Group
 
@@ -1011,20 +1011,20 @@ func (r *treeGeneratorImpl_v4) checkDutiesForSlot(attestations []beacon.Attestat
 }
 
 // Maps out the attestaion duties for the given epoch
-func (r *treeGeneratorImpl_v4) getDutiesForEpoch(committees []beacon.Committee) error {
+func (r *treeGeneratorImpl_v4) getDutiesForEpoch(committees beacon.Committees) error {
 
 	// Crawl the committees
-	for _, committee := range committees {
-		slotIndex := committee.Slot
+	for idx := 0; idx < committees.Count(); idx++ {
+		slotIndex := committees.Slot(idx)
 		if slotIndex < r.rewardsFile.ConsensusStartBlock || slotIndex > r.rewardsFile.ConsensusEndBlock {
 			// Ignore slots that are out of bounds
 			continue
 		}
-		committeeIndex := committee.Index
+		committeeIndex := committees.Index(idx)
 
 		// Check if there are any RP validators in this committee
 		rpValidators := map[int]*MinipoolInfo{}
-		for position, validator := range committee.Validators {
+		for position, validator := range committees.Validators(idx) {
 			minipoolInfo, exists := r.validatorIndexMap[validator]
 			if exists {
 				rpValidators[position] = minipoolInfo

--- a/shared/services/rewards/generator-impl-v4.go
+++ b/shared/services/rewards/generator-impl-v4.go
@@ -1013,6 +1013,8 @@ func (r *treeGeneratorImpl_v4) checkDutiesForSlot(attestations []beacon.Attestat
 // Maps out the attestaion duties for the given epoch
 func (r *treeGeneratorImpl_v4) getDutiesForEpoch(committees beacon.Committees) error {
 
+	defer committees.Release()
+
 	// Crawl the committees
 	for idx := 0; idx < committees.Count(); idx++ {
 		slotIndex := committees.Slot(idx)

--- a/shared/services/rewards/generator-impl-v5.go
+++ b/shared/services/rewards/generator-impl-v5.go
@@ -775,7 +775,7 @@ func (r *treeGeneratorImpl_v5) processAttestationsForInterval() error {
 func (r *treeGeneratorImpl_v5) processEpoch(getDuties bool, epoch uint64) error {
 
 	// Get the committee info and attestation records for this epoch
-	var committeeData []beacon.Committee
+	var committeeData beacon.Committees
 	attestationsPerSlot := make([][]beacon.AttestationInfo, r.slotsPerEpoch)
 	var wg errgroup.Group
 
@@ -889,20 +889,20 @@ func (r *treeGeneratorImpl_v5) checkDutiesForSlot(attestations []beacon.Attestat
 }
 
 // Maps out the attestaion duties for the given epoch
-func (r *treeGeneratorImpl_v5) getDutiesForEpoch(committees []beacon.Committee) error {
+func (r *treeGeneratorImpl_v5) getDutiesForEpoch(committees beacon.Committees) error {
 
 	// Crawl the committees
-	for _, committee := range committees {
-		slotIndex := committee.Slot
+	for idx := 0; idx < committees.Count(); idx++ {
+		slotIndex := committees.Slot(idx)
 		if slotIndex < r.rewardsFile.ConsensusStartBlock || slotIndex > r.rewardsFile.ConsensusEndBlock {
 			// Ignore slots that are out of bounds
 			continue
 		}
-		committeeIndex := committee.Index
+		committeeIndex := committees.Index(idx)
 
 		// Check if there are any RP validators in this committee
 		rpValidators := map[int]*MinipoolInfo{}
-		for position, validator := range committee.Validators {
+		for position, validator := range committees.Validators(idx) {
 			minipoolInfo, exists := r.validatorIndexMap[validator]
 			if exists {
 				rpValidators[position] = minipoolInfo

--- a/shared/services/rewards/generator-impl-v5.go
+++ b/shared/services/rewards/generator-impl-v5.go
@@ -891,6 +891,8 @@ func (r *treeGeneratorImpl_v5) checkDutiesForSlot(attestations []beacon.Attestat
 // Maps out the attestaion duties for the given epoch
 func (r *treeGeneratorImpl_v5) getDutiesForEpoch(committees beacon.Committees) error {
 
+	defer committees.Release()
+
 	// Crawl the committees
 	for idx := 0; idx < committees.Count(); idx++ {
 		slotIndex := committees.Slot(idx)


### PR DESCRIPTION
* Change []beacon.Committee to an interface to reduce copying on the hot path
* Allow buffered decoding in the BN std-http-client
* Reuse []string buffers for bn committee responses
* Reuse json.Decoder objects (which have internal buffers) across calls to the beacon node's committees endpoint