### PR TITLE
Fix a few bugs with the migration

### DIFF
--- a/src/shared/config/smartnode-config.go
+++ b/src/shared/config/smartnode-config.go
@@ -516,8 +516,9 @@ func (cfg *SmartNodeConfig) Serialize() map[string]any {
 
 // Deserializes a settings file into this config
 func (cfg *SmartNodeConfig) Deserialize(masterMap map[string]any) error {
+	var err error
 	// Upgrade the config to the latest version
-	err := migration.UpdateConfig(masterMap)
+	masterMap, err = migration.UpdateConfig(masterMap)
 	if err != nil {
 		return fmt.Errorf("error upgrading configuration to v%s: %w", shared.RocketPoolVersion, err)
 	}


### PR DESCRIPTION
`UpdateConfig` needs to actually return the updated config so it can be used by the upstream caller.

`configVersionString` was being clobbered.