### PR TITLE
fix: support for using alerting in native mode

### DIFF
--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -328,6 +328,10 @@ func getStatus(c *cli.Context) error {
 		}
 	}
 
+	if status.Warning != "" {
+		fmt.Printf("\n%sWARNING: %s%s\n", colorRed, status.Warning, colorReset)
+	}
+
 	// Return
 	return nil
 

--- a/rocketpool-cli/service/config/settings-alerting.go
+++ b/rocketpool-cli/service/config/settings-alerting.go
@@ -6,7 +6,8 @@ import (
 
 // The page wrapper for the alerting config
 type AlertingConfigPage struct {
-	home              *settingsHome
+	mainDisplay       *mainDisplay
+	homePage          *page
 	page              *page
 	layout            *standardLayout
 	masterConfig      *config.RocketPoolConfig
@@ -15,21 +16,42 @@ type AlertingConfigPage struct {
 
 func NewAlertingConfigPage(home *settingsHome) *AlertingConfigPage {
 	configPage := &AlertingConfigPage{
-		home:         home,
+		mainDisplay:  home.md,
+		homePage:     home.homePage,
 		masterConfig: home.md.Config,
 	}
 
 	configPage.createContent()
+	configPage.initPage(false)
 
+	return configPage
+}
+
+func NewAlertingConfigPageForNative(home *settingsNativeHome) *AlertingConfigPage {
+	configPage := &AlertingConfigPage{
+		mainDisplay:  home.md,
+		homePage:     home.homePage,
+		masterConfig: home.md.Config,
+	}
+
+	configPage.createContent()
+	configPage.initPage(true)
+
+	return configPage
+}
+
+func (configPage *AlertingConfigPage) initPage(isNative bool) {
+	id := "settings-alerting"
+	if isNative {
+		id = "settings-alerting-native"
+	}
 	configPage.page = newPage(
-		home.homePage,
-		"settings-alerting",
+		configPage.homePage,
+		id,
 		"Monitoring / Alerting",
 		"Select this to configure the alerting of the Smartnode. Requires metrics to be enabled.",
 		configPage.layout.grid,
 	)
-
-	return configPage
 }
 
 func (configPage *AlertingConfigPage) getPage() *page {
@@ -40,7 +62,7 @@ func (configPage *AlertingConfigPage) getPage() *page {
 func (configPage *AlertingConfigPage) createContent() {
 	configPage.layout = newStandardLayout()
 	configPage.layout.createForm(&configPage.masterConfig.Smartnode.Network, "Alerting Settings")
-	configPage.layout.setupEscapeReturnHomeHandler(configPage.home.md, configPage.home.homePage)
+	configPage.layout.setupEscapeReturnHomeHandler(configPage.mainDisplay, configPage.homePage)
 
 	// Set up the UI components
 	configPage.alertmanagerItems = createParameterizedFormItems(configPage.masterConfig.Alertmanager.GetParameters(), configPage.layout.descriptionBox)

--- a/rocketpool-cli/service/config/settings-alerting.go
+++ b/rocketpool-cli/service/config/settings-alerting.go
@@ -7,6 +7,44 @@ import (
 	"github.com/rocket-pool/smartnode/shared/services/config"
 )
 
+var alertingParametersNativeMode map[string]interface{} = map[string]interface{}{
+	"enableAlerting":                           nil,
+	"nativeModeHost":                           nil,
+	"nativeModePort":                           nil,
+	"discordWebhookURL":                        nil,
+	"alertEnabled_FeeRecipientChanged":         nil,
+	"alertEnabled_MinipoolBondReduced":         nil,
+	"alertEnabled_MinipoolBalanceDistributed":  nil,
+	"alertEnabled_MinipoolPromoted":            nil,
+	"alertEnabled_MinipoolStaked":              nil,
+	"alertEnabled_ExecutionClientSyncComplete": nil,
+	"alertEnabled_BeaconClientSyncComplete":    nil,
+}
+
+var alertingParametersDockerMode map[string]interface{} = map[string]interface{}{
+	"enableAlerting":                           nil,
+	"port":                                     nil,
+	"openPort":                                 nil,
+	"containerTag":                             nil,
+	"discordWebhookURL":                        nil,
+	"alertEnabled_ClientSyncStatusBeacon":      nil,
+	"alertEnabled_UpcomingSyncCommittee":       nil,
+	"alertEnabled_ActiveSyncCommittee":         nil,
+	"alertEnabled_UpcomingProposal":            nil,
+	"alertEnabled_RecentProposal":              nil,
+	"alertEnabled_LowDiskSpaceWarning":         nil,
+	"alertEnabled_LowDiskSpaceCritical":        nil,
+	"alertEnabled_OSUpdatesAvailable":          nil,
+	"alertEnabled_RPUpdatesAvailable":          nil,
+	"alertEnabled_FeeRecipientChanged":         nil,
+	"alertEnabled_MinipoolBondReduced":         nil,
+	"alertEnabled_MinipoolBalanceDistributed":  nil,
+	"alertEnabled_MinipoolPromoted":            nil,
+	"alertEnabled_MinipoolStaked":              nil,
+	"alertEnabled_ExecutionClientSyncComplete": nil,
+	"alertEnabled_BeaconClientSyncComplete":    nil,
+}
+
 // The page wrapper for the alerting config
 type AlertingConfigPage struct {
 	mainDisplay         *mainDisplay
@@ -81,7 +119,11 @@ func (configPage *AlertingConfigPage) createContent() {
 			enableAlertingBox = item.item.(*tview.Checkbox)
 			continue
 		}
-		configPage.otherItems = append(configPage.otherItems, item)
+		_, isNativeParameter := alertingParametersNativeMode[item.parameter.ID]
+		_, isDockerParameter := alertingParametersDockerMode[item.parameter.ID]
+		if (configPage.masterConfig.IsNativeMode && isNativeParameter) || (!configPage.masterConfig.IsNativeMode && isDockerParameter) {
+			configPage.otherItems = append(configPage.otherItems, item)
+		}
 	}
 
 	if enableAlertingBox != nil {

--- a/rocketpool-cli/service/config/settings-native-home.go
+++ b/rocketpool-cli/service/config/settings-native-home.go
@@ -18,6 +18,7 @@ type settingsNativeHome struct {
 	nativePage       *NativePage
 	fallbackPage     *NativeFallbackConfigPage
 	metricsPage      *NativeMetricsConfigPage
+	alertingPage     *AlertingConfigPage
 	categoryList     *tview.List
 	settingsSubpages []*page
 	content          tview.Primitive
@@ -40,11 +41,13 @@ func newSettingsNativeHome(md *mainDisplay) *settingsNativeHome {
 	home.nativePage = NewNativePage(home)
 	home.fallbackPage = NewNativeFallbackConfigPage(home)
 	home.metricsPage = NewNativeMetricsConfigPage(home)
+	home.alertingPage = NewAlertingConfigPageForNative(home)
 	settingsSubpages := []*page{
 		home.smartnodePage.page,
 		home.nativePage.page,
 		home.fallbackPage.page,
 		home.metricsPage.page,
+		home.alertingPage.page,
 	}
 	home.settingsSubpages = settingsSubpages
 
@@ -211,5 +214,9 @@ func (home *settingsNativeHome) refresh() {
 
 	if home.metricsPage != nil {
 		home.metricsPage.layout.refresh()
+	}
+
+	if home.alertingPage != nil {
+		home.alertingPage.layout.refresh()
 	}
 }

--- a/rocketpool/api/node/status.go
+++ b/rocketpool/api/node/status.go
@@ -237,6 +237,8 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 			// no reason to make `rocketpool node status` fail if we can't get alerts
 			// (this is more likely to happen in native mode than docker where
 			// alertmanager is more complex to set up)
+			// Do save a warning though to print to the user
+			response.Warning = fmt.Sprintf("Error fetching alerts from Alertmanager: %s", err)
 			alerts = make([]*models.GettableAlert, 0)
 		}
 		response.Alerts = make([]api.NodeAlert, len(alerts))

--- a/rocketpool/api/node/status.go
+++ b/rocketpool/api/node/status.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/rocket-pool/smartnode/shared/services"
 	"github.com/rocket-pool/smartnode/shared/services/alerting"
+	"github.com/rocket-pool/smartnode/shared/services/alerting/alertmanager/models"
 	"github.com/rocket-pool/smartnode/shared/services/beacon"
 	"github.com/rocket-pool/smartnode/shared/types/api"
 	rputils "github.com/rocket-pool/smartnode/shared/utils/rp"
@@ -233,7 +234,10 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 	wg.Go(func() error {
 		alerts, err := alerting.FetchAlerts(cfg)
 		if err != nil {
-			return err
+			// no reason to make `rocketpool node status` fail if we can't get alerts
+			// (this is more likely to happen in native mode than docker where
+			// alertmanager is more complex to set up)
+			alerts = make([]*models.GettableAlert, 0)
 		}
 		response.Alerts = make([]api.NodeAlert, len(alerts))
 

--- a/shared/services/alerting/alerting.go
+++ b/shared/services/alerting/alerting.go
@@ -280,7 +280,13 @@ func createAlert(uniqueName string, summary string, description string, severity
 }
 
 func createClient(cfg *config.RocketPoolConfig) *apiclient.Alertmanager {
+	// use the alertmanager container name for the hostname
 	host := fmt.Sprintf("%s:%d", config.AlertmanagerContainerName, cfg.Alertmanager.Port.Value)
+
+	if cfg.IsNativeMode {
+		host = fmt.Sprintf("%s:%d", cfg.Alertmanager.Host.Value, cfg.Alertmanager.Port.Value)
+	}
+
 	transport := apiclient.DefaultTransportConfig().WithHost(host)
 	client := apiclient.NewHTTPClientWithConfig(strfmt.Default, transport)
 	return client

--- a/shared/services/alerting/alerting.go
+++ b/shared/services/alerting/alerting.go
@@ -284,7 +284,7 @@ func createClient(cfg *config.RocketPoolConfig) *apiclient.Alertmanager {
 	host := fmt.Sprintf("%s:%d", config.AlertmanagerContainerName, cfg.Alertmanager.Port.Value)
 
 	if cfg.IsNativeMode {
-		host = fmt.Sprintf("%s:%d", cfg.Alertmanager.Host.Value, cfg.Alertmanager.Port.Value)
+		host = fmt.Sprintf("%s:%d", cfg.Alertmanager.NativeModeHost.Value, cfg.Alertmanager.NativeModePort.Value)
 	}
 
 	transport := apiclient.DefaultTransportConfig().WithHost(host)

--- a/shared/services/alerting/alerting.go
+++ b/shared/services/alerting/alerting.go
@@ -254,7 +254,7 @@ const (
 )
 
 func isAlertingEnabled(cfg *config.RocketPoolConfig) bool {
-	return cfg.EnableMetrics.Value == true
+	return cfg.Alertmanager.EnableAlerting.Value == true
 }
 
 // Creates a uniform alert with the basic labels and annotations we expect.

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -17,6 +17,7 @@ import (
 type NodeStatusResponse struct {
 	Status                            string          `json:"status"`
 	Error                             string          `json:"error"`
+	Warning                           string          `json:"warning"`
 	AccountAddress                    common.Address  `json:"accountAddress"`
 	AccountAddressFormatted           string          `json:"accountAddressFormatted"`
 	WithdrawalAddress                 common.Address  `json:"withdrawalAddress"`


### PR DESCRIPTION
- Adds a new Alertmanger host config that is only used in native mode
- The AlertingConfigPage is was made reusable so it works in both native mode config and docker config
fixes #462
fixes #463

Related to rocket-pool/docs.rocketpool.net#79

Keeping this a draft pending:
- [x] #463 (fixed herein)
- [x] #464 (fixed in rocket-pool/smartnode-install#123)