### PR TITLE
Bump debian version used for rocketpool container image to bookworm

### DIFF
--- a/docker/rocketpool-dockerfile
+++ b/docker/rocketpool-dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG TARGETARCH
 COPY ./rocketpool/rocketpool-daemon-linux-${TARGETARCH} /go/bin/rocketpool


### PR DESCRIPTION
Provides parity with smartnode-builder which was bumped in support of go 1.21

Without this, the rocketpool container attempts to run a binary built in bookworm with a bullseye base container, which has a different version of GLIBC