### PR TITLE
Add local file abstraction for treegen and fix compression bugs with cid calculation

### DIFF
--- a/rocketpool/watchtower/generate-rewards-tree.go
+++ b/rocketpool/watchtower/generate-rewards-tree.go
@@ -248,28 +248,24 @@ func (t *generateRewardsTree) generateRewardsTreeImpl(rp *rocketpool.RocketPool,
 	// Create the JSON files
 	rewardsFile.SetMinipoolPerformanceFileCID("---")
 	t.log.Printlnf("%s Saving JSON files...", generationPrefix)
-	minipoolPerformanceBytes, err := rewardsFile.GetMinipoolPerformanceFile().Serialize()
-	if err != nil {
-		t.handleError(fmt.Errorf("%s Error serializing minipool performance file into JSON: %w", generationPrefix, err))
-		return
-	}
-	wrapperBytes, err := rewardsFile.Serialize()
-	if err != nil {
-		t.handleError(fmt.Errorf("%s Error serializing proof wrapper into JSON: %w", generationPrefix, err))
-		return
-	}
+	localMinipoolPerformanceFile := rprewards.NewLocalFile[rprewards.IMinipoolPerformanceFile](
+		rewardsFile.GetMinipoolPerformanceFile(),
+		t.cfg.Smartnode.GetMinipoolPerformancePath(index, true),
+	)
+	localRewardsFile := rprewards.NewLocalFile[rprewards.IRewardsFile](
+		rewardsFile,
+		t.cfg.Smartnode.GetRewardsTreePath(index, true),
+	)
 
 	// Write the files
-	path := t.cfg.Smartnode.GetRewardsTreePath(index, true)
-	minipoolPerformancePath := t.cfg.Smartnode.GetMinipoolPerformancePath(index, true)
-	err = os.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
+	err = localMinipoolPerformanceFile.Write()
 	if err != nil {
-		t.handleError(fmt.Errorf("%s Error saving minipool performance file to %s: %w", generationPrefix, minipoolPerformancePath, err))
+		t.handleError(fmt.Errorf("%s %w", generationPrefix, err))
 		return
 	}
-	err = os.WriteFile(path, wrapperBytes, 0644)
+	err = localRewardsFile.Write()
 	if err != nil {
-		t.handleError(fmt.Errorf("%s Error saving rewards file to %s: %w", generationPrefix, path, err))
+		t.handleError(fmt.Errorf("%s %w", generationPrefix, err))
 		return
 	}
 

--- a/rocketpool/watchtower/generate-rewards-tree.go
+++ b/rocketpool/watchtower/generate-rewards-tree.go
@@ -260,12 +260,12 @@ func (t *generateRewardsTree) generateRewardsTreeImpl(rp *rocketpool.RocketPool,
 	// Write the files
 	err = localMinipoolPerformanceFile.Write()
 	if err != nil {
-		t.handleError(fmt.Errorf("%s %w", generationPrefix, err))
+		t.handleError(fmt.Errorf("%s error saving minipool performance file: %w", generationPrefix, err))
 		return
 	}
 	err = localRewardsFile.Write()
 	if err != nil {
-		t.handleError(fmt.Errorf("%s %w", generationPrefix, err))
+		t.handleError(fmt.Errorf("%s error saving rewards file: %w", generationPrefix, err))
 		return
 	}
 

--- a/rocketpool/watchtower/submit-rewards-tree-rolling.go
+++ b/rocketpool/watchtower/submit-rewards-tree-rolling.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/big"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -249,8 +248,7 @@ func (t *submitRewardsTree_Rolling) run(headState *state.NetworkState) error {
 		// Run updates and submissions as required
 		if isRewardsReadyForReport {
 			// Check if there's an existing file for this interval, and try submitting that
-			rewardsTreePath := t.cfg.Smartnode.GetRewardsTreePath(headState.NetworkDetails.RewardIndex, true)
-			existingRewardsFile, fileBytes, valid, mustRegenerate := t.isExistingFileValid(rewardsTreePath, intervalsPassed, nodeAddress, isInOdao)
+			existingRewardsFile, valid, mustRegenerate := t.isExistingFileValid(headState.NetworkDetails.RewardIndex, intervalsPassed, nodeAddress, isInOdao)
 			if existingRewardsFile != nil {
 				if valid && !mustRegenerate {
 					// We already have a valid file and submission
@@ -298,7 +296,7 @@ func (t *submitRewardsTree_Rolling) run(headState *state.NetworkState) error {
 
 			// Process the rewards interval
 			t.log.Printlnf("%s Running rewards interval submission.", t.logPrefix)
-			err = t.runRewardsIntervalReport(client, state, isInOdao, intervalsPassed, startTime, endTime, mustRegenerate, existingRewardsFile, fileBytes)
+			err = t.runRewardsIntervalReport(client, state, isInOdao, intervalsPassed, startTime, endTime, mustRegenerate, existingRewardsFile)
 			if err != nil {
 				t.handleError(fmt.Errorf("error running rewards interval report: %w", err))
 				return
@@ -391,39 +389,35 @@ func (t *submitRewardsTree_Rolling) getTrueRewardsIntervalSubmissionSlot(targetS
 }
 
 // Checks to see if an existing rewards file is still valid and whether or not it should be regenerated or just resubmitted
-func (t *submitRewardsTree_Rolling) isExistingFileValid(rewardsTreePath string, intervalsPassed uint64, nodeAddress common.Address, isInOdao bool) (rprewards.IRewardsFile, []byte, bool, bool) {
+func (t *submitRewardsTree_Rolling) isExistingFileValid(rewardIndex uint64, intervalsPassed uint64, nodeAddress common.Address, isInOdao bool) (*rprewards.LocalRewardsFile, bool, bool) {
+	rewardsTreePath := t.cfg.Smartnode.GetRewardsTreePath(rewardIndex, true)
+
 	// Check if the rewards file exists
 	_, err := os.Stat(rewardsTreePath)
 	if os.IsNotExist(err) {
-		return nil, nil, false, true
+		return nil, false, true
 	}
 	if err != nil {
 		t.log.Printlnf("%s WARNING: failed to check if [%s] exists: %s; regenerating file...\n", t.logPrefix, rewardsTreePath, err.Error())
-		return nil, nil, false, true
+		return nil, false, true
 	}
 
 	// The file already exists, attempt to read it
-	filename := filepath.Base(rewardsTreePath)
-	fileBytes, err := os.ReadFile(rewardsTreePath)
+	localRewardsFile, err := rprewards.ReadLocalRewardsFile(rewardsTreePath)
 	if err != nil {
 		t.log.Printlnf("%s WARNING: failed to read %s: %s; regenerating file...\n", t.logPrefix, rewardsTreePath, err.Error())
-		return nil, nil, false, true
+		return nil, false, true
 	}
 
-	// Unmarshal it
-	proofWrapper, err := rprewards.DeserializeRewardsFile(fileBytes)
-	if err != nil {
-		t.log.Printlnf("%s WARNING: failed to deserialize %s: %s; regenerating file...\n", t.logPrefix, rewardsTreePath, err.Error())
-		return nil, nil, false, true
-	}
+	proofWrapper := localRewardsFile.Repr()
 	header := proofWrapper.GetHeader()
 
 	if isInOdao {
 		// Get the CID for it
-		cid, err := rprewards.GetCidForRewardsFile(proofWrapper, filename)
+		cid, err := localRewardsFile.CompressedCid()
 		if err != nil {
 			t.log.Printlnf("%s WARNING: failed to get CID for %s: %s; regenerating file...\n", t.logPrefix, rewardsTreePath, err.Error())
-			return nil, nil, false, true
+			return nil, false, true
 		}
 
 		// Check if this file has already been submitted
@@ -444,30 +438,30 @@ func (t *submitRewardsTree_Rolling) isExistingFileValid(rewardsTreePath string, 
 		hasSubmitted, err := rewards.GetTrustedNodeSubmittedSpecificRewards(t.rp, nodeAddress, submission, nil)
 		if err != nil {
 			t.log.Printlnf("%s WARNING: could not check if node has previously submitted file %s: %s; regenerating file...\n", t.logPrefix, rewardsTreePath, err.Error())
-			return nil, nil, false, true
+			return nil, false, true
 		}
 		if !hasSubmitted {
 			if header.IntervalsPassed != intervalsPassed {
 				t.log.Printlnf("%s Existing file for interval %d had %d intervals passed but %d have passed now, regenerating file...", t.logPrefix, header.Index, header.IntervalsPassed, intervalsPassed)
-				return proofWrapper, fileBytes, false, true
+				return localRewardsFile, false, true
 			}
 			t.log.Printlnf("%s Existing file for interval %d has not been submitted yet.", t.logPrefix, header.Index)
-			return proofWrapper, fileBytes, false, false
+			return localRewardsFile, false, false
 		}
 	}
 
 	// Check if the file's valid (same number of intervals passed as the current time)
 	if header.IntervalsPassed != intervalsPassed {
 		t.log.Printlnf("%s Existing file for interval %d had %d intervals passed but %d have passed now, regenerating file...", t.logPrefix, header.Index, header.IntervalsPassed, intervalsPassed)
-		return proofWrapper, fileBytes, false, true
+		return localRewardsFile, false, true
 	}
 
 	// File's good and it has the same number of intervals passed, so use it
-	return proofWrapper, fileBytes, true, false
+	return localRewardsFile, true, false
 }
 
 // Run a rewards interval report submission
-func (t *submitRewardsTree_Rolling) runRewardsIntervalReport(client *rocketpool.RocketPool, state *state.NetworkState, isInOdao bool, intervalsPassed uint64, startTime time.Time, endTime time.Time, mustRegenerate bool, existingRewardsFile rprewards.IRewardsFile, fileBytes []byte) error {
+func (t *submitRewardsTree_Rolling) runRewardsIntervalReport(client *rocketpool.RocketPool, state *state.NetworkState, isInOdao bool, intervalsPassed uint64, startTime time.Time, endTime time.Time, mustRegenerate bool, existingRewardsFile *rprewards.LocalRewardsFile) error {
 	// Prep the record for reporting
 	err := t.recordMgr.PrepareRecordForReport(state)
 	if err != nil {
@@ -504,14 +498,14 @@ func (t *submitRewardsTree_Rolling) runRewardsIntervalReport(client *rocketpool.
 
 		t.log.Printlnf("%s Merkle rewards tree for interval %d already exists at %s, attempting to resubmit...", t.logPrefix, currentIndex, rewardsTreePath)
 
-		cid, err := rprewards.SingleFileDirIPFSCid(fileBytes, compressedRewardsTreePath, "compressed rewards tree")
+		cid, err := existingRewardsFile.CompressedCid()
 		if err != nil {
 			return fmt.Errorf("error getting CID for file %s: %w", compressedRewardsTreePath, err)
 		}
 		t.printMessage(fmt.Sprintf("Calculated rewards tree CID: %s", cid))
 
 		// Submit to the contracts
-		err = t.submitRewardsSnapshot(currentIndexBig, snapshotBeaconBlock, elBlockIndex, existingRewardsFile.GetHeader(), cid.String(), big.NewInt(int64(intervalsPassed)))
+		err = t.submitRewardsSnapshot(currentIndexBig, snapshotBeaconBlock, elBlockIndex, existingRewardsFile.Repr().GetHeader(), cid.String(), big.NewInt(int64(intervalsPassed)))
 		if err != nil {
 			return fmt.Errorf("error submitting rewards snapshot: %w", err)
 		}
@@ -552,19 +546,17 @@ func (t *submitRewardsTree_Rolling) generateTree(rp *rocketpool.RocketPool, stat
 	}
 
 	// Serialize the minipool performance file
-	minipoolPerformanceBytes, err := rewardsFile.GetMinipoolPerformanceFile().Serialize()
+	localMinipoolPerformanceFile := rprewards.NewLocalFile[rprewards.IMinipoolPerformanceFile](
+		rewardsFile.GetMinipoolPerformanceFile(),
+		minipoolPerformancePath,
+	)
+	err = localMinipoolPerformanceFile.Write()
 	if err != nil {
 		return fmt.Errorf("Error serializing minipool performance file into JSON: %w", err)
 	}
 
-	// Write it to disk
-	err = os.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
-	if err != nil {
-		return fmt.Errorf("Error saving minipool performance file to %s: %w", minipoolPerformancePath, err)
-	}
-
 	if nodeTrusted {
-		minipoolPerformanceCid, err := rprewards.SingleFileDirIPFSCid(minipoolPerformanceBytes, compressedMinipoolPerformancePath, "compressed minipool performance")
+		minipoolPerformanceCid, err := localMinipoolPerformanceFile.CompressedCid()
 		if err != nil {
 			return fmt.Errorf("Error getting the CID for file %s: %w", compressedMinipoolPerformancePath, err)
 		}
@@ -576,20 +568,20 @@ func (t *submitRewardsTree_Rolling) generateTree(rp *rocketpool.RocketPool, stat
 	}
 
 	// Serialize the rewards tree to JSON
-	wrapperBytes, err := rewardsFile.Serialize()
-	if err != nil {
-		return fmt.Errorf("Error serializing proof wrapper into JSON: %w", err)
-	}
+	localRewardsFile := rprewards.NewLocalFile[rprewards.IRewardsFile](
+		rewardsFile,
+		rewardsTreePath,
+	)
 	t.printMessage("Generation complete! Saving tree...")
 
 	// Write the rewards tree to disk
-	err = os.WriteFile(rewardsTreePath, wrapperBytes, 0644)
+	err = localRewardsFile.Write()
 	if err != nil {
 		return fmt.Errorf("Error saving rewards tree file to %s: %w", rewardsTreePath, err)
 	}
 
 	if nodeTrusted {
-		cid, err := rprewards.SingleFileDirIPFSCid(wrapperBytes, compressedRewardsTreePath, "compressed rewards tree")
+		cid, err := localRewardsFile.CompressedCid()
 		if err != nil {
 			return fmt.Errorf("Error getting CID for file %s: %w", compressedRewardsTreePath, err)
 		}

--- a/rocketpool/watchtower/submit-rewards-tree-stateless.go
+++ b/rocketpool/watchtower/submit-rewards-tree-stateless.go
@@ -205,17 +205,14 @@ func (t *submitRewardsTree_Stateless) Run(nodeTrusted bool, state *state.Network
 		t.log.Printlnf("Merkle rewards tree for interval %d already exists at %s, attempting to resubmit...", currentIndex, rewardsTreePath)
 
 		// Deserialize the file
-		wrapperBytes, err := os.ReadFile(rewardsTreePath)
+		localRewardsFile, err := rprewards.ReadLocalRewardsFile(rewardsTreePath)
 		if err != nil {
 			return fmt.Errorf("Error reading rewards tree file: %w", err)
 		}
 
-		proofWrapper, err := rprewards.DeserializeRewardsFile(wrapperBytes)
-		if err != nil {
-			return fmt.Errorf("Error deserializing rewards tree file: %w", err)
-		}
+		proofWrapper := localRewardsFile.Repr()
 
-		cid, err := rprewards.SingleFileDirIPFSCid(wrapperBytes, compressedRewardsTreePath, "compressed rewards tree")
+		cid, err := localRewardsFile.CompressedCid()
 		if err != nil {
 			return fmt.Errorf("Error getting CID for file %s: %w", compressedRewardsTreePath, err)
 		}
@@ -257,32 +254,32 @@ func (t *submitRewardsTree_Stateless) printMessage(message string) {
 func (t *submitRewardsTree_Stateless) isExistingFileValid(rewardsTreePath string, intervalsPassed uint64) bool {
 
 	_, err := os.Stat(rewardsTreePath)
-	if !os.IsNotExist(err) {
-		// The file already exists, attempt to read it
-		fileBytes, err := os.ReadFile(rewardsTreePath)
-		if err != nil {
-			t.log.Printlnf("WARNING: failed to read %s: %s\nRegenerating file...\n", rewardsTreePath, err.Error())
-			return false
-		}
-
-		proofWrapper, err := rprewards.DeserializeRewardsFile(fileBytes)
-		if err != nil {
-			t.log.Printlnf("WARNING: failed to deserialize %s: %s\nRegenerating file...\n", rewardsTreePath, err.Error())
-			return false
-		}
-
-		// Compare the number of intervals in it with the current number of intervals
-		header := proofWrapper.GetHeader()
-		if header.IntervalsPassed != intervalsPassed {
-			t.log.Printlnf("Existing file for interval %d had %d intervals passed but %d have passed now, regenerating file...\n", header.Index, header.IntervalsPassed, intervalsPassed)
-			return false
-		}
-
-		// File's good and it has the same number of intervals passed, so use it
-		return true
+	if os.IsNotExist(err) {
+		return false
 	}
 
-	return false
+	// The file already exists, attempt to read it
+	localRewardsFile, err := rprewards.ReadLocalRewardsFile(rewardsTreePath)
+	if err != nil {
+		t.log.Printlnf("WARNING: failed to read %s: %s\nRegenerating file...\n", rewardsTreePath, err.Error())
+		return false
+	}
+
+	proofWrapper := localRewardsFile.Repr()
+	if err != nil {
+		t.log.Printlnf("WARNING: failed to deserialize %s: %s\nRegenerating file...\n", rewardsTreePath, err.Error())
+		return false
+	}
+
+	// Compare the number of intervals in it with the current number of intervals
+	header := proofWrapper.GetHeader()
+	if header.IntervalsPassed != intervalsPassed {
+		t.log.Printlnf("Existing file for interval %d had %d intervals passed but %d have passed now, regenerating file...\n", header.Index, header.IntervalsPassed, intervalsPassed)
+		return false
+	}
+
+	// File's good and it has the same number of intervals passed, so use it
+	return true
 
 }
 
@@ -349,19 +346,19 @@ func (t *submitRewardsTree_Stateless) generateTreeImpl(rp *rocketpool.RocketPool
 	}
 
 	// Serialize the minipool performance file
-	minipoolPerformanceBytes, err := rewardsFile.GetMinipoolPerformanceFile().Serialize()
-	if err != nil {
-		return fmt.Errorf("Error serializing minipool performance file into JSON: %w", err)
-	}
+	localMinipoolPerformanceFile := rprewards.NewLocalFile[rprewards.IMinipoolPerformanceFile](
+		rewardsFile.GetMinipoolPerformanceFile(),
+		minipoolPerformancePath,
+	)
 
 	// Write it to disk
-	err = os.WriteFile(minipoolPerformancePath, minipoolPerformanceBytes, 0644)
+	err = localMinipoolPerformanceFile.Write()
 	if err != nil {
 		return fmt.Errorf("Error saving minipool performance file to %s: %w", minipoolPerformancePath, err)
 	}
 
 	if nodeTrusted {
-		minipoolPerformanceCid, err := rprewards.SingleFileDirIPFSCid(minipoolPerformanceBytes, compressedMinipoolPerformancePath, "compressed minipool performance")
+		minipoolPerformanceCid, err := localMinipoolPerformanceFile.CompressedCid()
 		if err != nil {
 			return fmt.Errorf("Error getting CID for file %s: %w", compressedMinipoolPerformancePath, err)
 		}
@@ -373,20 +370,20 @@ func (t *submitRewardsTree_Stateless) generateTreeImpl(rp *rocketpool.RocketPool
 	}
 
 	// Serialize the rewards tree to JSON
-	wrapperBytes, err := rewardsFile.Serialize()
-	if err != nil {
-		return fmt.Errorf("Error serializing proof wrapper into JSON: %w", err)
-	}
+	localRewardsFile := rprewards.NewLocalFile[rprewards.IRewardsFile](
+		rewardsFile,
+		rewardsTreePath,
+	)
 	t.printMessage("Generation complete! Saving tree...")
 
 	// Write the rewards tree to disk
-	err = os.WriteFile(rewardsTreePath, wrapperBytes, 0644)
+	err = localRewardsFile.Write()
 	if err != nil {
 		return fmt.Errorf("Error saving rewards tree file to %s: %w", rewardsTreePath, err)
 	}
 
 	if nodeTrusted {
-		cid, err := rprewards.SingleFileDirIPFSCid(wrapperBytes, compressedRewardsTreePath, "compressed rewards tree")
+		cid, err := localRewardsFile.CompressedCid()
 		if err != nil {
 			return fmt.Errorf("Error getting CID for file %s : %w", rewardsTreePath, err)
 		}

--- a/shared/services/rewards/cid-calculator.go
+++ b/shared/services/rewards/cid-calculator.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	blockservice "github.com/ipfs/boxo/blockservice"
@@ -18,35 +17,25 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
-	"github.com/klauspost/compress/zstd"
 )
 
-func SingleFileDirIPFSCid(data []byte, filename string, description string) (cid.Cid, error) {
-	// Compress the file
-	encoder, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBestCompression))
-	compressedBytes := encoder.EncodeAll(data, make([]byte, 0, len(data)))
-
-	// Create the compressed file
-	compressedFile, err := os.Create(filename)
-	if err != nil {
-		return cid.Cid{}, fmt.Errorf("error creating %s file [%s]: %w", description, filename, err)
-	}
-	defer compressedFile.Close()
-
-	// Write the compressed data to the file
-	_, err = compressedFile.Write(compressedBytes)
-	if err != nil {
-		return cid.Cid{}, fmt.Errorf("error writing %s to %s: %w", description, filename, err)
-	}
-
+// Computes the CID for an arbitrary bytestring with a given filename
+// by adding the file to an empty directory at the root level of the IPFS node.
+//
+// Only the last segment of the filename will be used, ie, `/home/alice/foo.zip`
+// will be stripped to `foo.zip`.
+func singleFileDirIPFSCid(data []byte, filename string) (cid.Cid, error) {
 	ds := sync.MutexWrap(datastore.NewMapDatastore())
 	bsvc := blockservice.New(blockstore.NewBlockstore(ds), nil)
 	dag := merkledag.NewDAGService(bsvc)
 	cidBuilder := merkledag.V1CidPrefix()
 
+	// Strip the leading path segments to get the file name
+	filename = filepath.Base(filename)
+
 	// Create the root node, an empty directory
 	rootNode := unixfs.EmptyDirNode()
-	err = rootNode.SetCidBuilder(cidBuilder)
+	err := rootNode.SetCidBuilder(cidBuilder)
 	if err != nil {
 		return cid.Cid{}, fmt.Errorf("error creating the CID builder: %w", err)
 	}
@@ -56,7 +45,7 @@ func SingleFileDirIPFSCid(data []byte, filename string, description string) (cid
 	}
 
 	// Create a chunker-reader from the compressed data
-	chnk, err := chunker.FromString(bytes.NewReader(compressedBytes), "size-1048576")
+	chnk, err := chunker.FromString(bytes.NewReader(data), "size-1048576")
 	if err != nil {
 		return cid.Cid{}, fmt.Errorf("error creating chunker-reader from compressed bytes: %w", err)
 	}
@@ -78,7 +67,6 @@ func SingleFileDirIPFSCid(data []byte, filename string, description string) (cid
 		return cid.Cid{}, fmt.Errorf("error creating DAG layout: %w", err)
 	}
 
-	filename = filepath.Base(filename)
 	// Add the file to the root directory
 	err = mfs.PutNode(root, filename, node)
 	if err != nil {

--- a/shared/services/rewards/files.go
+++ b/shared/services/rewards/files.go
@@ -1,0 +1,122 @@
+package rewards
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ipfs/go-cid"
+	"github.com/klauspost/compress/zstd"
+	"github.com/rocket-pool/smartnode/shared/services/config"
+)
+
+type ILocalFile interface {
+	Serialize() ([]byte, error)
+}
+
+// A wrapper around ILocalFile representing a local rewards file or minipool performance file.
+// Can be used with anything that can be serialzed to bytes or parsed from bytes.
+type LocalFile[T ILocalFile] struct {
+	f        T
+	fullPath string
+}
+
+type LocalRewardsFile = LocalFile[IRewardsFile]
+type LocalMinipoolPerformanceFile = LocalFile[IMinipoolPerformanceFile]
+
+// NewLocalFile creates the wrapper, but doesn't write to disk.
+// This should be used when generating new trees / performance files.
+func NewLocalFile[T ILocalFile](ilf T, fullpath string) *LocalFile[T] {
+	return &LocalFile[T]{
+		f:        ilf,
+		fullPath: fullpath,
+	}
+}
+
+// Reads an existing RewardsFile from disk and wraps it in a LocalFile
+func ReadLocalRewardsFile(path string) (*LocalFile[IRewardsFile], error) {
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading rewards file from %s: %w", path, err)
+	}
+
+	// Unmarshal it
+	proofWrapper, err := DeserializeRewardsFile(fileBytes)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling rewards file from %s: %w", path, err)
+	}
+
+	return NewLocalFile[IRewardsFile](proofWrapper, path), nil
+}
+
+// Reads an existing MinipoolPerformanceFile from disk and wraps it in a LocalFile
+func ReadLocalMinipoolPerformanceFile(path string) (*LocalFile[IMinipoolPerformanceFile], error) {
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading rewards file from %s: %w", path, err)
+	}
+
+	// Unmarshal it
+	minipoolPerformance, err := DeserializeMinipoolPerformanceFile(fileBytes)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling rewards file from %s: %w", path, err)
+	}
+
+	return NewLocalFile[IMinipoolPerformanceFile](minipoolPerformance, path), nil
+}
+
+// Returns the underlying interface, IRewardsFile for rewards file, IMinipoolPerformanceFile for performance, etc.
+func (lf *LocalFile[T]) Repr() T {
+	return lf.f
+}
+
+// Converts the underlying interface to a byte slice
+func (lf *LocalFile[T]) Serialize() ([]byte, error) {
+	return lf.f.Serialize()
+}
+
+// Writes the file to disk
+func (lf *LocalFile[T]) Write() error {
+	data, err := lf.Serialize()
+	if err != nil {
+		return fmt.Errorf("Error serializing file: %w", err)
+	}
+
+	err = os.WriteFile(lf.fullPath, data, 0644)
+	if err != nil {
+		return fmt.Errorf("Error writing file to %s: %w", lf.fullPath, err)
+	}
+	return nil
+}
+
+// Computes the CID that would be used if we compressed the file with zst,
+// added the ipfs extension to the filename (.zst), and uploaded it to ipfs
+// in an empty directory, as web3storage did, once upon a time.
+//
+// N.B. This function will also save the compressed file to disk so it can
+// later be uploaded to ipfs
+func (lf *LocalFile[T]) CompressedCid() (cid.Cid, error) {
+	// Serialize
+	data, err := lf.Serialize()
+	if err != nil {
+		return cid.Cid{}, fmt.Errorf("Error serializing file: %w", err)
+	}
+
+	// Compress
+	encoder, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedBestCompression))
+	compressedBytes := encoder.EncodeAll(data, make([]byte, 0, len(data)))
+
+	filename := lf.fullPath + config.RewardsTreeIpfsExtension
+	c, err := singleFileDirIPFSCid(compressedBytes, filepath.Base(filename))
+	if err != nil {
+		return cid.Cid{}, fmt.Errorf("Error calculating CID: %w", err)
+	}
+
+	// Write to disk
+	// Take care to write to `filename` since it has the .zst extension added
+	err = os.WriteFile(filename, compressedBytes, 0644)
+	if err != nil {
+		return cid.Cid{}, fmt.Errorf("Error writing file to %s: %w", lf.fullPath, err)
+	}
+	return c, nil
+}

--- a/shared/services/rewards/files_test.go
+++ b/shared/services/rewards/files_test.go
@@ -1,0 +1,169 @@
+package rewards
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestFilesFromTree(t *testing.T) {
+	dir := t.TempDir()
+	t.Logf("%s using tempdir %s\n", t.Name(), dir)
+
+	f := RewardsFile_v3{
+		RewardsFileHeader: &RewardsFileHeader{
+			RewardsFileVersion: 3,
+			RulesetVersion:     8,
+		},
+		MinipoolPerformanceFile: MinipoolPerformanceFile_v3{
+			RewardsFileVersion: 3,
+			RulesetVersion:     8,
+		},
+	}
+
+	localRewardsFile := NewLocalFile[IRewardsFile](
+		&f,
+		path.Join(dir, "rewards.json"),
+	)
+
+	err := localRewardsFile.Write()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	minipoolPerformanceFile := localRewardsFile.Repr().GetMinipoolPerformanceFile()
+	localMinipoolPerformanceFile := NewLocalFile[IMinipoolPerformanceFile](
+		minipoolPerformanceFile,
+		path.Join(dir, "performance.json"),
+	)
+
+	err = localMinipoolPerformanceFile.Write()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the file can be parsed
+	localRewardsFile, err = ReadLocalRewardsFile(path.Join(dir, "rewards.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if localRewardsFile.Repr().GetHeader().RulesetVersion != f.RewardsFileHeader.RulesetVersion {
+		t.Fatalf(
+			"expected parsed version %d to match serialized version %d\n",
+			localRewardsFile.Repr().GetHeader().RulesetVersion,
+			f.RewardsFileHeader.RulesetVersion,
+		)
+	}
+
+	localMinipoolPerformanceFile, err = ReadLocalMinipoolPerformanceFile(path.Join(dir, "performance.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestCompressionAndCids(t *testing.T) {
+	dir := t.TempDir()
+	t.Logf("%s using tempdir %s\n", t.Name(), dir)
+
+	f := RewardsFile_v3{
+		RewardsFileHeader: &RewardsFileHeader{
+			RewardsFileVersion: 3,
+			RulesetVersion:     8,
+		},
+		MinipoolPerformanceFile: MinipoolPerformanceFile_v3{
+			RewardsFileVersion: 3,
+			RulesetVersion:     9,
+		},
+	}
+
+	localRewardsFile := NewLocalFile[IRewardsFile](
+		&f,
+		path.Join(dir, "rewards.json"),
+	)
+
+	minipoolPerformanceFile := localRewardsFile.Repr().GetMinipoolPerformanceFile()
+	localMinipoolPerformanceFile := NewLocalFile[IMinipoolPerformanceFile](
+		minipoolPerformanceFile,
+		path.Join(dir, "performance.json"),
+	)
+
+	rewardsCid, err := localRewardsFile.CompressedCid()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	performanceCid, err := localMinipoolPerformanceFile.CompressedCid()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that compressed files were written to disk and their cids match what was returned by CompressedCid
+	compressedRewardsBytes, err := os.ReadFile(path.Join(dir, "rewards.json.zst"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rewardsFileCid, err := singleFileDirIPFSCid(compressedRewardsBytes, "rewards.json.zst")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewardsFileCid != rewardsCid {
+		t.Fatalf("expected CompressedCid to return %s, got %s", rewardsFileCid, rewardsCid)
+	}
+
+	compressedPerformanceBytes, err := os.ReadFile(path.Join(dir, "performance.json.zst"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	performanceFileCid, err := singleFileDirIPFSCid(compressedPerformanceBytes, "performance.json.zst")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if performanceFileCid != performanceCid {
+		t.Fatalf("expected CompressedCid to return %s, got %s", performanceFileCid, performanceCid)
+	}
+
+	// Ensure that we can decompress both files
+	decompressedPerformance, err := decompressFile(compressedPerformanceBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decompressedRewards, err := decompressFile(compressedRewardsBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that we can parse the result of decompressing
+	parsedPerformance, err := DeserializeMinipoolPerformanceFile(decompressedPerformance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsedRewards, err := DeserializeRewardsFile(decompressedRewards)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make sure values were preserved in the round trip
+	if localRewardsFile.Repr().GetHeader().RulesetVersion != parsedRewards.GetHeader().RulesetVersion {
+		t.Fatalf(
+			"expected parsed version %d to match serialized version %d\n",
+			localRewardsFile.Repr().GetHeader().RulesetVersion,
+			parsedRewards.GetHeader().RulesetVersion,
+		)
+	}
+
+	if localRewardsFile.Repr().GetMinipoolPerformanceFile().(*MinipoolPerformanceFile_v3).RulesetVersion !=
+		parsedPerformance.(*MinipoolPerformanceFile_v3).RulesetVersion {
+
+		t.Fatalf(
+			"expected parsed version %d to match serialized version %d\n",
+			localRewardsFile.Repr().GetMinipoolPerformanceFile().(*MinipoolPerformanceFile_v3).RulesetVersion,
+			parsedPerformance.(*MinipoolPerformanceFile_v3).RulesetVersion,
+		)
+	}
+}

--- a/shared/services/rewards/files_test.go
+++ b/shared/services/rewards/files_test.go
@@ -31,7 +31,7 @@ func TestFilesFromTree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	minipoolPerformanceFile := localRewardsFile.Repr().GetMinipoolPerformanceFile()
+	minipoolPerformanceFile := localRewardsFile.Impl().GetMinipoolPerformanceFile()
 	localMinipoolPerformanceFile := NewLocalFile[IMinipoolPerformanceFile](
 		minipoolPerformanceFile,
 		path.Join(dir, "performance.json"),
@@ -48,10 +48,10 @@ func TestFilesFromTree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if localRewardsFile.Repr().GetHeader().RulesetVersion != f.RewardsFileHeader.RulesetVersion {
+	if localRewardsFile.Impl().GetHeader().RulesetVersion != f.RewardsFileHeader.RulesetVersion {
 		t.Fatalf(
 			"expected parsed version %d to match serialized version %d\n",
-			localRewardsFile.Repr().GetHeader().RulesetVersion,
+			localRewardsFile.Impl().GetHeader().RulesetVersion,
 			f.RewardsFileHeader.RulesetVersion,
 		)
 	}
@@ -83,18 +83,18 @@ func TestCompressionAndCids(t *testing.T) {
 		path.Join(dir, "rewards.json"),
 	)
 
-	minipoolPerformanceFile := localRewardsFile.Repr().GetMinipoolPerformanceFile()
+	minipoolPerformanceFile := localRewardsFile.Impl().GetMinipoolPerformanceFile()
 	localMinipoolPerformanceFile := NewLocalFile[IMinipoolPerformanceFile](
 		minipoolPerformanceFile,
 		path.Join(dir, "performance.json"),
 	)
 
-	rewardsCid, err := localRewardsFile.CompressedCid()
+	rewardsCid, err := localRewardsFile.CreateCompressedFileAndCid()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	performanceCid, err := localMinipoolPerformanceFile.CompressedCid()
+	performanceCid, err := localMinipoolPerformanceFile.CreateCompressedFileAndCid()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,20 +149,20 @@ func TestCompressionAndCids(t *testing.T) {
 	}
 
 	// Make sure values were preserved in the round trip
-	if localRewardsFile.Repr().GetHeader().RulesetVersion != parsedRewards.GetHeader().RulesetVersion {
+	if localRewardsFile.Impl().GetHeader().RulesetVersion != parsedRewards.GetHeader().RulesetVersion {
 		t.Fatalf(
 			"expected parsed version %d to match serialized version %d\n",
-			localRewardsFile.Repr().GetHeader().RulesetVersion,
+			localRewardsFile.Impl().GetHeader().RulesetVersion,
 			parsedRewards.GetHeader().RulesetVersion,
 		)
 	}
 
-	if localRewardsFile.Repr().GetMinipoolPerformanceFile().(*MinipoolPerformanceFile_v3).RulesetVersion !=
+	if localRewardsFile.Impl().GetMinipoolPerformanceFile().(*MinipoolPerformanceFile_v3).RulesetVersion !=
 		parsedPerformance.(*MinipoolPerformanceFile_v3).RulesetVersion {
 
 		t.Fatalf(
 			"expected parsed version %d to match serialized version %d\n",
-			localRewardsFile.Repr().GetMinipoolPerformanceFile().(*MinipoolPerformanceFile_v3).RulesetVersion,
+			localRewardsFile.Impl().GetMinipoolPerformanceFile().(*MinipoolPerformanceFile_v3).RulesetVersion,
 			parsedPerformance.(*MinipoolPerformanceFile_v3).RulesetVersion,
 		)
 	}

--- a/shared/services/rewards/utils.go
+++ b/shared/services/rewards/utils.go
@@ -117,7 +117,7 @@ func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.RocketPoolConfig, no
 		return
 	}
 
-	proofWrapper := localRewardsFile.Repr()
+	proofWrapper := localRewardsFile.Impl()
 
 	// Make sure the Merkle root has the expected value
 	merkleRootFromFile := common.HexToHash(proofWrapper.GetHeader().MerkleRoot)


### PR DESCRIPTION
Introducing a new interface allows us to abstract the process of writing/reading tree and performance files from disk, as well as compressing the files and calculating their CIDs.

This resolves at least one bug where CIDs are calculated with incorrect filenames.

Read shared/services/rewards/files.go first. This is the new abstraction.
See it in action in the rest of the files. The rules are:
1. When downloading or generating a tree, we call `NewLocalFile` to create the struct, `Write` when we want to write it, `CompressedCid()` to calculate the cid and write the compressed file to disk.
2. When reading a file from disk we use `ReadLocalRewardsFile` or `ReadLocalMinipoolPerformanceFile` which reads the files and parses the bytes in one go. It assumes the file is _not_ compressed, as the only code that operates over compressed files is the tree downloader, which decompresses ad-hoc. We can feasibly change the contents of the file and overwrite it with `Write()`, but we don't actually do that anywhere.

New tests are passing:
```
$ go test -test.v .
=== RUN   TestFilesFromTree
    files_test.go:11: TestFilesFromTree using tempdir /tmp/TestFilesFromTree4014754575/001
--- PASS: TestFilesFromTree (0.00s)
=== RUN   TestCompressionAndCids
    files_test.go:68: TestCompressionAndCids using tempdir /tmp/TestCompressionAndCids271413775/001
--- PASS: TestCompressionAndCids (0.21s)
PASS
ok      github.com/rocket-pool/smartnode/shared/services/rewards        (cached)
```