### PR TITLE
Fix: Generate state manager as needed

### DIFF
--- a/rocketpool/watchtower/watchtower.go
+++ b/rocketpool/watchtower/watchtower.go
@@ -159,7 +159,7 @@ func run(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("error during penalties check: %w", err)
 	}*/
-	generateRewardsTree, err := newGenerateRewardsTree(c, log.NewColorLogger(SubmitRewardsTreeColor), errorLog, m)
+	generateRewardsTree, err := newGenerateRewardsTree(c, log.NewColorLogger(SubmitRewardsTreeColor), errorLog)
 	if err != nil {
 		return fmt.Errorf("error during manual tree generation check: %w", err)
 	}


### PR DESCRIPTION
Fix: Generate state manager as needed, using the watchtower Archive node when possible.

Closes #397 