### PR TITLE
Prevent truncation of user-settings.yml when disk is full by writing to /tmp first and moving the result to user-settings.yml

### DIFF
--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -260,12 +260,11 @@ func (c *Client) LoadBackupConfig() (*config.RocketPoolConfig, error) {
 
 // Save the config
 func (c *Client) SaveConfig(cfg *config.RocketPoolConfig) error {
-	settingsFilePath := filepath.Join(c.configPath, SettingsFile)
-	expandedPath, err := homedir.Expand(settingsFilePath)
+	settingsFileDirectoryPath, err := homedir.Expand(c.configPath)
 	if err != nil {
 		return err
 	}
-	return rp.SaveConfig(cfg, expandedPath)
+	return rp.SaveConfig(cfg, settingsFileDirectoryPath, SettingsFile)
 }
 
 // Remove the upgrade flag file

--- a/shared/utils/rp/config.go
+++ b/shared/utils/rp/config.go
@@ -1,7 +1,9 @@
 package rp
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -38,8 +40,44 @@ func SaveConfig(cfg *config.RocketPoolConfig, path string) error {
 		return fmt.Errorf("could not serialize settings file: %w", err)
 	}
 
-	if err := os.WriteFile(path, configBytes, 0664); err != nil {
+	// Make a tmp file
+	// The empty string directs CreateTemp to use the OS's $TMPDIR (or GetTempPath) on windows
+	// The * in the second string is replaced with random characters by CreateTemp
+	f, err := os.CreateTemp("", "rp-user-settings-new-*.yml")
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("could not create file to save config to disk... do you need to clean your tmpdir (%s)?: %w", os.TempDir(), err)
+		}
+
+		return fmt.Errorf("could not create file to save config to disk: %w", err)
+	}
+	// Clean up the temporary file
+	// This prevents us from filling up TMPDIR with partially written files on failure
+	// If the file is successfully written, it fails with an error since it will be renamed
+	// before it is deleted, which we explicitly ignore / don't care about.
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+
+	// Save the serialized settings to the temporary file
+	if _, err := f.Write(configBytes); err != nil {
 		return fmt.Errorf("could not write Rocket Pool config to %s: %w", shellescape.Quote(path), err)
+	}
+
+	// Close the file for writing
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("error saving Rocket Pool config to %s: %w", shellescape.Quote(path), err)
+	}
+
+	// Rename the temp file to overwrite the actual file.
+	// On Unix systems this operation is atomic and won't fail if the disk is now full
+	if err := os.Rename(f.Name(), path); err != nil {
+		return fmt.Errorf("error replacing old Rocket Pool config with %s: %w", f.Name(), err)
+	}
+
+	// Just in case the rename didn't overwrite (and preserve the perms of) the original file, set them now.
+	if err := os.Chmod(path, 0664); err != nil {
+		return fmt.Errorf("error updating permissions of %s: %w", path, err)
 	}
 
 	return nil


### PR DESCRIPTION
closes https://github.com/rocket-pool/smartnode/issues/401