### PR TITLE
feat: rocketpool service reset for bounty BA0902402 (Patches Delegated Work)

### DIFF
--- a/rocketpool-cli/service/commands.go
+++ b/rocketpool-cli/service/commands.go
@@ -231,7 +231,8 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 					}
 
 					// Run command
-					return pauseService(c)
+					_, err := pauseService(c)
+					return err
 
 				},
 			},
@@ -254,8 +255,31 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 					}
 
 					// Run command
-					return pauseService(c)
+					_, err := pauseService(c)
+					return err
 
+				},
+			},
+
+			{
+				Name:      "reset",
+				Aliases:   []string{"r"},
+				Usage:     "Cleanup Docker system resources, including stopped containers, dangling images, and unused networks and volumes. Requires temporarily pausing your clients.",
+				UsageText: "rocketpool service reset [options]",
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "yes, y",
+						Usage: "Automatically confirm service suspension",
+					},
+				},
+				Action: func(c *cli.Context) error {
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run command
+					return resetDocker(c)
 				},
 			},
 

--- a/rocketpool-cli/service/commands.go
+++ b/rocketpool-cli/service/commands.go
@@ -271,6 +271,10 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 						Name:  "yes, y",
 						Usage: "Automatically confirm service suspension",
 					},
+					cli.BoolFlag{
+						Name:  "all, a",
+						Usage: "Removes all Docker images, including those currently used by the Smartnode stack. This will force a full re-download of all images when the Smartnode is restarted.",
+					},
 				},
 				Action: func(c *cli.Context) error {
 					// Validate args
@@ -287,6 +291,12 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Name:      "prune",
 				Usage:     "Cleanup unused Docker resources, including stopped containers, unused images, networks and volumes. Does not restart smartnode, so the running containers and the images and networks they reference will not be pruned.",
 				UsageText: "rocketpool service prune",
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "all, a",
+						Usage: "Removes all Docker images, including those currently used by the Smartnode stack. This will force a full re-download of all images when the Smartnode is restarted.",
+					},
+				},
 				Action: func(c *cli.Context) error {
 
 					// Validate args

--- a/rocketpool-cli/service/commands.go
+++ b/rocketpool-cli/service/commands.go
@@ -264,7 +264,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:      "reset",
 				Aliases:   []string{"r"},
-				Usage:     "Cleanup Docker system resources, including stopped containers, dangling images, and unused networks and volumes. Requires temporarily pausing your clients.",
+				Usage:     "Cleanup Docker resources, including stopped containers, unused images and networks. Stops and restarts Smartnode.",
 				UsageText: "rocketpool service reset [options]",
 				Flags: []cli.Flag{
 					cli.BoolFlag{
@@ -280,6 +280,22 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 					// Run command
 					return resetDocker(c)
+				},
+			},
+
+			{
+				Name:      "prune",
+				Usage:     "Cleanup unused Docker resources, including stopped containers, unused images, networks and volumes. Does not restart smartnode, so the running containers and the images and networks they reference will not be pruned.",
+				UsageText: "rocketpool service prune",
+				Action: func(c *cli.Context) error {
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run command
+					return pruneDocker(c)
 				},
 			},
 

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -1163,7 +1163,7 @@ func pruneDocker(c *cli.Context) error {
 				fmt.Printf("Error deleting image %s: %s\n", image.String(), err.Error())
 			}
 		} else {
-			fmt.Printf("Skipping image used by Smartnode stack: %s\n", image)
+			fmt.Printf("Skipping image used by Smartnode stack: %s\n", image.String())
 		}
 	}
 

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -1110,7 +1110,9 @@ func resetDocker(c *cli.Context) error {
 	confirmed, err := pauseService(c)
 	if err != nil {
 		return err
-	} else if !confirmed {
+	}
+
+	if !confirmed {
 		// if the user cancelled the pause, then we cancel the rest of the operation here:
 		return nil
 	}

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -1168,9 +1168,10 @@ func pruneDocker(c *cli.Context) error {
 					// safe to ignore and print to user, since it may just be an image referenced by a running container that is managed outside of the smartnode's compose stack
 					fmt.Printf("Error deleting image %s: %s\n", image.String(), err.Error())
 				}
-			} else {
-				fmt.Printf("Skipping image used by Smartnode stack: %s\n", image.String())
+				continue
 			}
