### PR TITLE
Make rewardsFileVersion type to encapsulate version range checks. Make errors more user friendly

### DIFF
--- a/shared/services/rewards/rewards-file-v2.go
+++ b/shared/services/rewards/rewards-file-v2.go
@@ -15,7 +15,7 @@ import (
 
 // Holds information
 type MinipoolPerformanceFile_v2 struct {
-	RewardsFileVersion  uint64                                                  `json:"rewardsFileVersion"`
+	RewardsFileVersion  rewardsFileVersion                                      `json:"rewardsFileVersion"`
 	RulesetVersion      uint64                                                  `json:"rulesetVersion"`
 	Index               uint64                                                  `json:"index"`
 	Network             string                                                  `json:"network"`

--- a/shared/services/rewards/rewards-file-v3.go
+++ b/shared/services/rewards/rewards-file-v3.go
@@ -15,7 +15,7 @@ import (
 
 // Holds information
 type MinipoolPerformanceFile_v3 struct {
-	RewardsFileVersion  uint64                                                  `json:"rewardsFileVersion"`
+	RewardsFileVersion  rewardsFileVersion                                      `json:"rewardsFileVersion"`
 	RulesetVersion      uint64                                                  `json:"rulesetVersion"`
 	Index               uint64                                                  `json:"index"`
 	Network             string                                                  `json:"network"`

--- a/shared/services/rewards/utils.go
+++ b/shared/services/rewards/utils.go
@@ -403,49 +403,33 @@ func GetStartSlotForInterval(previousIntervalEvent rewards.RewardsEvent, bc beac
 }
 
 // Deserializes a byte array into a rewards file interface
-func DeserializeRewardsFile(bytes []byte) (IRewardsFile, error) {
-	var header RewardsFileHeader
-	err := json.Unmarshal(bytes, &header)
-	if err != nil {
-		return nil, fmt.Errorf("error deserializing rewards file header: %w", err)
-	}
-
-	switch header.RewardsFileVersion {
-	case 1:
-		file := &RewardsFile_v1{}
-		return file, file.Deserialize(bytes)
-	case 2:
-		file := &RewardsFile_v2{}
-		return file, file.Deserialize(bytes)
-	case 3:
-		file := &RewardsFile_v3{}
-		return file, file.Deserialize(bytes)
-	default:
-		return nil, fmt.Errorf("unexpected rewards file version [%d]", header.RewardsFileVersion)
-	}
-}
-
-// Deserializes a byte array into a rewards file interface
-func DeserializeMinipoolPerformanceFile(bytes []byte) (IMinipoolPerformanceFile, error) {
+func deserializeVersionHeader(bytes []byte) (*VersionHeader, error) {
 	var header VersionHeader
 	err := json.Unmarshal(bytes, &header)
 	if err != nil {
 		return nil, fmt.Errorf("error deserializing version header: %w", err)
 	}
+	return &header, nil
+}
 
-	switch header.RewardsFileVersion {
-	case 1:
-		file := &MinipoolPerformanceFile_v1{}
-		return file, file.Deserialize(bytes)
-	case 2:
-		file := &MinipoolPerformanceFile_v2{}
-		return file, file.Deserialize(bytes)
-	case 3:
-		file := &MinipoolPerformanceFile_v3{}
-		return file, file.Deserialize(bytes)
-	default:
-		return nil, fmt.Errorf("unexpected rewards file version [%d]", header.RewardsFileVersion)
+// Deserializes a byte array into a rewards file interface
+func DeserializeRewardsFile(bytes []byte) (IRewardsFile, error) {
+	header, err := deserializeVersionHeader(bytes)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing rewards file header: %w", err)
 	}
+
+	return header.deserializeRewardsFile(bytes)
+}
+
+// Deserializes a byte array into a rewards file interface
+func DeserializeMinipoolPerformanceFile(bytes []byte) (IMinipoolPerformanceFile, error) {
+	header, err := deserializeVersionHeader(bytes)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing rewards file header: %w", err)
+	}
+
+	return header.deserializeMinipoolPerformanceFile(bytes)
 }
 
 // Decompresses a rewards file


### PR DESCRIPTION
Main goal is to print a more verbose error message when a rewards file has a version in excess of the binary's maximum- we should just tell the user to update smartnode in the error message rather than having them file into support:

![image](https://github.com/rocket-pool/smartnode/assets/116244/584e2189-76a5-4bf7-b1fb-fe07900a4685)

Secondary goal is to improve the parse implementation. Merges the parsing of the header into a single function, adds a function that rangechecks the version.

The package interface is unchanged.