### PR TITLE
Remove sszgen.sh

### DIFF
--- a/sszgen.sh
+++ b/sszgen.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Generates the ssz encoding methods for eth2 types with fastssz
-# Install sszgen with `go get github.com/ferranbt/fastssz/sszgen`
-rm -f ./shared/types/eth2/types_encoding.go
-sszgen --path ./shared/types/eth2


### PR DESCRIPTION
sszgen.sh used to generate a file that is now part of NMC, so it should be removed from smartnode.

Counterpart: https://github.com/rocket-pool/node-manager-core/pull/3