### PR TITLE
Fix -c shorthand for subcommands

### DIFF
--- a/rocketpool-cli/rocketpool-cli.go
+++ b/rocketpool-cli/rocketpool-cli.go
@@ -121,6 +121,7 @@ ______           _        _    ______           _
 				os.Exit(1)
 			}
 			configPath = os.Args[index+1]
+			break
 		}
 	}
 


### PR DESCRIPTION
Using `os.Arg` on L117 is janky but I accept that we want to parse the config file before calling `app.Run`.

However, once we find the first instance of `-c` or `--config-path`, we should break.

Otherwise, `rocketpool -c ~/.rocketpool wallet init -c` doesn't work, despite:
```
$ rocketpool wallet init --help

NAME:
   rocketpool wallet init - Initialize the node wallet

USAGE:
   rocketpool wallet init [options]

OPTIONS:
   --password value, -p value         The password to secure the wallet with (if not already set)
   --confirm-mnemonic, -c             Automatically confirm the mnemonic phrase
   --derivation-path value, -d value  Specify the derivation path for the wallet.
Omit this flag (or leave it blank) for the default of "m/44'/60'/0'/0/%d" (where %d is the index).
Set this to "ledgerLive" to use Ledger Live's path of "m/44'/60'/%d/0/0".
Set this to "mew" to use MyEtherWallet's path of "m/44'/60'/0'/%d".
For custom paths, simply enter them here.
```

Obviously, without the break, we parse the first `-c` and it succeeds, but we keep iterating to the second `-c` and error out.