### PR TITLE
Phase out web3.storage usage

### DIFF
--- a/rocketpool/watchtower/submit-rewards-tree-rolling.go
+++ b/rocketpool/watchtower/submit-rewards-tree-rolling.go
@@ -598,8 +598,9 @@ func (t *submitRewardsTree_Rolling) generateTree(rp *rocketpool.RocketPool, stat
 		// Upload the rewards tree file
 		t.printMessage("Uploading to Web3.Storage and submitting results to the contracts...")
 		cid, err := t.uploadFileToWeb3Storage(wrapperBytes, compressedRewardsTreePath, "compressed rewards tree")
+		// Don't return on error as we're phasing out. Just keep the CID for the submission and users will be able to fetch from different providers
 		if err != nil {
-			return fmt.Errorf("Error uploading Merkle tree to Web3.Storage: %w", err)
+			t.printMessage(fmt.Sprintf("Error uploading Merkle tree to Web3.Storage: %w", err))
 		}
 		t.printMessage(fmt.Sprintf("Uploaded Merkle tree with CID %s", cid))
 

--- a/shared/services/config/smartnode-config.go
+++ b/shared/services/config/smartnode-config.go
@@ -30,6 +30,7 @@ const (
 	PrimaryRewardsFileUrl              string = "https://%s.ipfs.dweb.link/%s"
 	SecondaryRewardsFileUrl            string = "https://ipfs.io/ipfs/%s/%s"
 	GithubRewardsFileUrl               string = "https://github.com/rocket-pool/rewards-trees/raw/main/%s/%s"
+	RescueNodeRewardsFileUrl           string = "https://rescuenode.com/rewards-trees/%s/%s"
 	FeeRecipientFilename               string = "rp-fee-recipient.txt"
 	NativeFeeRecipientFilename         string = "rp-fee-recipient-env.txt"
 )
@@ -78,6 +79,9 @@ type SmartnodeConfig struct {
 
 	// Mode for acquiring Merkle rewards trees
 	RewardsTreeMode config.Parameter `yaml:"rewardsTreeMode,omitempty"`
+
+	// Custom URL to download a rewards tree
+	RewardsTreeCustomUrl config.Parameter `yaml:"rewardsTreeCustomUrl,omitempty"`
 
 	// URL for an EC with archive mode, for manual rewards tree generation
 	ArchiveECUrl config.Parameter `yaml:"archiveEcUrl,omitempty"`
@@ -323,6 +327,18 @@ func NewSmartnodeConfig(cfg *RocketPoolConfig) *SmartnodeConfig {
 			ID:                   "archiveECUrl",
 			Name:                 "Archive-Mode EC URL",
 			Description:          "[orange]**For manual Merkle rewards tree generation only.**[white]\n\nGenerating the Merkle rewards tree files for past rewards intervals typically requires an Execution client with Archive mode enabled, which is usually disabled on your primary and fallback Execution clients to save disk space.\nIf you want to generate your own rewards tree files for intervals from a long time ago, you may enter the URL of an Execution client with Archive access here.\n\nFor a free light client with Archive access, you may use https://www.alchemy.com/supernode.",
+			Type:                 config.ParameterType_String,
+			Default:              map[config.Network]interface{}{config.Network_All: ""},
+			AffectsContainers:    []config.ContainerID{config.ContainerID_Watchtower},
+			EnvironmentVariables: []string{},
+			CanBeBlank:           true,
+			OverwriteOnUpgrade:   false,
+		},
+
+		RewardsTreeCustomUrl: config.Parameter{
+			ID:                   "rewardsTreeCustomUrl",
+			Name:                 "Rewards tree custom download URLs",
+			Description:          "[orange]**Only used if you want an extra source to download rewards tree files.**[white]\n\nThe smartnode will automatically try to download rewards tree files from multiple sources like IPFS, GitHub, rescuenode.com. Use this field if you want to provide a extra URL for the download (multiple URLs can be provided using ';' as separator).\nUsers don't need to trust any of the file sources as the content will need to match what was voted by the oDAO.",
 			Type:                 config.ParameterType_String,
 			Default:              map[config.Network]interface{}{config.Network_All: ""},
 			AffectsContainers:    []config.ContainerID{config.ContainerID_Watchtower},

--- a/shared/services/rewards/utils.go
+++ b/shared/services/rewards/utils.go
@@ -272,6 +272,13 @@ func DownloadRewardsFile(cfg *config.RocketPoolConfig, interval uint64, cid stri
 		fmt.Sprintf(config.PrimaryRewardsFileUrl, cid, ipfsFilename),
 		fmt.Sprintf(config.SecondaryRewardsFileUrl, cid, ipfsFilename),
 		fmt.Sprintf(config.GithubRewardsFileUrl, string(cfg.Smartnode.Network.Value.(cfgtypes.Network)), rewardsTreeFilename),
+		fmt.Sprintf(config.RescueNodeRewardsFileUrl, string(cfg.Smartnode.Network.Value.(cfgtypes.Network)), rewardsTreeFilename),
+	}
+
+	rewardsTreeCustomUrl := cfg.Smartnode.RewardsTreeCustomUrl.Value.(string)
+	if len(rewardsTreeCustomUrl) != 0 {
+		splitRewardsTreeCustomUrls := strings.Split(rewardsTreeCustomUrl, ";")
+		urls = append(urls, splitRewardsTreeCustomUrls...)
 	}
 
 	// Attempt downloads


### PR DESCRIPTION
- Won't fail if web3.storage uploads fail (will continue with submission flow using the CID)
- Adds rescuenode.com as a trusted provider for rewards trees files
- Users can provide one (or more) custom download URLs