### PR TITLE
[FIX] replace broken link in error message

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -331,7 +331,7 @@ func configureService(c *cli.Context) error {
 
 			err = changeNetworks(c, rp, fmt.Sprintf("%s%s", prefix, ApiContainerSuffix))
 			if err != nil {
-				fmt.Printf("%s%s%s\nThe Smartnode could not automatically change networks for you, so you will have to run the steps manually. Please follow the steps laid out in the Node Operator's guide (https://docs.rocketpool.net/guides/node/mainnet.html).\n", colorRed, err.Error(), colorReset)
+				fmt.Printf("%s%s%s\nThe Smartnode could not automatically change networks for you, so you will have to run the steps manually. Please follow the steps laid out in the Node Operator's guide (https://docs.rocketpool.net/guides/node/docker.html).\n", colorRed, err.Error(), colorReset)
 			}
 			return nil
 		}


### PR DESCRIPTION
Hi everyone!

There's an error log when the Smartnode fails to delete a non-existing folder when changing the network in the config:
> The Smartnode could not automatically change networks for you, so you will have to run the steps manually. Please follow the steps laid out in the Node Operator's guide (https://docs.rocketpool.net/guides/node/mainnet.html).

Unless I'm mistaken, in this message, the link is broken.
I suggest replacing it with the [Creating a Standard Rocket Pool Node with Docker
](https://docs.rocketpool.net/guides/node/docker.html) page, but feel free to update my change with another page if it could make more sense.