### PR TITLE
fix: when bc status is not syncing fix progress to 1.0

### DIFF
--- a/rocketpool/node/collectors/node-collector.go
+++ b/rocketpool/node/collectors/node-collector.go
@@ -383,6 +383,9 @@ func (collector *NodeCollector) Collect(channel chan<- prometheus.Metric) {
 			return nil
 		} else {
 			progress = syncStatus.Progress
+			if !syncStatus.Syncing {
+				progress = 1.0
+			}
 		}
 		// note this metric is emitted asynchronously, while others in this file tend to be emitted at the end of the outer function (mostly due to dependencies between metrics). See https://github.com/rocket-pool/smartnode/issues/186
 		channel <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
0xfornax saw a mainnet node that had momentary periods of rocketpool_node_sync_progress{client="beacon"} slightly less than zero (e.g. 0.9999998854537224) and it was triggering the alert. Yet `rocketpool node sync` reported the client was synced. This is a somewhat speculative fix to potentially prevent that.

@0xfornax Wonder if this might help out in your case. The [Beacon API docs](https://ethereum.github.io/beacon-APIs/#/Node/getSyncingStatus) aren't explicit but they imply that progress is only valid if is_syncing is false. I saw somewhere else that the node was forcing progress to 1 when syncing=false.