### PR TITLE
Print total node weight in treegen logs

### DIFF
--- a/shared/services/rewards/generator-impl-v8.go
+++ b/shared/services/rewards/generator-impl-v8.go
@@ -498,7 +498,10 @@ func (r *treeGeneratorImpl_v8) calculateRplRewards() error {
 	// Get actual protocol DAO rewards
 	pDaoRewards.Sub(&pDaoRewards.Int, totalCalculatedOdaoRewards)
 	r.rewardsFile.TotalRewards.ProtocolDaoRpl = pDaoRewards
-	r.log.Printlnf("%s Actual Protocol DAO rewards:   %s to account for truncation", r.logPrefix, pDaoRewards.String())
+	r.log.Printlnf("%s Actual Protocol DAO rewards:  %s to account for truncation", r.logPrefix, pDaoRewards.String())
+
+	// Print total node weight
+	r.log.Printlnf("%s Total Node Weight:            %s", r.logPrefix, totalNodeWeight)
 
 	return nil
 


### PR DESCRIPTION
```
2024/01/10 02:44:48  Calculated rewards:           37457092819124878921189 (error = 1978 wei)
2024/01/10 02:44:48  Total Oracle DAO RPL rewards: 3157097823326239794952 (3157.098)
2024/01/10 02:44:48  Calculated rewards:           3157097823326239794936 (error = 16 wei)
2024/01/10 02:44:48  Actual Protocol DAO rewards:  12895941956298708316972 to account for truncation
2024/01/10 02:44:48  Total Node Weight:            6726637820256974218802831
```