### PR TITLE
Using a TUI timestamp parameter for prices/balances submissions

### DIFF
--- a/rocketpool/api/node/set-stake-rpl-for-allowed.go
+++ b/rocketpool/api/node/set-stake-rpl-for-allowed.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rocket-pool/rocketpool-go/node"
 	"github.com/urfave/cli"
@@ -45,7 +46,6 @@ func canSetStakeRplForAllowed(c *cli.Context, caller common.Address, allowed boo
 	return &response, nil
 
 }
-
 
 func setStakeRplForAllowed(c *cli.Context, caller common.Address, allowed bool) (*api.SetStakeRplForAllowedResponse, error) {
 

--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -146,19 +146,16 @@ func (t *submitNetworkBalances) run(state *state.NetworkState) error {
 		if err != nil {
 			return fmt.Errorf("Can't get the latest block time: %w", err)
 		}
-		latestBlockTime := int64(latestEth1Block.Time)
+		latestBlockTimestamp := int64(latestEth1Block.Time)
 
-		// Calculate the difference between latestBlockTime and the reference timestamp
-		timeDifference := latestBlockTime - referenceTimestamp
-
-		// Calculate the remainder to find out how far off from a multiple of the interval the current time is
-		remainder := timeDifference % submissionIntervalInSeconds
-
-		// Subtract the remainder from current time to find the first multiple of the interval in the past
-		submissionTimeRef := latestBlockTime - remainder
+		// Calculate the next submission timestamp
+		submissionTimestamp, err := utils.FindNextSubmissionTimestamp(latestBlockTimestamp, referenceTimestamp, submissionIntervalInSeconds)
+		if err != nil {
+			return err
+		}
 
 		// Convert the submission timestamp to time.Time
-		nextSubmissionTime := time.Unix(submissionTimeRef, 0)
+		nextSubmissionTime := time.Unix(submissionTimestamp, 0)
 
 		// Log
 		t.log.Println("Checking for network balance checkpoint...")

--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -127,11 +127,6 @@ func (t *submitNetworkBalances) run(state *state.NetworkState) error {
 		return err
 	}
 
-	rp, err := services.GetRocketPool(t.c)
-	if err != nil {
-		return err
-	}
-
 	// Check if balance submission is enabled
 	if !state.NetworkDetails.SubmitBalancesEnabled {
 		return nil
@@ -147,7 +142,7 @@ func (t *submitNetworkBalances) run(state *state.NetworkState) error {
 		eth2Config := state.BeaconConfig
 
 		// Get the time of the latest block
-		latestEth1Block, err := rp.Client.HeaderByNumber(context.Background(), nil)
+		latestEth1Block, err := t.rp.Client.HeaderByNumber(context.Background(), nil)
 		if err != nil {
 			return fmt.Errorf("Can't get the latest block time: %w", err)
 		}

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -19,7 +18,6 @@ import (
 	"github.com/rocket-pool/rocketpool-go/dao/trustednode"
 	v120_network "github.com/rocket-pool/rocketpool-go/legacy/v1.2.0/network"
 	"github.com/rocket-pool/rocketpool-go/network"
-	"github.com/rocket-pool/rocketpool-go/rewards"
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
 	"github.com/rocket-pool/rocketpool-go/utils/eth"
 	"github.com/urfave/cli"
@@ -311,6 +309,11 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		return err
 	}
 
+	rp, err := services.GetRocketPool(t.c)
+	if err != nil {
+		return err
+	}
+
 	// Check if submission is enabled
 	if !state.NetworkDetails.SubmitPricesEnabled {
 		return nil
@@ -370,82 +373,44 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 
 	if state.IsHoustonDeployed {
 
-		// Check the last submission block
-		lastSubmissionBlock := state.NetworkDetails.BalancesBlock.Uint64()
+		lastSubmissionBlock := state.NetworkDetails.PricesBlock
 
+		referenceTimestamp := t.cfg.Smartnode.PriceBalanceSubmissionReferenceTimestamp.Value.(int64)
 		// Get the duration in seconds for the interval between submissions
-		submissionIntervalDuration := time.Duration(state.NetworkDetails.PricesSubmissionFrequency * uint64(time.Second))
+		submissionIntervalInSeconds := int64(state.NetworkDetails.PricesSubmissionFrequency)
 		eth2Config := state.BeaconConfig
 
-		// Get the last prices updated event
-		found, event, err := network.GetPriceUpdatedEvent(t.rp, lastSubmissionBlock, nil)
+		// Get the time of the latest block
+		latestEth1Block, err := rp.Client.HeaderByNumber(context.Background(), nil)
 		if err != nil {
-			return fmt.Errorf("error getting event for price updated on block %d: %w", lastSubmissionBlock, err)
+			return fmt.Errorf("Can't get the latest block time: %w", err)
 		}
-		var nextSubmissionTime time.Time
-		if !found {
-			// The first submission after Houston is deployed won't find an event emitted by this contract
-			// The submission time will be adjusted to align with the reward time
+		latestBlockTimestamp := int64(latestEth1Block.Time)
 
-			// Sync
-			var wg errgroup.Group
-			var lastCheckpoint time.Time
-			var rewardsInterval time.Duration
+		// Calculate the difference between latestBlockTime and the reference timestamp
+		timeDifference := latestBlockTimestamp - referenceTimestamp
 
-			// Get the start of the rewards checkpoint
-			wg.Go(func() error {
-				lastCheckpoint, err = rewards.GetClaimIntervalTimeStart(t.rp, nil)
-				return err
-			})
+		// Calculate the remainder to find out how far off from a multiple of the interval the current time is
+		remainder := timeDifference % submissionIntervalInSeconds
 
-			// Get the rewards checkpoint interval
-			wg.Go(func() error {
-				rewardsInterval, err = rewards.GetClaimIntervalTime(t.rp, nil)
-				return err
-			})
+		// Subtract the remainder from current time to find the first multiple of the interval in the past
+		submissionTimeRef := latestBlockTimestamp - remainder
 
-			// Wait for data
-			if err := wg.Wait(); err != nil {
-				return err
-			}
-
-			// Find the next checkpoint
-			nextCheckpoint := lastCheckpoint.Add(rewardsInterval)
-
-			// Calculate the number of submissions between now and the next checkpoint adding one so we have the first submission time that is in the past
-			timeDifference := time.Until(nextCheckpoint)
-			submissionsUntilNextCheckpoint := int(timeDifference/submissionIntervalDuration) + 1
-
-			nextSubmissionTime = nextCheckpoint.Add(-time.Duration(submissionsUntilNextCheckpoint) * submissionIntervalDuration)
-		} else {
-
-			// Get the last submission reference time
-			lastSubmissionTime := time.Unix(event.SlotTimestamp.Int64(), 0)
-
-			nextSubmissionTime = lastSubmissionTime.Add(submissionIntervalDuration)
-		}
-		if time.Now().Before(nextSubmissionTime) {
-			return nil
-		}
-
-		// Get the Beacon block corresponding to this time
-		genesisTime := time.Unix(int64(eth2Config.GenesisTime), 0)
-		timeSinceGenesis := nextSubmissionTime.Sub(genesisTime)
-		slotNumber := uint64(timeSinceGenesis.Seconds()) / eth2Config.SecondsPerSlot
+		// Get the Beacon slot corresponding to this time
+		genesisTime := (int64(eth2Config.GenesisTime))
+		timeSinceGenesis := submissionTimeRef - genesisTime
+		slotNumber := uint64(timeSinceGenesis) / eth2Config.SecondsPerSlot
 
 		// Search for the last existing EL block, going back up to 32 slots if the block is not found.
-		ecBlock, err := utils.FindLastExistingELBlockFromSlot(t.bc, slotNumber)
+		targetBlock, err := utils.FindLastBlockWithExecutionPayload(t.bc, slotNumber)
 		if err != nil {
 			return err
 		}
-
-		// Fetch the target block
-		targetBlockHeader, err := t.ec.HeaderByHash(context.Background(), ecBlock.BlockHash)
-		if err != nil {
-			return err
+		targetBlockNumber := targetBlock.ExecutionBlockNumber
+		if targetBlockNumber <= lastSubmissionBlock {
+			// No submission needed: target block older or equal to the last submission
+			return nil
 		}
-
-		blockNumber := targetBlockHeader.Number.Uint64()
 
 		// Check if the targetEpoch is finalized yet
 		targetEpoch := slotNumber / eth2Config.SlotsPerEpoch
@@ -455,7 +420,7 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		}
 		finalizedEpoch := beaconHead.FinalizedEpoch
 		if targetEpoch > finalizedEpoch {
-			t.log.Printlnf("Prices must be reported for EL block %d, waiting until Epoch %d is finalized (currently %d)", blockNumber, targetEpoch, finalizedEpoch)
+			t.log.Printlnf("Prices must be reported for EL block %d, waiting until Epoch %d is finalized (currently %d)", targetBlockNumber, targetEpoch, finalizedEpoch)
 			return nil
 		}
 
@@ -476,10 +441,10 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 			t.log.Printlnf("%s Starting price report in a separate thread.", logPrefix)
 
 			// Log
-			t.log.Printlnf("Getting RPL price for block %d...", blockNumber)
+			t.log.Printlnf("Getting RPL price for block %d...", targetBlockNumber)
 
 			// Get RPL price at block
-			rplPrice, err := t.getRplTwap(blockNumber)
+			rplPrice, err := t.getRplTwap(targetBlockNumber)
 			if err != nil {
 				t.handleError(fmt.Errorf("%s %w", logPrefix, err))
 				return
@@ -489,7 +454,7 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 			t.log.Printlnf("RPL price: %.6f ETH", mathutils.RoundDown(eth.WeiToEth(rplPrice), 6))
 
 			// Check if we have reported these specific values before
-			hasSubmittedSpecific, err := t.hasSubmittedSpecificBlockPrices(nodeAccount.Address, blockNumber, uint64(nextSubmissionTime.Unix()), rplPrice, true)
+			hasSubmittedSpecific, err := t.hasSubmittedSpecificBlockPrices(nodeAccount.Address, targetBlockNumber, uint64(submissionTimeRef), rplPrice, true)
 			if err != nil {
 				t.handleError(fmt.Errorf("%s %w", logPrefix, err))
 				return
@@ -502,20 +467,20 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 			}
 
 			// We haven't submitted these values, check if we've submitted any for this block so we can log it
-			hasSubmitted, err := t.hasSubmittedBlockPrices(nodeAccount.Address, blockNumber, uint64(nextSubmissionTime.Unix()), true)
+			hasSubmitted, err := t.hasSubmittedBlockPrices(nodeAccount.Address, targetBlockNumber, uint64(submissionTimeRef), true)
 			if err != nil {
 				t.handleError(fmt.Errorf("%s %w", logPrefix, err))
 				return
 			}
 			if hasSubmitted {
-				t.log.Printlnf("Have previously submitted out-of-date prices for block %d, trying again...", blockNumber)
+				t.log.Printlnf("Have previously submitted out-of-date prices for block %d, trying again...", targetBlockNumber)
 			}
 
 			// Log
 			t.log.Println("Submitting RPL price...")
 
 			// Submit RPL price
-			if err := t.submitRplPrice(blockNumber, uint64(nextSubmissionTime.Unix()), rplPrice, true); err != nil {
+			if err := t.submitRplPrice(targetBlockNumber, uint64(submissionTimeRef), rplPrice, true); err != nil {
 				t.handleError(fmt.Errorf("%s could not submit RPL price: %w", logPrefix, err))
 				return
 			}

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -309,11 +309,6 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		return err
 	}
 
-	rp, err := services.GetRocketPool(t.c)
-	if err != nil {
-		return err
-	}
-
 	// Check if submission is enabled
 	if !state.NetworkDetails.SubmitPricesEnabled {
 		return nil
@@ -381,7 +376,7 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		eth2Config := state.BeaconConfig
 
 		// Get the time of the latest block
-		latestEth1Block, err := rp.Client.HeaderByNumber(context.Background(), nil)
+		latestEth1Block, err := t.rp.Client.HeaderByNumber(context.Background(), nil)
 		if err != nil {
 			return fmt.Errorf("Can't get the latest block time: %w", err)
 		}

--- a/rocketpool/watchtower/utils/utils.go
+++ b/rocketpool/watchtower/utils/utils.go
@@ -48,3 +48,22 @@ func FindLastBlockWithExecutionPayload(bc beacon.Client, slotNumber uint64) (bea
 	}
 	return beaconBlock, nil
 }
+
+func FindNextSubmissionTimestamp(latestBlockTimestamp int64, referenceTimestamp int64, submissionIntervalInSeconds int64) (int64, error) {
+	if latestBlockTimestamp == 0 || referenceTimestamp == 0 || submissionIntervalInSeconds == 0 {
+		return 0, fmt.Errorf("FindNextSubmissionTimestamp can't use zero values")
+	}
+
+	// Calculate the difference between latestBlockTime and the reference timestamp
+	timeDifference := latestBlockTimestamp - referenceTimestamp
+	if timeDifference < 0 {
+		return 0, fmt.Errorf("FindNextSubmissionTimestamp referenceTimestamp in the future")
+	}
+
+	// Calculate the remainder to find out how far off from a multiple of the interval the current time is
+	remainder := timeDifference % submissionIntervalInSeconds
+
+	// Subtract the remainder from current time to find the first multiple of the interval in the past
+	submissionTimeRef := latestBlockTimestamp - remainder
+	return submissionTimeRef, nil
+}

--- a/rocketpool/watchtower/utils/utils.go
+++ b/rocketpool/watchtower/utils/utils.go
@@ -33,18 +33,18 @@ func GetWatchtowerPrioFee(cfg *config.RocketPoolConfig) float64 {
 	return setting
 }
 
-func FindLastExistingELBlockFromSlot(bc beacon.Client, slotNumber uint64) (beacon.Eth1Data, error) {
-	ecBlock := beacon.Eth1Data{}
+func FindLastBlockWithExecutionPayload(bc beacon.Client, slotNumber uint64) (beacon.BeaconBlock, error) {
+	beaconBlock := beacon.BeaconBlock{}
 	var err error
 	for blockExists, searchSlot := false, slotNumber; !blockExists; searchSlot -= 1 {
-		ecBlock, blockExists, err = bc.GetEth1DataForEth2Block(strconv.FormatUint(searchSlot, 10))
+		beaconBlock, blockExists, err = bc.GetBeaconBlock(strconv.FormatUint(searchSlot, 10))
 		if err != nil {
-			return ecBlock, err
+			return beacon.BeaconBlock{}, err
 		}
 		// If we go back more than 32 slots, error out
 		if slotNumber-searchSlot > 32 {
-			return ecBlock, fmt.Errorf("could not find EL block from slot %d", slotNumber)
+			return beacon.BeaconBlock{}, fmt.Errorf("could not find EL block from slot %d", slotNumber)
 		}
 	}
-	return ecBlock, nil
+	return beaconBlock, nil
 }

--- a/rocketpool/watchtower/utils/utils_test.go
+++ b/rocketpool/watchtower/utils/utils_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestFindNextSubmission(t *testing.T) {
+	latestBlockTimestamp := 1713420045 // Same day
+	referenceTimestamp := 1713420000   // 06:00AM
+	intervalInSeconds := 86400
+	result, err := FindNextSubmissionTimestamp(int64(latestBlockTimestamp), int64(referenceTimestamp), int64(intervalInSeconds))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%s", time.Unix(result, 0).String())
+	if result != 1713420000 {
+		t.Fatalf("Wrong result")
+	}
+	latestBlockTimestamp = 1713510000
+	result, err = FindNextSubmissionTimestamp(int64(latestBlockTimestamp), int64(referenceTimestamp), int64(intervalInSeconds))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != 1713506400 {
+		t.Fatalf("Wrong result")
+	}
+	// Test zero values
+	_, err = FindNextSubmissionTimestamp(int64(latestBlockTimestamp), int64(referenceTimestamp), 0)
+	if err == nil {
+		t.Fatalf("Should have errored after using 0 for the interval")
+	}
+	_, err = FindNextSubmissionTimestamp(int64(latestBlockTimestamp), 0, int64(intervalInSeconds))
+	if err == nil {
+		t.Fatalf("Should have errored after using 0 for the reference timestamp")
+	}
+	_, err = FindNextSubmissionTimestamp(0, int64(referenceTimestamp), int64(intervalInSeconds))
+	if err == nil {
+		t.Fatalf("Should have errored after using 0 for the latest block timestamp")
+	}
+
+	// Test reference timestamp in the future
+	_, err = FindNextSubmissionTimestamp(int64(latestBlockTimestamp), int64(latestBlockTimestamp+86400), int64(intervalInSeconds))
+	if err == nil {
+		t.Fatalf("Should have error when using a reference date in the future")
+	}
+}

--- a/shared/services/config/smartnode-config.go
+++ b/shared/services/config/smartnode-config.go
@@ -80,6 +80,9 @@ type SmartnodeConfig struct {
 	// Mode for acquiring Merkle rewards trees
 	RewardsTreeMode config.Parameter `yaml:"rewardsTreeMode,omitempty"`
 
+	// Timestamp used as reference for prices/balances submissions
+	PriceBalanceSubmissionReferenceTimestamp config.Parameter `yaml:"priceBalanceSubmissionReferenceTimestamp,omitempty"`
+
 	// Custom URL to download a rewards tree
 	RewardsTreeCustomUrl config.Parameter `yaml:"rewardsTreeCustomUrl,omitempty"`
 
@@ -344,6 +347,17 @@ func NewSmartnodeConfig(cfg *RocketPoolConfig) *SmartnodeConfig {
 				Description: "Use your node to automatically generate the Merkle Tree rewards file once a checkpoint has passed. This option lets you build and verify the file that the Oracle DAO created if you prefer not to trust it and want to generate the tree yourself.\n\n[orange]WARNING: Generating the tree can take a *very long time* if many node operators are opted into the Smoothing Pool, which could impact your attestation performance!",
 				Value:       config.RewardsMode_Generate,
 			}},
+		},
+
+		PriceBalanceSubmissionReferenceTimestamp: config.Parameter{
+			ID:                 "priceBalanceSubmissionReferenceTimestamp",
+			Name:               "P/B Submission Time Ref",
+			Description:        "Prices and balances submission time reference. An Unix timestamp used by oDAO members as an initial reference to calculate when submissions are due based on the onchain stored submission interval value.",
+			Type:               config.ParameterType_Int,
+			Default:            map[config.Network]interface{}{config.Network_All: int64(config.PBSubmission_6AM)},
+			AffectsContainers:  []config.ContainerID{config.ContainerID_Watchtower},
+			CanBeBlank:         false,
+			OverwriteOnUpgrade: true,
 		},
 
 		RewardsTreeCustomUrl: config.Parameter{
@@ -669,6 +683,7 @@ func (cfg *SmartnodeConfig) GetParameters() []*config.Parameter {
 		&cfg.DistributeThreshold,
 		&cfg.VerifyProposals,
 		&cfg.RewardsTreeMode,
+		&cfg.PriceBalanceSubmissionReferenceTimestamp,
 		&cfg.RewardsTreeCustomUrl,
 		&cfg.ArchiveECUrl,
 		&cfg.WatchtowerMaxFeeOverride,

--- a/shared/services/rewards/types.go
+++ b/shared/services/rewards/types.go
@@ -149,7 +149,7 @@ type IntervalInfo struct {
 	SmoothingPoolEthAmount *QuotedBigInt `json:"smoothingPoolEthAmount"`
 	MerkleProof            []common.Hash `json:"merkleProof"`
 
-	TotalNodeWeight        *QuotedBigInt `json:"-"`
+	TotalNodeWeight *QuotedBigInt `json:"-"`
 }
 
 type MinipoolInfo struct {

--- a/shared/services/rocketpool/network.go
+++ b/shared/services/rocketpool/network.go
@@ -176,4 +176,3 @@ func (c *Client) GetLatestDelegate() (api.GetLatestDelegateResponse, error) {
 	}
 	return response, nil
 }
-

--- a/shared/types/config/types.go
+++ b/shared/types/config/types.go
@@ -10,6 +10,7 @@ type RewardsMode string
 type MevRelayID string
 type MevSelectionMode string
 type NimbusPruningMode string
+type PBSubmissionRef int
 
 // Enum to describe which container(s) a parameter impacts, so the Smartnode knows which
 // ones to restart upon a settings change
@@ -81,6 +82,10 @@ const (
 	RewardsMode_Unknown  RewardsMode = ""
 	RewardsMode_Download RewardsMode = "download"
 	RewardsMode_Generate RewardsMode = "generate"
+)
+
+const (
+	PBSubmission_6AM PBSubmissionRef = 1713420000
 )
 
 // Enum to identify MEV-boost relays


### PR DESCRIPTION
This PR refactors prices and balances submissions previously based on locating event submissions to define the next submission time. The code now introduced a new TUI parameter that will be used to calculate when the next submission is due.

The default value for the new parameter is 1713420000 (April 18, 2024 6:00:00 AM UTC). Considering the 24-hour submission interval (on mainnet), after the Houston launch, oDAO nodes would submit new prices/balances every day for the block at 6:00:00 AM UTC (or, in case of a missed slot, the last proposed block before this time). This makes the submission process in a predictable way, as mandate by RPIP-35, and gets rid of event issues, especially during the transition to Houston.