### PR TITLE
fixed tooltip to accurately represent guardrails

### DIFF
--- a/rocketpool-cli/pdao/commands.go
+++ b/rocketpool-cli/pdao/commands.go
@@ -783,7 +783,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 									{
 										Name:      "deposit-fee",
 										Aliases:   []string{"df"},
-										Usage:     fmt.Sprintf("Propose updating the %s setting; %s", protocol.DepositFeeSettingPath, "specify a percentage between 0 and 0.01 (e.g., '0.0001' for 0.010%)"),
+										Usage:     fmt.Sprintf("Propose updating the %s setting; %s", protocol.DepositFeeSettingPath, "specify a percentage between 0 and 0.01 (e.g., '0.001' for 0.10%)"),
 										UsageText: "rocketpool pdao propose setting deposit deposit-fee value",
 										Flags: []cli.Flag{
 											cli.BoolFlag{

--- a/rocketpool-cli/pdao/commands.go
+++ b/rocketpool-cli/pdao/commands.go
@@ -783,7 +783,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 									{
 										Name:      "deposit-fee",
 										Aliases:   []string{"df"},
-										Usage:     fmt.Sprintf("Propose updating the %s setting; %s", protocol.DepositFeeSettingPath, "specify a percentage between 0 and 0.01 (e.g., '0.001' for 0.010%)"),
+										Usage:     fmt.Sprintf("Propose updating the %s setting; %s", protocol.DepositFeeSettingPath, "specify a percentage between 0 and 0.01 (e.g., '0.0001' for 0.010%)"),
 										UsageText: "rocketpool pdao propose setting deposit deposit-fee value",
 										Flags: []cli.Flag{
 											cli.BoolFlag{

--- a/rocketpool-cli/pdao/commands.go
+++ b/rocketpool-cli/pdao/commands.go
@@ -783,7 +783,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 									{
 										Name:      "deposit-fee",
 										Aliases:   []string{"df"},
-										Usage:     fmt.Sprintf("Propose updating the %s setting; %s", protocol.DepositFeeSettingPath, percentUsage),
+										Usage:     fmt.Sprintf("Propose updating the %s setting; %s", protocol.DepositFeeSettingPath, "specify a percentage between 0 and 0.01 (e.g., '0.001' for 0.010%)"),
 										UsageText: "rocketpool pdao propose setting deposit deposit-fee value",
 										Flags: []cli.Flag{
 											cli.BoolFlag{


### PR DESCRIPTION
old: 
```
   deposit-fee, df                                    Propose updating the deposit.fee setting; specify a percentage between 0 and 1 (e.g., '0.51' for 51%)
```

new:
```
   deposit-fee, df                                    Propose updating the deposit.fee setting; specify a percentage between 0 and 0.01 (e.g., '0.001' for 0.10%)
```