### PR TITLE
Dedup calls to LoadConfig

### DIFF
--- a/rocketpool-cli/network/dao-proposals.go
+++ b/rocketpool-cli/network/dao-proposals.go
@@ -20,8 +20,14 @@ func getActiveDAOProposals(c *cli.Context) error {
 	}
 	defer rp.Close()
 
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
 	// Print what network we're on
-	err = cliutils.PrintNetwork(rp)
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -30,8 +30,14 @@ func getStatus(c *cli.Context) error {
 	rp := rocketpool.NewClientFromCtx(c)
 	defer rp.Close()
 
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
 	// Print what network we're on
-	err := cliutils.PrintNetwork(rp)
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}
@@ -40,12 +46,6 @@ func getStatus(c *cli.Context) error {
 	status, err := rp.NodeStatus()
 	if err != nil {
 		return err
-	}
-
-	// Get the config
-	cfg, _, err := rp.LoadConfig()
-	if err != nil {
-		return fmt.Errorf("Error loading configuration: %w", err)
 	}
 
 	// Account address & balances

--- a/rocketpool-cli/node/sync.go
+++ b/rocketpool-cli/node/sync.go
@@ -53,8 +53,14 @@ func getSyncProgress(c *cli.Context) error {
 	rp := rocketpool.NewClientFromCtx(c)
 	defer rp.Close()
 
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
 	// Print what network we're on
-	err := cliutils.PrintNetwork(rp)
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -182,8 +182,14 @@ func serviceStatus(c *cli.Context) error {
 	rp := rocketpool.NewClientFromCtx(c)
 	defer rp.Close()
 
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
 	// Print what network we're on
-	err := cliutils.PrintNetwork(rp)
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}
@@ -1223,8 +1229,14 @@ func serviceVersion(c *cli.Context) error {
 	rp := rocketpool.NewClientFromCtx(c)
 	defer rp.Close()
 
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
 	// Print what network we're on
-	err := cliutils.PrintNetwork(rp)
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}
@@ -1233,15 +1245,6 @@ func serviceVersion(c *cli.Context) error {
 	serviceVersion, err := rp.GetServiceVersion()
 	if err != nil {
 		return err
-	}
-
-	// Get config
-	cfg, isNew, err := rp.LoadConfig()
-	if err != nil {
-		return err
-	}
-	if isNew {
-		return fmt.Errorf("Settings file not found. Please run `rocketpool service config` to set up your Smartnode.")
 	}
 
 	// Handle native mode

--- a/rocketpool-cli/wallet/status.go
+++ b/rocketpool-cli/wallet/status.go
@@ -15,8 +15,14 @@ func getStatus(c *cli.Context) error {
 	rp := rocketpool.NewClientFromCtx(c)
 	defer rp.Close()
 
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
 	// Print what network we're on
-	err := cliutils.PrintNetwork(rp)
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}

--- a/shared/services/config/rocket-pool-config.go
+++ b/shared/services/config/rocket-pool-config.go
@@ -1173,6 +1173,10 @@ func (cfg *RocketPoolConfig) Validate() []string {
 	return errors
 }
 
+func (cfg *RocketPoolConfig) GetNetwork() config.Network {
+	return cfg.Smartnode.Network.Value.(config.Network)
+}
+
 // Applies all of the defaults to all of the settings that have them defined
 func (cfg *RocketPoolConfig) applyAllDefaults() error {
 	for _, param := range cfg.GetParameters() {

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -228,6 +228,7 @@ func (c *Client) Close() {
 }
 
 // Load the config
+// Returns the RocketPoolConfig and whether or not it was newly generated
 func (c *Client) LoadConfig() (*config.RocketPoolConfig, bool, error) {
 	settingsFilePath := filepath.Join(c.configPath, SettingsFile)
 	expandedPath, err := homedir.Expand(settingsFilePath)
@@ -240,12 +241,13 @@ func (c *Client) LoadConfig() (*config.RocketPoolConfig, bool, error) {
 		return nil, false, err
 	}
 
-	isNew := false
-	if cfg == nil {
-		cfg = config.NewRocketPoolConfig(c.configPath, c.daemonPath != "")
-		isNew = true
+	if cfg != nil {
+		// A config was loaded, return it now
+		return cfg, false, nil
 	}
-	return cfg, isNew, nil
+
+	// Config wasn't loaded, but there was no error- we should create one.
+	return config.NewRocketPoolConfig(c.configPath, c.daemonPath != ""), true, nil
 }
 
 // Load the backup config

--- a/shared/utils/cli/utils.go
+++ b/shared/utils/cli/utils.go
@@ -129,16 +129,11 @@ func PrintDepositMismatchError(rpNetwork, beaconNetwork uint64, rpDepositAddress
 }
 
 // Prints what network you're currently on
-func PrintNetwork(rp *rocketpool.Client) error {
-	cfg, isNew, err := rp.LoadConfig()
-	if err != nil {
-		return fmt.Errorf("Error loading global config: %w", err)
-	}
+func PrintNetwork(currentNetwork cfgtypes.Network, isNew bool) error {
 	if isNew {
 		return fmt.Errorf("Settings file not found. Please run `rocketpool service config` to set up your Smartnode.")
 	}
 
-	currentNetwork := cfg.Smartnode.Network.Value.(cfgtypes.Network)
 	switch currentNetwork {
 	case cfgtypes.Network_Mainnet:
 		fmt.Printf("Your Smartnode is currently using the %sEthereum Mainnet.%s\n\n", colorGreen, colorReset)


### PR DESCRIPTION
We often call `cliutils.PrintNetwork(rp)`, which in turn calls `rp.LoadConfig()`, which then discards the result before it returns. The same functions often proceed to call `rp.LoadConfig()` again.

This isn't ideal for two reasons:
1) If LoadConfig ever has side-effects, it may not be reentrant
2) We parse stuff twice, which isn't slow but it isn't fast either.

Instead we can just add a function on RocketPoolConfig to get the network, and change `cliutils.PrintNetwork` to take that as an argument.