### PR TITLE
Correct rocketpool_node approximate rpl reward panel for RPIP-30 changes (Milestone A)

### DIFF
--- a/rocketpool/node/collectors/node-collector.go
+++ b/rocketpool/node/collectors/node-collector.go
@@ -480,9 +480,12 @@ func (collector *NodeCollector) Collect(channel chan<- prometheus.Metric) {
 	 *
 	 * Formula:
 	 * 		current_node_weight / (current_node_weight + previous_interval_total_node_weight) * estimated_collateral_rewards
+	 *
+	 * Note that if the node has no effective stake, has no eligibleBorrowedETH, or if this is the very first rewards
+	 * period we don't attempt an estimate and simply use 0.
 	 */
 	estimatedRewards := float64(0)
-	if totalEffectiveStake.Cmp(big.NewInt(0)) == 1 && nodeWeight.Cmp(big.NewInt(0)) == 1 {
+	if totalEffectiveStake.Cmp(big.NewInt(0)) == 1 && nodeWeight.Cmp(big.NewInt(0)) == 1 && state.NetworkDetails.RewardIndex > 0 {
 
 		nodeWeightSum := big.NewInt(0).Add(nodeWeight, previousIntervalTotalNodeWeight)
 

--- a/shared/services/rewards/types.go
+++ b/shared/services/rewards/types.go
@@ -143,7 +143,7 @@ type IntervalInfo struct {
 	CID                    string        `json:"cid"`
 	StartTime              time.Time     `json:"startTime"`
 	EndTime                time.Time     `json:"endTime"`
-	TotalNodeWeight        *QuotedBigInt `json:"totalNodeWeight"`
+	TotalNodeWeight        *QuotedBigInt `json:"-"`
 	NodeExists             bool          `json:"nodeExists"`
 	CollateralRplAmount    *QuotedBigInt `json:"collateralRplAmount"`
 	ODaoRplAmount          *QuotedBigInt `json:"oDaoRplAmount"`

--- a/shared/services/rewards/types.go
+++ b/shared/services/rewards/types.go
@@ -143,12 +143,13 @@ type IntervalInfo struct {
 	CID                    string        `json:"cid"`
 	StartTime              time.Time     `json:"startTime"`
 	EndTime                time.Time     `json:"endTime"`
-	TotalNodeWeight        *QuotedBigInt `json:"-"`
 	NodeExists             bool          `json:"nodeExists"`
 	CollateralRplAmount    *QuotedBigInt `json:"collateralRplAmount"`
 	ODaoRplAmount          *QuotedBigInt `json:"oDaoRplAmount"`
 	SmoothingPoolEthAmount *QuotedBigInt `json:"smoothingPoolEthAmount"`
 	MerkleProof            []common.Hash `json:"merkleProof"`
+
+	TotalNodeWeight        *QuotedBigInt `json:"-"`
 }
 
 type MinipoolInfo struct {

--- a/shared/services/rewards/types.go
+++ b/shared/services/rewards/types.go
@@ -143,6 +143,7 @@ type IntervalInfo struct {
 	CID                    string        `json:"cid"`
 	StartTime              time.Time     `json:"startTime"`
 	EndTime                time.Time     `json:"endTime"`
+	TotalNodeWeight        *QuotedBigInt `json:"totalNodeWeight"`
 	NodeExists             bool          `json:"nodeExists"`
 	CollateralRplAmount    *QuotedBigInt `json:"collateralRplAmount"`
 	ODaoRplAmount          *QuotedBigInt `json:"oDaoRplAmount"`

--- a/shared/services/rewards/utils.go
+++ b/shared/services/rewards/utils.go
@@ -119,6 +119,8 @@ func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.RocketPoolConfig, no
 
 	proofWrapper := localRewardsFile.Impl()
 
+	info.TotalNodeWeight = proofWrapper.GetHeader().TotalRewards.TotalNodeWeight
+
 	// Make sure the Merkle root has the expected value
 	merkleRootFromFile := common.HexToHash(proofWrapper.GetHeader().MerkleRoot)
 	if merkleRootCanon != merkleRootFromFile {

--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -325,7 +325,7 @@ func CreateNetworkStateForNode(cfg *config.RocketPoolConfig, rp *rocketpool.Rock
 	return state, totalEffectiveStake, nil
 }
 
-func (s *NetworkState) getNodeWeight(eligibleBorrowedEth *big.Int, nodeStake *big.Int) *big.Int {
+func (s *NetworkState) GetNodeWeight(eligibleBorrowedEth *big.Int, nodeStake *big.Int) *big.Int {
 	rplPrice := s.NetworkDetails.RplPrice
 
 	// stakedRplValueInEth := nodeStake * ratio / 1 Eth
@@ -382,29 +382,7 @@ func (s *NetworkState) CalculateNodeWeights() (map[common.Address]*big.Int, *big
 		i := i
 		node := node
 		wg.Go(func() error {
-			eligibleBorrowedEth := big.NewInt(0)
-			for _, mpd := range s.MinipoolDetailsByNode[node.NodeAddress] {
-				// It must exist and be staking
-				if !mpd.Exists || mpd.Status != types.Staking {
-					continue
-				}
-
-				// Doesn't exist on Beacon yet
-				validatorStatus, exists := s.ValidatorDetails[mpd.Pubkey]
-				if !exists {
-					//s.logLine("NOTE: minipool %s (pubkey %s) didn't exist, ignoring it in effective RPL calculation", mpd.MinipoolAddress.Hex(), mpd.Pubkey.Hex())
-					continue
-				}
-
-				intervalEndEpoch := s.BeaconSlotNumber / s.BeaconConfig.SlotsPerEpoch
-				// Already exited
-				if validatorStatus.ExitEpoch <= intervalEndEpoch {
-					//s.logLine("NOTE: Minipool %s exited on epoch %d which is not after interval epoch %d so it's not eligible for RPL rewards", mpd.MinipoolAddress.Hex(), validatorStatus.ExitEpoch, intervalEndEpoch)
-					continue
-				}
-				// It's eligible, so add up the borrowed and bonded amounts
-				eligibleBorrowedEth.Add(eligibleBorrowedEth, mpd.UserDepositBalance)
-			}
+			eligibleBorrowedEth := s.GetEligibleBorrowedEth(&node)
 
 			// minCollateral := borrowedEth * minCollateralFraction / ratio
 			// NOTE: minCollateralFraction and ratio are both percentages, but multiplying and dividing by them cancels out the need for normalization by eth.EthToWei(1)
@@ -418,7 +396,7 @@ func (s *NetworkState) CalculateNodeWeights() (map[common.Address]*big.Int, *big
 				return nil
 			}
 
-			nodeWeight.Set(s.getNodeWeight(eligibleBorrowedEth, node.RplStake))
+			nodeWeight.Set(s.GetNodeWeight(eligibleBorrowedEth, node.RplStake))
 
 			// Scale the node weight by the participation in the current interval
 			// Get the timestamp of the node's registration
@@ -450,6 +428,37 @@ func (s *NetworkState) CalculateNodeWeights() (map[common.Address]*big.Int, *big
 	}
 
 	return weights, totalWeight, nil
+}
+
+func (s *NetworkState) GetEligibleBorrowedEth(node *rpstate.NativeNodeDetails) *big.Int {
+	eligibleBorrowedEth := big.NewInt(0)
+
+	for _, mpd := range s.MinipoolDetailsByNode[node.NodeAddress] {
+
+		// It must exist and be staking
+		if !mpd.Exists || mpd.Status != types.Staking {
+			continue
+		}
+
+		// Doesn't exist on Beacon yet
+		validatorStatus, exists := s.ValidatorDetails[mpd.Pubkey]
+		if !exists {
+			//s.logLine("NOTE: minipool %s (pubkey %s) didn't exist, ignoring it in effective RPL calculation", mpd.MinipoolAddress.Hex(), mpd.Pubkey.Hex())
+			continue
+		}
+
+		intervalEndEpoch := s.BeaconSlotNumber / s.BeaconConfig.SlotsPerEpoch
+
+		// Already exited
+		if validatorStatus.ExitEpoch <= intervalEndEpoch {
+			//s.logLine("NOTE: Minipool %s exited on epoch %d which is not after interval epoch %d so it's not eligible for RPL rewards", mpd.MinipoolAddress.Hex(), validatorStatus.ExitEpoch, intervalEndEpoch)
+			continue
+		}
+
+		// It's eligible, so add up the borrowed and bonded amounts
+		eligibleBorrowedEth.Add(eligibleBorrowedEth, mpd.UserDepositBalance)
+	}
+	return eligibleBorrowedEth
 }
 
 // Calculate the true effective stakes of all nodes in the state, using the validator status


### PR DESCRIPTION
resolves https://github.com/rocket-pool/smartnode/issues/439. Tested against Patch's (overcollateralized) holesky node. 

Before:
<img width="236" alt="Screenshot 2024-03-10 at 4 13 17 PM" src="https://github.com/rocket-pool/smartnode/assets/2594879/b2e7f8f4-7fb6-4c7e-834f-ffa7d4a1e03c">

After:
<img width="236" alt="Screenshot 2024-03-10 at 4 20 10 PM" src="https://github.com/rocket-pool/smartnode/assets/2594879/4992a1f0-54ee-4700-a314-f49ceeaece2c">