+			
+			fmt.Printf("Skipping image used by Smartnode stack: %s\n", image.String())
 		}
 	}
 

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -1101,9 +1101,6 @@ func pruneExecutionClient(c *cli.Context) error {
 
 // Stops Smartnode stack containers, prunes docker, and restarts the Smartnode stack.
 func resetDocker(c *cli.Context) error {
-	// Get RP client
-	rp := rocketpool.NewClientFromCtx(c)
-	defer rp.Close()
 
 	fmt.Println("Once cleanup is complete, Rocket Pool will restart automatically.")
 	fmt.Println()
@@ -1118,22 +1115,65 @@ func resetDocker(c *cli.Context) error {
 		return nil
 	}
 
-	// Prune...
-	fmt.Println()
-
-	// NOTE: DockerSystemPrune prints its output (which could be errors)
-	err = rp.DockerSystemPrune()
+	// Prune images...
+	err = pruneDocker(c)
 	if err != nil {
-		return fmt.Errorf("error pruning docker: %w", err)
+		return fmt.Errorf("error pruning Docker: %s", err)
 	}
 
 	// Restart...
 	// NOTE: startService does some other sanity checks and messages that we leverage here:
-	fmt.Print("Restarting Rocket Pool...\n")
+	fmt.Println("Restarting Rocket Pool...")
 	err = startService(c, true)
 	if err != nil {
 		return fmt.Errorf("error starting Rocket Pool: %s", err)
 	}
+	return nil
+}
+
+func pruneDocker(c *cli.Context) error {
+
+	// Get RP client
+	rp := rocketpool.NewClientFromCtx(c)
+	defer rp.Close()
+
+	// NOTE: we deliberately avoid using `docker system prune -a` and delete all images manually so that we can preserve the current smartnode-stack images
+	ourImages, err := rp.GetComposeImages(getComposeFiles(c))
+	if err != nil {
+		return fmt.Errorf("error getting compose images: %w", err)
+	}
+
+	ourImagesMap := make(map[string]struct{})
+	for _, image := range ourImages {
+		ourImagesMap[image] = struct{}{}
+	}
+
+	allImages, err := rp.GetAllDockerImages()
+	if err != nil {
+		return fmt.Errorf("error getting all docker images: %w", err)
+	}
+
+	fmt.Println("Deleting images not used by the Rocket Pool Smartnode...")
+	for _, image := range allImages {
+		if _, ok := ourImagesMap[image.String()]; !ok {
+			fmt.Printf("Deleting %s...\n", image)
+			_, err = rp.DeleteDockerImage(image.ID)
+			if err != nil {
+				// safe to ignore and print to user, since it may just be an image referenced by a running container that is managed outside of the smartnode's compose stack
+				fmt.Printf("Error deleting image %s: %s\n", image.String(), err.Error())
+			}
+		} else {
+			fmt.Printf("Skipping image used by Smartnode stack: %s\n", image)
+		}
+	}
+
+	// now we can run docker system prune (without --all) to remove all stopped containers and networks:
+	fmt.Println("Pruning Docker system...")
+	err = rp.DockerSystemPrune()
+	if err != nil {
+		return fmt.Errorf("error pruning Docker system: %w", err)
+	}
+
 	return nil
 }
 

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -731,6 +731,17 @@ func (c *Client) DeleteVolume(volume string) (string, error) {
 
 }
 
+// Runs docker system prune remove all unused containers, networks, and unused images
+func (c *Client) DockerSystemPrune() error {
+
+	cmd := "docker system prune -af"
+	err := c.printOutput(cmd)
+	if err != nil {
+		return fmt.Errorf("error running docker system prune: %w", err)
+	}
+	return nil
+}
+
 // Gets the absolute file path of the client volume
 func (c *Client) GetClientVolumeSource(container string, volumeTarget string) (string, error) {
 

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -745,12 +745,15 @@ func (c *Client) DeleteDockerImage(id string) (string, error) {
 }
 
 // Runs docker system prune remove all unused containers, networks, and unused images
-func (c *Client) DockerSystemPrune() error {
+func (c *Client) DockerSystemPrune(deleteAllImages bool) error {
 
 	// NOTE: explicitly *NOT* using the --all flag, as it would remove all images,
 	//   not just unused ones, and we use this command to preserve the current
 	//   smartnode stack images.
 	cmd := "docker system prune -f"
+	if deleteAllImages {
+		cmd += " --all"
+	}
 	err := c.printOutput(cmd)
 	if err != nil {
 		return fmt.Errorf("error running docker system prune: %w", err)
@@ -778,8 +781,12 @@ type DockerImage struct {
 	ID         string `json:"ID"`
 }
 
-func (img *DockerImage) String() string {
+func (img *DockerImage) TagString() string {
 	return fmt.Sprintf("%s:%s", img.Repository, img.Tag)
+}
+
+func (img *DockerImage) String() string {
+	return fmt.Sprintf("%s:%s (%s)", img.Repository, img.Tag, img.ID)
 }
 
 // Returns all Docker images on the system


### PR DESCRIPTION
This is an implementation for claiming part of bounty BA0902402 ("Patches Delegated Work") which was awarded at https://dao.rocketpool.net/t/round-9-jan-14th-feb-12th-grants-bounties-retrospective-awards-results/2752

Specifically this is an implementation of the new `rocketpool service reset` and `rocketpool service prune` commands as specified in [the bounty application](https://dao.rocketpool.net/t/round-9-gmc-call-for-bounty-applications-deadline-is-february-11/2635/3) under "Feature Request: rocketpool service prune and rocketpool service reset" and corresponding to issue #323 .

~~This is a draft until I add `rocketpool service prune` and resolve a discussion with patches in #323 .~~

NOTE: There is a discussion #323 that we should resolve before merging.


<details>

<summary>Example commands and their output</summary>

```shell
$ go run rocketpool-cli.go service prune

Deleting images not used by the Rocket Pool Smartnode...
Skipping image used by Smartnode stack: rocketpool/smartnode:v1.11.9-dev
Deleting {<none> <none> 130efa288896}...
Error deleting image <none>:<none>: exit status 1
Skipping image used by Smartnode stack: flashbots/mev-boost:1.7
Skipping image used by Smartnode stack: chainsafe/lodestar:v1.16.0
Skipping image used by Smartnode stack: nethermind/nethermind:1.25.4
Skipping image used by Smartnode stack: prom/prometheus:v2.47.1
Skipping image used by Smartnode stack: grafana/grafana:9.4.15
Skipping image used by Smartnode stack: prom/node-exporter:v1.6.1
Pruning Docker system...
Total reclaimed space: 0B

$ go run rocketpool-cli.go service reset

Once cleanup is complete, Rocket Pool will restart automatically.

Are you sure you want to pause the Rocket Pool service? Any staking minipools will be penalized! [y/n]
y

[+] Stopping 10/10
 ✔ Container rocketpool_eth2        Stopped                                                                                                                                                                                                                                 3.4s 
 ✔ Container rocketpool_watchtower  Stopped                                                                                                                                                                                                                                 0.7s 
 ✔ Container rocketpool_validator   Stopped                                                                                                                                                                                                                                 1.0s 
 ✔ Container rocketpool_node        Stopped                                                                                                                                                                                                                                 0.9s 
 ✔ Container rocketpool_grafana     Stopped                                                                                                                                                                                                                                 1.2s 
 ✔ Container rocketpool_eth1        Stopped                                                                                                                                                                                                                                 3.1s 
 ✔ Container rocketpool_mev-boost   Stopped                                                                                                                                                                                                                                 0.0s 
 ✔ Container rocketpool_api         Stopped                                                                                                                                                                                                                                 0.8s 
 ✔ Container rocketpool_exporter    Stopped                                                                                                                                                                                                                                 0.3s 
 ✔ Container rocketpool_prometheus  Stopped                                                                                                                                                                                                                                 1.4s 
Deleting images not used by the Rocket Pool Smartnode...
Skipping image used by Smartnode stack: rocketpool/smartnode:v1.11.9-dev
Deleting {<none> <none> 130efa288896}...
Error deleting image <none>:<none>: exit status 1
Skipping image used by Smartnode stack: flashbots/mev-boost:1.7
Skipping image used by Smartnode stack: chainsafe/lodestar:v1.16.0
Skipping image used by Smartnode stack: nethermind/nethermind:1.25.4
Skipping image used by Smartnode stack: prom/prometheus:v2.47.1
Skipping image used by Smartnode stack: grafana/grafana:9.4.15
Skipping image used by Smartnode stack: prom/node-exporter:v1.6.1
Pruning Docker system...
Deleted Containers:
ed2578a7f81e217c94badefec1a774780359b4a777e94ca0e20a2e16f224bbe1
897567c61cb06cc60142604fc0f6000343380ff56c1aa28541d59f833cf372a6
dd79ef26bbad6ba1b84e4f98221eaf86761219616c01917ac9d54db152220c0d
d2666fa8f2765e6fa8ce926f195cf124632725412896a8b573f3166a95203b7c
17b1a022756a6ca3792d593556f122962c344d822db0a06e0c8d18a2c48e49fe
c3be70b1df5948bccbe3bb66a6659634a617c75b686694b0d09edbffefc3055a
d01360bdbf87c8ea09f1d9867ba89e19a09bef2a14547529892f57d11e750fe4
c050007458cbd36b82eb668e646bf07d8be751a8c648e431cca7aeb1fd2c5e74
d937b63baf9226b3b5a8a9394aa61fe982791eebab27d36646b2c941b4628924
d89b81a55a25f57da1b4a5b246da4435c6470c42bdfa42fe91f0a0f70122f3e3

Deleted Networks:
rocketpool_monitor-net
rocketpool_net

Deleted Images:
deleted: sha256:130efa288896634d269e17db18445ce67930270b70d04058f149a8df7a53d8bb

Deleted build cache objects:
r2a571wjsvbq7ekxq1lhqhw22
k28ovqjrrynsyoes6osuzb1lh

Total reclaimed space: 61.47MB
Restarting Rocket Pool...
WARNING: couldn't verify that the validator container can be safely restarted:
	Error getting current validator image: exit status 1
If you are changing to a different ETH2 client, it may resubmit an attestation you have already submitted.
This will slash your validator!
To prevent slashing, you must wait 15 minutes from the time you stopped the clients before starting them again.

**If you did NOT change clients, you can safely ignore this warning.**

Press y when you understand the above warning, have waited, and are ready to start Rocket Pool: [y/n]
y

[+] Running 10/12
 ⠇ Network rocketpool_net           Created                                                                                                                                                                                                                                 1.8s 
 ⠇ Network rocketpool_monitor-net   Created                                                                                                                                                                                                                                 1.8s 
 ✔ Container rocketpool_eth1        Started                                                                                                                                                                                                                                 1.4s 
 ✔ Container rocketpool_node        Started                                                                                                                                                                                                                                 0.9s 
 ✔ Container rocketpool_grafana     Started                                                                                                                                                                                                                                 0.8s 
 ✔ Container rocketpool_prometheus  Started                                                                                                                                                                                                                                 1.6s 
 ✔ Container rocketpool_validator   Started                                                                                                                                                                                                                                 1.0s 
 ✔ Container rocketpool_eth2        Started                                                                                                                                                                                                                                 1.4s 
 ✔ Container rocketpool_mev-boost   Started                                                                                                                                                                                                                                 0.8s 
 ✔ Container rocketpool_api         Started                                                                                                                                                                                                                                 1.5s 
 ✔ Container rocketpool_watchtower  Started                                                                                                                                                                                                                                 1.4s 
 ✔ Container rocketpool_exporter    Started                                                                                                                                                                                                                                 0.2s 


 ```

</details>
