### PR TITLE
Fix voluntary exit signatures

### DIFF
--- a/rocketpool/api/minipool/change-withdrawal-creds.go
+++ b/rocketpool/api/minipool/change-withdrawal-creds.go
@@ -198,7 +198,7 @@ func changeWithdrawalCreds(c *cli.Context, minipoolAddress common.Address, mnemo
 		return nil, err
 	}
 
-	// Get voluntary exit signature domain
+	// Get the BlsToExecutionChange signature domain
 	signatureDomain, err := bc.GetDomainData(eth2types.DomainBlsToExecutionChange[:], head.Epoch, true)
 	if err != nil {
 		return nil, err

--- a/shared/services/beacon/client/std-http-client.go
+++ b/shared/services/beacon/client/std-http-client.go
@@ -412,6 +412,7 @@ func (c *StandardHttpClient) GetDomainData(domainType []byte, epoch uint64, useG
 		return err
 	})
 
+	// Get the BN spec as we need the CAPELLA_FORK_VERSION
 	wg.Go(func() error {
 		var err error
 		eth2Config, err = c.getEth2Config()
@@ -426,8 +427,10 @@ func (c *StandardHttpClient) GetDomainData(domainType []byte, epoch uint64, useG
 	// Get fork version
 	var forkVersion []byte
 	if useGenesisFork {
+		// Used to compute the domain for credential changes
 		forkVersion = genesis.Data.GenesisForkVersion
 	} else {
+		// According to EIP-7044 (https://eips.ethereum.org/EIPS/eip-7044) the CAPELLA_FORK_VERSION should always be used to compute the domain for voluntary exits signatures.
 		forkVersion = eth2Config.Data.CapellaForkVersion
 	}
 

--- a/shared/services/beacon/client/types.go
+++ b/shared/services/beacon/client/types.go
@@ -39,9 +39,10 @@ type SyncStatusResponse struct {
 }
 type Eth2ConfigResponse struct {
 	Data struct {
-		SecondsPerSlot               uinteger `json:"SECONDS_PER_SLOT"`
-		SlotsPerEpoch                uinteger `json:"SLOTS_PER_EPOCH"`
-		EpochsPerSyncCommitteePeriod uinteger `json:"EPOCHS_PER_SYNC_COMMITTEE_PERIOD"`
+		SecondsPerSlot               uinteger  `json:"SECONDS_PER_SLOT"`
+		SlotsPerEpoch                uinteger  `json:"SLOTS_PER_EPOCH"`
+		CapellaForkVersion           byteArray `json:"CAPELLA_FORK_VERSION"`
+		EpochsPerSyncCommitteePeriod uinteger  `json:"EPOCHS_PER_SYNC_COMMITTEE_PERIOD"`
 	} `json:"data"`
 }
 type Eth2DepositContractResponse struct {


### PR DESCRIPTION
Fix the exit signatures as they were failing after the Dencun upgrade on Holesky.
Always using the CAPELLA_FORK_VERSION when computing the domain for the voluntary exit signature.
Domain() function was deprecated so it was replaced by ComputeDomain()