### PR TITLE
Copy over 150% hardcode from v8 to v8-rolling

### DIFF
--- a/shared/services/rewards/generator-impl-v8-rolling.go
+++ b/shared/services/rewards/generator-impl-v8-rolling.go
@@ -381,6 +381,10 @@ func (r *treeGeneratorImpl_v8_rolling) calculateRplRewards() error {
 	r.log.Printlnf("%s Approx. total collateral RPL rewards: %s (%.3f)", r.logPrefix, totalNodeRewards.String(), eth.WeiToEth(totalNodeRewards))
 
 	// Calculate the effective stake of each node, scaling by their participation in this interval
+	// Before entering this function, make sure to hard-code MaxCollateralFraction to 1.5 eth (150% in wei), to comply with RPIP-30.
+	// Do it here, as the network state value will still be used for vote power, so doing it upstream is likely to introduce more issues.
+	// Doing it here also ensures that v1-7 continue to run correctly on networks other than mainnet where the max collateral fraction may not have always been 150%.
+	r.networkState.NetworkDetails.MaxCollateralFraction = big.NewInt(1.5e18) // 1.5 eth is 150% in wei
 	trueNodeEffectiveStakes, totalNodeEffectiveStake, err := r.networkState.CalculateTrueEffectiveStakes(true, true)
 	if err != nil {
 		return fmt.Errorf("error calculating effective RPL stakes: %w", err)


### PR DESCRIPTION
The interval ends in 7 days and we never did this.

I consider this to need additional testing for parity with non-rolling.

# We should ask the oDAO to disable RR, regardless of whether they update to this version, so we have time to test it.