### PR TITLE
Refactor build.sh a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Dockerfile
 /rocketpool/rocketpool-daemon-linux-amd64
 /rocketpool/rocketpool-daemon-darwin-arm64
 /rocketpool/rocketpool-daemon-linux-arm64
+*.swp
 
 # Packaging
 build/

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # This script will build all of the artifacts involved in a new Smart Node release.
-# NOTE: You MUST put this in a directory that has the `smartnode` repository cloned as a subdirectory.
 
 # =================
 # === Functions ===
@@ -19,78 +18,57 @@ fail() {
 
 # Builds all of the CLI binaries
 build_cli() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
     echo -n "Building CLI binaries... "
-    docker buildx build --rm -f docker/cli.dockerfile --output ../$VERSION --target cli . || fail "Error building CLI binaries."
-    #rm -rf rocketpool-cli/build
+    docker buildx build --rm -f docker/cli.dockerfile --output build/$VERSION --target cli . || fail "Error building CLI binaries."
     echo "done!"
-
-    cd ..
 }
 
 
 # Builds the smart node distro packages
 build_distro_packages() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
     echo -n "Building deb packages..."
-    docker buildx build --rm -f install/packages/debian/package.dockerfile --output ../$VERSION --target package . || fail "Error building deb packages."
-    rm ../$VERSION/*.build ../$VERSION/*.buildinfo ../$VERSION/*.changes
+    docker buildx build --rm -f install/packages/debian/package.dockerfile --output build/$VERSION --target package . || fail "Error building deb packages."
+    rm build/$VERSION/*.build build/$VERSION/*.buildinfo build/$VERSION/*.changes
     echo "done!"
-
-    cd ..
 }
 
 
 # Builds the .tar.xz file packages with the RP configuration files
 build_install_packages() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-    rm -f smartnode-install.tar.xz
-
     echo -n "Building Smart Node installer packages... "
-    tar cfJ smartnode-install.tar.xz install/deploy || fail "Error building installer package."
-    mv smartnode-install.tar.xz ../$VERSION
-    cp install/install.sh ../$VERSION
-    cp install/install-update-tracker.sh ../$VERSION
+    tar cfJ build/$VERSION/smartnode-install.tar.xz install/deploy || fail "Error building installer package."
+    cp install/install.sh build/$VERSION
+    cp install/install-update-tracker.sh build/$VERSION
     echo "done!"
 
     echo -n "Building update tracker package... "
-    tar cfJ rp-update-tracker.tar.xz install/rp-update-tracker || fail "Error building update tracker package."
-    mv rp-update-tracker.tar.xz ../$VERSION
+    tar cfJ build/$VERSION/rp-update-tracker.tar.xz install/rp-update-tracker || fail "Error building update tracker package."
     echo "done!"
-
-    cd ..
 }
 
 
 # Builds the daemon binaries and Docker Smart Node images, and pushes them to Docker Hub
 # NOTE: You must install qemu first; e.g. sudo apt-get install -y qemu qemu-user-static
 build_daemon() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
     echo "Building Smart Node daemon binaries..."
-    docker buildx build --rm --platform=linux/amd64,linux/arm64 -f docker/daemon-build.dockerfile --output ../$VERSION --target daemon . || fail "Error building Smart Node daemon binaries."
+    docker buildx build --rm --platform=linux/amd64,linux/arm64 -f docker/daemon-build.dockerfile --output build/$VERSION --target daemon . || fail "Error building Smart Node daemon binaries."
     echo "done!"
 
-    # Copy the daemon binaries to a build folder so the image can access them
-    mkdir -p ./build
-    cp ../$VERSION/linux_amd64/* ./build
-    cp ../$VERSION/linux_arm64/* ./build
-    echo "done!"
+    # Flatted the folders to make it easier to upload artifacts to github
+    mv build/$VERSION/linux_amd64/rocketpool-daemon build/$VERSION/rocketpool-daemon-linux-amd64
+    mv build/$VERSION/linux_arm64/rocketpool-daemon build/$VERSION/rocketpool-daemon-linux-arm64
+
+    # Clean up the empty directories
+    rmdir build/$VERSION/linux_amd64 build/$VERSION/linux_arm64
 
     echo "Building Smart Node Docker image..."
-    docker buildx build --rm --platform=linux/amd64,linux/arm64 -t rocketpool/smartnode:$VERSION -f docker/daemon.dockerfile --push . || fail "Error building Smart Node Docker image."
+    # If uploading, make and push a manifest
+    if [ "$UPLOAD" = true ]; then
+        docker buildx build --rm --platform=linux/amd64,linux/arm64 --build-arg BINARIES_PATH=build/$VERSION -t rocketpool/smartnode:$VERSION -f docker/daemon.dockerfile --push . || fail "Error building Smart Node Docker image."
+    else
+        docker buildx build --rm --load --build-arg BINARIES_PATH=build/$VERSION -t rocketpool/smartnode:$VERSION -f docker/daemon.dockerfile . || fail "Error building Smart Node Docker image."
+    fi
     echo "done!"
-
-    # Cleanup
-    mv ../$VERSION/linux_amd64/* ../$VERSION
-    mv ../$VERSION/linux_arm64/* ../$VERSION
-    rm -rf ../$VERSION/linux_amd64/
-    rm -rf ../$VERSION/linux_arm64/
-    rm -rf ./build
-
-    cd ..
 }
 
 
@@ -100,9 +78,13 @@ build_latest_docker_manifest() {
     docker tag rocketpool/smartnode:$VERSION rocketpool/smartnode:latest
     echo "done!"
 
-    echo -n "Pushing to Docker Hub... "
-    docker push rocketpool/smartnode:latest
-    echo "done!"
+    if [ "$UPLOAD" = true ]; then
+        echo -n "Pushing to Docker Hub... "
+        docker push rocketpool/smartnode:latest
+        echo "done!"
+    else
+        echo "The image tag only exists locally. Rerun with -u to upload to Docker Hub."
+    fi
 }
 
 
@@ -115,8 +97,9 @@ usage() {
     echo $'\t-c\tBuild the CLI binaries for all platforms'
     echo $'\t-t\tBuild the distro packages (.deb)'
     echo $'\t-p\tBuild the Smart Node installer packages'
-    echo $'\t-d\tBuild the Smart Node Daemon image, and push it to Docker Hub'
-    echo $'\t-l\tTag the Docker image as "latest" and push it to Docker Hub'
+    echo $'\t-d\tBuild the Smart Node Daemon image'
+    echo $'\t-l\tTag the Docker image as "latest"'
+    echo $'\t-u\tWhen passed with a build, upload the resulting image tags to Docker Hub'
     exit 0
 }
 
@@ -126,7 +109,7 @@ usage() {
 # =================
 
 # Parse arguments
-while getopts "actpdlv:" FLAG; do
+while getopts "actpdluv:" FLAG; do
     case "$FLAG" in
         a) CLI=true DISTRO=true PACKAGES=true DAEMON=true ;;
         c) CLI=true ;;
@@ -134,6 +117,7 @@ while getopts "actpdlv:" FLAG; do
         p) PACKAGES=true ;;
         d) DAEMON=true ;;
         l) LATEST_MANIFEST=true ;;
+        u) UPLOAD=true ;;
         v) VERSION="$OPTARG" ;;
         *) usage ;;
     esac
@@ -143,8 +127,8 @@ if [ -z "$VERSION" ]; then
 fi
 
 # Cleanup old artifacts
-rm -f ./$VERSION/*
-mkdir -p ./$VERSION
+rm -rf build/$VERSION/*
+mkdir -p build/$VERSION
 
 # Make a multiarch builder, ignore if it's already there
 docker buildx create --name multiarch-builder --driver docker-container --use > /dev/null 2>&1
@@ -173,47 +157,23 @@ fi
 
 # Builds the deb package builder image
 build_deb_builder() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
     echo -n "Building deb builder..."
     docker buildx build --rm --platform=linux/amd64,linux/arm64 -t rocketpool/smartnode-deb-builder:$VERSION -f install/packages/debian/builder.dockerfile --push . || fail "Error building deb builder."
     echo "done!"
-
-    cd ..
 }
 
 
 # Builds the prune provisioner image and pushes it to Docker Hub
 build_docker_prune_provision() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
     echo "Building Prune Provisioner image..."
     docker buildx build --platform=linux/amd64,linux/arm64 -t rocketpool/eth1-prune-provision:$VERSION -f util-containers/prune-provision.dockerfile --push . || fail "Error building Prune Provision image."
     echo "done!"
-
-    cd ..
 }
 
 
 # Builds the EC migrator image and pushes it to Docker Hub
 build_ec_migrator() {
-    cd smartnode || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
     echo "Building EC Migrator image..."
     docker buildx build --platform=linux/amd64,linux/arm64 -t rocketpool/ec-migrator:$VERSION -f util-containers/ec-migrator.dockerfile --push . || fail "Error building EC Migrator image."
     echo "done!"
-
-    cd ..
-}
-
-# Builds the Docker prune starter image and pushes it to Docker Hub
-# TODO: Move this to the NPS repo
-build_docker_prune_starter() {
-    cd NethermindPruneStarter || fail "Directory ${PWD}/smartnode does not exist or you don't have permissions to access it."
-
-    echo "Building Docker Prune Starter image..."
-    docker buildx build --platform=linux/amd64,linux/arm64 -t rocketpool/nm-prune-starter:$VERSION -f docker/rocketpool-nm-prune-starter --push . || fail "Error building Docker Prune Starter image."
-    echo "done!"
-
-    cd ..
 }

--- a/docker/daemon-build.dockerfile
+++ b/docker/daemon-build.dockerfile
@@ -13,9 +13,9 @@ RUN if [ "$BUILDPLATFORM" = "linux/amd64" -a "$TARGETARCH" = "arm64" ]; then \
         export CC=x86_64-linux-gnu-gcc && export CC_FOR_TARGET=gcc-x86-64-linux-gnu; \
     fi && \
     cd /rocketpool/src/rocketpool-daemon && \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /build/rocketpool-daemon-${TARGETOS}-${TARGETARCH}
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /build/rocketpool-daemon
 
 # Copy the output
 FROM scratch AS daemon
 ARG TARGETOS TARGETARCH
-COPY --from=builder /build/rocketpool-daemon-${TARGETOS}-${TARGETARCH} /
+COPY --from=builder /build/rocketpool-daemon /rocketpool-daemon

--- a/docker/daemon.dockerfile
+++ b/docker/daemon.dockerfile
@@ -1,7 +1,8 @@
 # The daemon image
 FROM debian:bookworm-slim
+ARG BINARIES_PATH
 ARG TARGETOS TARGETARCH
-COPY ./build/rocketpool-daemon-${TARGETOS}-${TARGETARCH} /usr/bin/rocketpool-daemon
+COPY ${BINARIES_PATH}/rocketpool-daemon-${TARGETOS}-${TARGETARCH} /usr/bin/rocketpool-daemon
 RUN apt update && \
     apt install ca-certificates -y && \
 	# Cleanup


### PR DESCRIPTION
1. Removes the requirement that build.sh must be run from the project's parent dir
2. Ignores build/ subtree
3. Cleans up artifact naming a bit to reduce complexity of build docker files and remove a bunch of `mv` from the script
4. Only pushes to docker hub if `-u` is passed. (allows for local development with the 'official' build pipeline artifacts)