### PR TITLE
Replace eth1/eth2 with execution/consensus

### DIFF
--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -35,7 +35,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:      "sync",
 				Aliases:   []string{"y"},
-				Usage:     "Get the sync progress of the eth1 and eth2 clients",
+				Usage:     "Get the sync progress of the execution and consensus clients",
 				UsageText: "rocketpool node sync",
 				Action: func(c *cli.Context) error {
 

--- a/rocketpool-cli/node/create-vacant-minipool.go
+++ b/rocketpool-cli/node/create-vacant-minipool.go
@@ -41,7 +41,7 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 		return nil
 	}
 
-	fmt.Println("Your eth2 client is on the correct network.\n")
+	fmt.Println("Your consensus client is on the correct network.\n")
 
 	// Check if the fee distributor has been initialized
 	isInitializedResponse, err := rp.IsFeeDistributorInitialized()

--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -42,7 +42,7 @@ func nodeDeposit(c *cli.Context) error {
 		return nil
 	}
 
-	fmt.Println("Your eth2 client is on the correct network.\n")
+	fmt.Println("Your consensus client is on the correct network.\n")
 
 	// Check if the fee distributor has been initialized
 	isInitializedResponse, err := rp.IsFeeDistributorInitialized()

--- a/rocketpool-cli/service/commands.go
+++ b/rocketpool-cli/service/commands.go
@@ -196,7 +196,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Flags: []cli.Flag{
 					cli.BoolFlag{
 						Name:  "ignore-slash-timer",
-						Usage: "Bypass the safety timer that forces a delay when switching to a new ETH2 client",
+						Usage: "Bypass the safety timer that forces a delay when switching to a new consensus client",
 					},
 					cli.BoolFlag{
 						Name:  "yes, y",
@@ -339,7 +339,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:      "prune-eth1",
 				Aliases:   []string{"n"},
-				Usage:     "Shuts down the main ETH1 client and prunes its database, freeing up disk space, then restarts it when it's done.",
+				Usage:     "Shuts down the main execution client and prunes its database, freeing up disk space, then restarts it when it's done.",
 				UsageText: "rocketpool service prune-eth1",
 				Action: func(c *cli.Context) error {
 
@@ -474,7 +474,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 			{
 				Name:      "resync-eth1",
-				Usage:     fmt.Sprintf("%sDeletes the main ETH1 client's chain data and resyncs it from scratch. Only use this as a last resort!%s", colorRed, colorReset),
+				Usage:     fmt.Sprintf("%sDeletes the main execution client's chain data and resyncs it from scratch. Only use this as a last resort!%s", colorRed, colorReset),
 				UsageText: "rocketpool service resync-eth1",
 				Action: func(c *cli.Context) error {
 
@@ -491,7 +491,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 			{
 				Name:      "resync-eth2",
-				Usage:     fmt.Sprintf("%sDeletes the ETH2 client's chain data and resyncs it from scratch. Only use this as a last resort!%s", colorRed, colorReset),
+				Usage:     fmt.Sprintf("%sDeletes the consensus client's chain data and resyncs it from scratch. Only use this as a last resort!%s", colorRed, colorReset),
 				UsageText: "rocketpool service resync-eth2",
 				Action: func(c *cli.Context) error {
 

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -553,7 +553,7 @@ func startService(c *cli.Context, ignoreConfigSuggestion bool) error {
 		err := checkForValidatorChange(rp, cfg)
 		if err != nil {
 			fmt.Printf("%sWARNING: couldn't verify that the validator container can be safely restarted:\n\t%s\n", colorYellow, err.Error())
-			fmt.Println("If you are changing to a different ETH2 client, it may resubmit an attestation you have already submitted.")
+			fmt.Println("If you are changing to a different consensus client, it may resubmit an attestation you have already submitted.")
 			fmt.Println("This will slash your validator!")
 			fmt.Println("To prevent slashing, you must wait 15 minutes from the time you stopped the clients before starting them again.\n")
 			fmt.Println("**If you did NOT change clients, you can safely ignore this warning.**\n")
@@ -1316,7 +1316,7 @@ func getComposeFiles(c *cli.Context) []string {
 	return c.Parent().StringSlice("compose-file")
 }
 
-// Destroy and resync the eth1 client from scratch
+// Destroy and resync the execution client from scratch
 func resyncEth1(c *cli.Context) error {
 
 	// Get RP client
@@ -1332,8 +1332,8 @@ func resyncEth1(c *cli.Context) error {
 		return fmt.Errorf("Settings file not found. Please run `rocketpool service config` to set up your Smartnode.")
 	}
 
-	fmt.Println("This will delete the chain data of your primary ETH1 client and resync it from scratch.")
-	fmt.Printf("%sYou should only do this if your ETH1 client has failed and can no longer start or sync properly.\nThis is meant to be a last resort.%s\n", colorYellow, colorReset)
+	fmt.Println("This will delete the chain data of your primary execution client and resync it from scratch.")
+	fmt.Printf("%sYou should only do this if your execution client has failed and can no longer start or sync properly.\nThis is meant to be a last resort.%s\n", colorYellow, colorReset)
 
 	// Get the container prefix
 	prefix, err := getContainerPrefix(rp)
@@ -1342,7 +1342,7 @@ func resyncEth1(c *cli.Context) error {
 	}
 
 	// Prompt for confirmation
-	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sAre you SURE you want to delete and resync your main ETH1 client from scratch? This cannot be undone!%s", colorRed, colorReset))) {
+	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sAre you SURE you want to delete and resync your main execution client from scratch? This cannot be undone!%s", colorRed, colorReset))) {
 		fmt.Println("Cancelled.")
 		return nil
 	}
@@ -1391,13 +1391,13 @@ func resyncEth1(c *cli.Context) error {
 		return fmt.Errorf("Error starting Rocket Pool: %s", err)
 	}
 
-	fmt.Printf("\nDone! Your main ETH1 client is now resyncing. You can follow its progress with `rocketpool service logs eth1`.\n")
+	fmt.Printf("\nDone! Your main execution client is now resyncing. You can follow its progress with `rocketpool service logs eth1`.\n")
 
 	return nil
 
 }
 
-// Destroy and resync the eth2 client from scratch
+// Destroy and resync the consensus client from scratch
 func resyncEth2(c *cli.Context) error {
 
 	// Get RP client
@@ -1413,8 +1413,8 @@ func resyncEth2(c *cli.Context) error {
 		return fmt.Errorf("Settings file not found. Please run `rocketpool service config` to set up your Smartnode.")
 	}
 
-	fmt.Println("This will delete the chain data of your ETH2 client and resync it from scratch.")
-	fmt.Printf("%sYou should only do this if your ETH2 client has failed and can no longer start or sync properly.\nThis is meant to be a last resort.%s\n\n", colorYellow, colorReset)
+	fmt.Println("This will delete the chain data of your consensus client and resync it from scratch.")
+	fmt.Printf("%sYou should only do this if your consensus client has failed and can no longer start or sync properly.\nThis is meant to be a last resort.%s\n\n", colorYellow, colorReset)
 
 	// Get the parameters that the selected client doesn't support
 	var unsupportedParams []string
@@ -1445,14 +1445,14 @@ func resyncEth2(c *cli.Context) error {
 		}
 	}
 	if !supportsCheckpointSync {
-		fmt.Printf("%sYour ETH2 client (%s) does not support checkpoint sync.\nIf you have active validators, they %swill be considered offline and will leak ETH%s%s while the client is syncing.%s\n\n", colorRed, clientName, colorBold, colorReset, colorRed, colorReset)
+		fmt.Printf("%sYour consensus client (%s) does not support checkpoint sync.\nIf you have active validators, they %swill be considered offline and will leak ETH%s%s while the client is syncing.%s\n\n", colorRed, clientName, colorBold, colorReset, colorRed, colorReset)
 	} else {
 		// Get the current checkpoint sync URL
 		checkpointSyncUrl := cfg.ConsensusCommon.CheckpointSyncProvider.Value.(string)
 		if checkpointSyncUrl == "" {
-			fmt.Printf("%sYou do not have a checkpoint sync provider configured.\nIf you have active validators, they %swill be considered offline and will lose ETH%s%s until your ETH2 client finishes syncing.\nWe strongly recommend you configure a checkpoint sync provider with `rocketpool service config` so it syncs instantly before running this.%s\n\n", colorRed, colorBold, colorReset, colorRed, colorReset)
+			fmt.Printf("%sYou do not have a checkpoint sync provider configured.\nIf you have active validators, they %swill be considered offline and will lose ETH%s%s until your consensus client finishes syncing.\nWe strongly recommend you configure a checkpoint sync provider with `rocketpool service config` so it syncs instantly before running this.%s\n\n", colorRed, colorBold, colorReset, colorRed, colorReset)
 		} else {
-			fmt.Printf("You have a checkpoint sync provider configured (%s).\nYour ETH2 client will use it to sync to the head of the Beacon Chain instantly after being rebuilt.\n\n", checkpointSyncUrl)
+			fmt.Printf("You have a checkpoint sync provider configured (%s).\nYour consensus client will use it to sync to the head of the Beacon Chain instantly after being rebuilt.\n\n", checkpointSyncUrl)
 		}
 	}
 
@@ -1463,7 +1463,7 @@ func resyncEth2(c *cli.Context) error {
 	}
 
 	// Prompt for confirmation
-	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sAre you SURE you want to delete and resync your main ETH2 client from scratch? This cannot be undone!%s", colorRed, colorReset))) {
+	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sAre you SURE you want to delete and resync your main consensus client from scratch? This cannot be undone!%s", colorRed, colorReset))) {
 		fmt.Println("Cancelled.")
 		return nil
 	}
@@ -1512,7 +1512,7 @@ func resyncEth2(c *cli.Context) error {
 		return fmt.Errorf("Error starting Rocket Pool: %s", err)
 	}
 
-	fmt.Printf("\nDone! Your ETH2 client is now resyncing. You can follow its progress with `rocketpool service logs eth2`.\n")
+	fmt.Printf("\nDone! Your consensus client is now resyncing. You can follow its progress with `rocketpool service logs eth2`.\n")
 
 	return nil
 
@@ -1611,7 +1611,7 @@ func exportEcData(c *cli.Context, targetDir string) error {
 	}
 
 	var result string
-	// If dirty flag is used, copies chain data without stopping the eth1 client.
+	// If dirty flag is used, copies chain data without stopping the execution client.
 	// This requires a second quick pass to sync the remaining files after stopping the client.
 	if !c.Bool("dirty") {
 		fmt.Printf("Stopping %s...\n", executionContainerName)

--- a/rocketpool/api/node/commands.go
+++ b/rocketpool/api/node/commands.go
@@ -37,7 +37,7 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 			{
 				Name:      "sync",
 				Aliases:   []string{"y"},
-				Usage:     "Get the sync progress of the eth1 and eth2 clients",
+				Usage:     "Get the sync progress of the execution and consensus clients",
 				UsageText: "rocketpool api node sync",
 				Action: func(c *cli.Context) error {
 

--- a/rocketpool/node/collectors/beacon-collector.go
+++ b/rocketpool/node/collectors/beacon-collector.go
@@ -28,7 +28,7 @@ type BeaconCollector struct {
 	// The beacon client
 	bc beacon.Client
 
-	// The eth1 client
+	// The execution client
 	ec rocketpool.ExecutionClient
 
 	// The node's address

--- a/rocketpool/node/collectors/node-collector.go
+++ b/rocketpool/node/collectors/node-collector.go
@@ -88,7 +88,7 @@ type NodeCollector struct {
 	// The node's address
 	nodeAddress common.Address
 
-	// The event log interval for the current eth1 client
+	// The event log interval for the current execution client
 	eventLogInterval *big.Int
 
 	// The next block to start from when looking at cumulative RPL rewards

--- a/rocketpool/node/collectors/odao-collector.go
+++ b/rocketpool/node/collectors/odao-collector.go
@@ -9,7 +9,7 @@ import (
 
 // Represents the collector for the ODAO metrics
 type OdaoCollector struct {
-	// The latest block reported by the ETH1 client at the time of collecting the metrics
+	// The latest block reported by the execution client at the time of collecting the metrics
 	currentEth1Block *prometheus.Desc
 
 	// The ETH1 block that was used when reporting the latest prices
@@ -36,7 +36,7 @@ func NewOdaoCollector(rp *rocketpool.RocketPool, stateLocker *StateLocker) *Odao
 	subsystem := "odao"
 	return &OdaoCollector{
 		currentEth1Block: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "current_eth1_block"),
-			"The latest block reported by the ETH1 client at the time of collecting the metrics",
+			"The latest block reported by the execution client at the time of collecting the metrics",
 			nil, nil,
 		),
 		pricesBlock: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "prices_block"),

--- a/rocketpool/node/collectors/trusted-node-collector.go
+++ b/rocketpool/node/collectors/trusted-node-collector.go
@@ -58,7 +58,7 @@ type TrustedNodeCollector struct {
 	cacheTime     time.Time
 	cachedMetrics []prometheus.Metric
 
-	// The event log interval for the current eth1 client
+	// The event log interval for the current execution client
 	eventLogInterval *big.Int
 
 	// The thread-safe locker for the network state

--- a/shared/utils/cli/utils.go
+++ b/shared/utils/cli/utils.go
@@ -115,7 +115,7 @@ func PrettyPrintError(err error) {
 func PrintDepositMismatchError(rpNetwork, beaconNetwork uint64, rpDepositAddress, beaconDepositAddress common.Address) {
 	fmt.Printf("%s***ALERT***\n", colorRed)
 	fmt.Println("YOUR ETH2 CLIENT IS NOT CONNECTED TO THE SAME NETWORK THAT ROCKET POOL IS USING!")
-	fmt.Println("This is likely because your ETH2 client is using the wrong configuration.")
+	fmt.Println("This is likely because your consensus client is using the wrong configuration.")
 	fmt.Println("For the safety of your funds, Rocket Pool will not let you deposit your ETH until this is resolved.")
 	fmt.Println()
 	fmt.Println("To fix it if you are in Docker mode:")

--- a/shared/utils/eth1/eth1.go
+++ b/shared/utils/eth1/eth1.go
@@ -30,7 +30,7 @@ func CheckForNonceOverride(c *cli.Context, opts *bind.TransactOpts) error {
 		// otherwise the user is burning gas for no reason
 		ec, err := services.GetEthClient(c)
 		if err != nil {
-			return fmt.Errorf("Could not retrieve ETH1 client: %w", err)
+			return fmt.Errorf("Could not retrieve execution client: %w", err)
 		}
 
 		// Make sure it's not higher than the next available nonce


### PR DESCRIPTION
eth1/eth2 is an outdated terminology. There's been some work before to rename, e.g. https://github.com/rocket-pool/smartnode/commit/727d7ea2a5987a0f99896422de06a9b36c82e794 but there are some eth1/eth2 left, so the current state is inconsistent. This attempts to fix that.