### PR TITLE
Make alerting package stateful and directly error-logging. Fix the rest of the unchecked errors.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,9 +34,6 @@ jobs:
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
 
-          # For now, Smart Node will enforce everything except errcheck
-          args: --disable errcheck
-
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prysmaticlabs/prysm/v5 v5.0.3
 	github.com/rivo/tview v0.0.0-20230208211350-7dfff1ce7854 // DO NOT UPGRADE
-	github.com/rocket-pool/node-manager-core v0.2.1-0.20240417173109-4b54852b003a
-	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-20240418131940-9aa4643f67c7
+	github.com/rocket-pool/node-manager-core v0.2.1-0.20240421193204-a16d03d086e8
+	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-20240421193935-e15a3e374153
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/wealdtech/go-ens/v3 v3.6.0

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,12 @@ github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9K
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
 github.com/rocket-pool/node-manager-core v0.2.1-0.20240417173109-4b54852b003a h1:hBuBMT4XT1ne/6eUdnE3BIfnMsFmFPF7pIRud0aWod8=
 github.com/rocket-pool/node-manager-core v0.2.1-0.20240417173109-4b54852b003a/go.mod h1:KeVUgf+tc7e+fDUzc/FH3COtgGPoAyIV2Tx3jLN4zng=
+github.com/rocket-pool/node-manager-core v0.2.1-0.20240421193204-a16d03d086e8 h1:nUHIRbYWKo+FO0zom8lpXAasNUt91iJ6k74e3fD6UvM=
+github.com/rocket-pool/node-manager-core v0.2.1-0.20240421193204-a16d03d086e8/go.mod h1:KeVUgf+tc7e+fDUzc/FH3COtgGPoAyIV2Tx3jLN4zng=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-20240418131940-9aa4643f67c7 h1:liWy3ZNMhHmNOlbKfJXZbUgbBaGj4ZyEZJv+0mWaZ+k=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-20240418131940-9aa4643f67c7/go.mod h1:2IMaRByN0wfkLgNa85LA0I9oJ1QKv1nCNoffFdhF714=
+github.com/rocket-pool/rocketpool-go/v2 v2.0.0-20240421193935-e15a3e374153 h1:BE6SdszUN+emqc7riBJJtbTpKFeNTtt+78PX1iUVS7c=
+github.com/rocket-pool/rocketpool-go/v2 v2.0.0-20240421193935-e15a3e374153/go.mod h1:2IMaRByN0wfkLgNa85LA0I9oJ1QKv1nCNoffFdhF714=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=

--- a/rocketpool-cli/commands/minipool/vanity.go
+++ b/rocketpool-cli/commands/minipool/vanity.go
@@ -161,7 +161,10 @@ func runWorker(report bool, stop *bool, targetPrefix *big.Int, nodeAddress []byt
 		salt.FillBytes(saltBytes[:])
 		hasher.Write(nodeAddress)
 		hasher.Write(saltBytes[:])
-		hasher.Read(nodeSalt[:])
+		_, err := hasher.Read(nodeSalt[:])
+		if err != nil {
+			panic(err)
+		}
 		hasher.Reset()
 
 		// This block is the fast way to do `crypto.CreateAddress2(minipoolManagerAddress, nodeSalt, initHash)`
@@ -174,7 +177,10 @@ func runWorker(report bool, stop *bool, targetPrefix *big.Int, nodeAddress []byt
 		hasher.Write(minipoolManagerAddress.Bytes())
 		hasher.Write(nodeSalt[:])
 		hasher.Write(initHash)
-		hasher.Read(addressResult[:])
+		_, err = hasher.Read(addressResult[:])
+		if err != nil {
+			panic(err)
+		}
 		hasher.Reset()
 
 		hashInt.SetBytes(addressResult[12:])

--- a/rocketpool-cli/commands/service/config.go
+++ b/rocketpool-cli/commands/service/config.go
@@ -131,8 +131,13 @@ func configureService(c *cli.Context) error {
 				suffix := config.GetContainerName(container)
 				name := cfg.GetDockerArtifactName(suffix)
 				fmt.Printf("Stopping %s... ", name)
-				rp.StopContainer(name)
-				fmt.Print("done!\n")
+				err := rp.StopContainer(name)
+				if err != nil {
+					fmt.Println("error!")
+					fmt.Fprintf(os.Stderr, "Error stopping container %s: %s\n", name, err.Error())
+					continue
+				}
+				fmt.Println("done!")
 			}
 
 			fmt.Println()

--- a/rocketpool-cli/commands/service/start.go
+++ b/rocketpool-cli/commands/service/start.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -40,8 +41,12 @@ func startService(c *cli.Context, ignoreConfigSuggestion bool) error {
 	if isUpdate && !ignoreConfigSuggestion {
 		if c.Bool("yes") || utils.Confirm("Smart Node upgrade detected - starting will overwrite certain settings with the latest defaults (such as container versions).\nYou may want to run `service config` first to see what's changed.\n\nWould you like to continue starting the service?") {
 			cfg.UpdateDefaults()
-			rp.SaveConfig(cfg)
-			fmt.Printf("%sUpdated settings successfully.%s\n", terminal.ColorGreen, terminal.ColorReset)
+			err := rp.SaveConfig(cfg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%sError saving settings: %s%s\n", terminal.ColorRed, err.Error(), terminal.ColorReset)
+			} else {
+				fmt.Printf("%sUpdated settings successfully.%s\n", terminal.ColorGreen, terminal.ColorReset)
+			}
 		} else {
 			fmt.Println("Cancelled.")
 			return nil

--- a/rocketpool-daemon/api/node/status.go
+++ b/rocketpool-daemon/api/node/status.go
@@ -308,7 +308,7 @@ func (c *nodeStatusContext) PrepareData(data *api.NodeStatusData, opts *bind.Tra
 	}
 
 	// Get alerts from Alertmanager
-	alerts, err := alerting.FetchAlerts(c.cfg)
+	alerts, err := alerting.NewAlertFetcher(c.cfg).FetchAlerts()
 	if err != nil {
 		// no reason to make `rocketpool node status` fail if we can't get alerts
 		// (this is more likely to happen in native mode than docker where

--- a/rocketpool-daemon/common/rewards/generator-impl-v8.go
+++ b/rocketpool-daemon/common/rewards/generator-impl-v8.go
@@ -822,7 +822,7 @@ func (r *treeGeneratorImpl_v8) processEpoch(context context.Context, getDuties b
 }
 
 // Handle all of the attestations in the given slot
-func (r *treeGeneratorImpl_v8) checkDutiesForSlot(attestations []beacon.AttestationInfo, slot uint64) error {
+func (r *treeGeneratorImpl_v8) checkDutiesForSlot(attestations []beacon.AttestationInfo, slot uint64) {
 
 	one := eth.EthToWei(1)
 	validatorReq := eth.EthToWei(32)
@@ -880,9 +880,6 @@ func (r *treeGeneratorImpl_v8) checkDutiesForSlot(attestations []beacon.Attestat
 			r.successfulAttestations++
 		}
 	}
-
-	return nil
-
 }
 
 // Maps out the attestaion duties for the given epoch

--- a/rocketpool-daemon/common/rewards/utils.go
+++ b/rocketpool-daemon/common/rewards/utils.go
@@ -339,7 +339,10 @@ func DownloadRewardsFile(cfg *config.SmartNodeConfig, i *sharedtypes.IntervalInf
 			deserializedRewardsFile.GetHeader().MerkleRoot = ""
 
 			// Reconstruct the merkle tree from the file data, this should overwrite the stored Merkle Root with a new one
-			deserializedRewardsFile.GenerateMerkleTree()
+			err = deserializedRewardsFile.GenerateMerkleTree()
+			if err != nil {
+				return fmt.Errorf("Error generating merkle tree from %s: %w", rewardsTreePath, err)
+			}
 
 			// Get the resulting merkle root
 			calculatedRoot := deserializedRewardsFile.GetHeader().MerkleRoot

--- a/rocketpool-daemon/common/services/requirements.go
+++ b/rocketpool-daemon/common/services/requirements.go
@@ -472,6 +472,9 @@ func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool
 		panic("context didn't have a logger!")
 	}
 
+	// Make an alerter
+	alerter := alerting.NewAlerter(sp.GetConfig(), logger)
+
 	// Wait for sync
 	for {
 		// Check timeout
@@ -488,7 +491,7 @@ func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool
 				return false, err
 			}
 			if synced {
-				alerting.AlertExecutionClientSyncComplete(sp.GetConfig())
+				alerter.AlertExecutionClientSyncComplete()
 				return true, nil
 			}
 		}
@@ -518,7 +521,7 @@ func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool
 			}
 			// Only return true if the last reportedly known block is within our defined threshold
 			if isUpToDate {
-				alerting.AlertExecutionClientSyncComplete(sp.GetConfig())
+				alerter.AlertExecutionClientSyncComplete()
 				return true, nil
 			}
 		}
@@ -556,6 +559,9 @@ func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose b
 		panic("context didn't have a logger!")
 	}
 
+	// Make an alerter
+	alerter := alerting.NewAlerter(sp.GetConfig(), logger)
+
 	// Wait for sync
 	for {
 		// Check timeout
@@ -572,7 +578,7 @@ func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose b
 				return false, err
 			}
 			if synced {
-				alerting.AlertBeaconClientSyncComplete(sp.GetConfig())
+				alerter.AlertBeaconClientSyncComplete()
 				return true, nil
 			}
 		}
@@ -589,7 +595,7 @@ func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose b
 				logger.Info("Beacon Node syncing...", slog.Float64(SyncProgressKey, syncStatus.Progress*100))
 			}
 		} else {
-			alerting.AlertBeaconClientSyncComplete(sp.GetConfig())
+			alerter.AlertBeaconClientSyncComplete()
 			return true, nil
 		}
 

--- a/rocketpool-daemon/common/validator/validator-manager.go
+++ b/rocketpool-daemon/common/validator/validator-manager.go
@@ -117,7 +117,10 @@ func (m *ValidatorManager) GetNextValidatorKey(save bool) (*eth2types.BLSPrivate
 
 		// Increment the next account
 		m.nextAccount++
-		saveNextAccount(m.nextAccount, m.cfg.GetNextAccountFilePath())
+		err = saveNextAccount(m.nextAccount, m.cfg.GetNextAccountFilePath())
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	// Return validator key
@@ -161,7 +164,10 @@ func (m *ValidatorManager) SaveValidatorKey(key ValidatorKey) error {
 	if err != nil {
 		return fmt.Errorf("could not store validator %s key: %w", key.PublicKey.HexWithPrefix(), err)
 	}
-	saveNextAccount(m.nextAccount, m.cfg.GetNextAccountFilePath())
+	err = saveNextAccount(m.nextAccount, m.cfg.GetNextAccountFilePath())
+	if err != nil {
+		return fmt.Errorf("could not store next validator account index: %w", err)
+	}
 
 	// Return
 	return nil
@@ -204,7 +210,10 @@ func (m *ValidatorManager) RecoverValidatorKey(pubkey beacon.ValidatorPubkey, st
 	if err != nil {
 		return 0, fmt.Errorf("error storing validator %s key: %w", pubkey.HexWithPrefix(), err)
 	}
-	saveNextAccount(m.nextAccount, m.cfg.GetNextAccountFilePath())
+	err = saveNextAccount(m.nextAccount, m.cfg.GetNextAccountFilePath())
+	if err != nil {
+		return 0, fmt.Errorf("error storing next validator account index: %w", err)
+	}
 
 	// Return
 	return index + startIndex, nil

--- a/rocketpool-daemon/node/distribute-minipools.go
+++ b/rocketpool-daemon/node/distribute-minipools.go
@@ -29,6 +29,7 @@ import (
 type DistributeMinipools struct {
 	sp                  *services.ServiceProvider
 	logger              *slog.Logger
+	alerter             *alerting.Alerter
 	cfg                 *config.SmartNodeConfig
 	w                   *wallet.Wallet
 	rp                  *rocketpool.RocketPool
@@ -67,6 +68,7 @@ func NewDistributeMinipools(sp *services.ServiceProvider, logger *log.Logger) *D
 	return &DistributeMinipools{
 		sp:                  sp,
 		logger:              log,
+		alerter:             alerting.NewAlerter(cfg, logger),
 		cfg:                 cfg,
 		w:                   sp.GetWallet(),
 		rp:                  sp.GetRocketPool(),
@@ -218,7 +220,7 @@ func (t *DistributeMinipools) distributeMinipools(submissions []*eth.Transaction
 	callbacks := make([]func(err error), len(minipools))
 	for i, mp := range minipools {
 		callbacks[i] = func(err error) {
-			alerting.AlertMinipoolBalanceDistributed(t.cfg, mp.MinipoolAddress, err == nil)
+			t.alerter.AlertMinipoolBalanceDistributed(mp.MinipoolAddress, err == nil)
 		}
 	}
 

--- a/rocketpool-daemon/node/metrics-exporter.go
+++ b/rocketpool-daemon/node/metrics-exporter.go
@@ -71,7 +71,7 @@ func runMetricsServer(ctx context.Context, sp *services.ServiceProvider, logger 
 	metricsPath := "/metrics"
 	http.Handle(metricsPath, handler)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html>
+		_, err := w.Write([]byte(`<html>
             <head><title>Rocket Pool Metrics Exporter</title></head>
             <body>
             <h1>Rocket Pool Metrics Exporter</h1>
@@ -79,6 +79,10 @@ func runMetricsServer(ctx context.Context, sp *services.ServiceProvider, logger 
             </body>
             </html>`,
 		))
+
+		if err != nil {
+			logger.Warn("Error replying to http request in metrics exporter", log.Err(err))
+		}
 	})
 
 	// Run the server

--- a/rocketpool-daemon/node/node.go
+++ b/rocketpool-daemon/node/node.go
@@ -52,6 +52,7 @@ const (
 type TaskLoop struct {
 	// Services
 	logger            *log.Logger
+	alerter           *alerting.Alerter
 	ctx               context.Context
 	sp                *services.ServiceProvider
 	wg                *sync.WaitGroup
@@ -92,6 +93,7 @@ func NewTaskLoop(sp *services.ServiceProvider, wg *sync.WaitGroup) *TaskLoop {
 	t := &TaskLoop{
 		sp:                          sp,
 		logger:                      logger,
+		alerter:                     alerting.NewAlerter(sp.GetConfig(), logger),
 		ctx:                         ctx,
 		wg:                          wg,
 		cfg:                         sp.GetConfig(),
@@ -198,7 +200,7 @@ func (t *TaskLoop) waitUntilReady() waitUntilReadyResult {
 	if !t.wasExecutionClientSynced {
 		t.logger.Info("Execution Client is now synced.")
 		t.wasExecutionClientSynced = true
-		alerting.AlertExecutionClientSyncComplete(t.cfg)
+		t.alerter.AlertExecutionClientSyncComplete()
 	}
 
 	// Check the BC status
@@ -217,7 +219,7 @@ func (t *TaskLoop) waitUntilReady() waitUntilReadyResult {
 	if !t.wasBeaconClientSynced {
 		t.logger.Info("Beacon Node is now synced.")
 		t.wasBeaconClientSynced = true
-		alerting.AlertBeaconClientSyncComplete(t.cfg)
+		t.alerter.AlertBeaconClientSyncComplete()
 	}
 
 	// Load contracts

--- a/rocketpool-daemon/node/promote-minipools.go
+++ b/rocketpool-daemon/node/promote-minipools.go
@@ -29,6 +29,7 @@ import (
 type PromoteMinipools struct {
 	sp             *services.ServiceProvider
 	logger         *slog.Logger
+	alerter        *alerting.Alerter
 	cfg            *config.SmartNodeConfig
 	w              *wallet.Wallet
 	rp             *rocketpool.RocketPool
@@ -46,6 +47,7 @@ func NewPromoteMinipools(sp *services.ServiceProvider, logger *log.Logger) *Prom
 	return &PromoteMinipools{
 		sp:             sp,
 		logger:         log,
+		alerter:        alerting.NewAlerter(cfg, logger),
 		cfg:            cfg,
 		w:              sp.GetWallet(),
 		rp:             sp.GetRocketPool(),
@@ -212,7 +214,7 @@ func (t *PromoteMinipools) promoteMinipools(submissions []*eth.TransactionSubmis
 	callbacks := make([]func(err error), len(minipools))
 	for i, mp := range minipools {
 		callbacks[i] = func(err error) {
-			alerting.AlertMinipoolPromoted(t.cfg, mp.MinipoolAddress, err == nil)
+			t.alerter.AlertMinipoolPromoted(mp.MinipoolAddress, err == nil)
 		}
 	}
 

--- a/rocketpool-daemon/node/reduce-bonds.go
+++ b/rocketpool-daemon/node/reduce-bonds.go
@@ -37,6 +37,7 @@ const (
 type ReduceBonds struct {
 	sp             *services.ServiceProvider
 	logger         *slog.Logger
+	alerter        *alerting.Alerter
 	cfg            *config.SmartNodeConfig
 	w              *wallet.Wallet
 	rp             *rocketpool.RocketPool
@@ -60,6 +61,7 @@ func NewReduceBonds(sp *services.ServiceProvider, logger *log.Logger) *ReduceBon
 	return &ReduceBonds{
 		sp:             sp,
 		logger:         log,
+		alerter:        alerting.NewAlerter(cfg, logger),
 		cfg:            cfg,
 		w:              sp.GetWallet(),
 		rp:             sp.GetRocketPool(),
@@ -364,7 +366,7 @@ func (t *ReduceBonds) reduceBonds(submissions []*eth.TransactionSubmission, mini
 	callbacks := make([]func(err error), len(minipools))
 	for i, mp := range minipools {
 		callbacks[i] = func(err error) {
-			alerting.AlertMinipoolBondReduced(t.cfg, mp.Address, err == nil)
+			t.alerter.AlertMinipoolBondReduced(mp.Address, err == nil)
 		}
 	}
 

--- a/rocketpool-daemon/rocketpool-daemon.go
+++ b/rocketpool-daemon/rocketpool-daemon.go
@@ -108,7 +108,10 @@ func main() {
 			fmt.Println("Shutting down node and watchtower...")
 			sp.CancelContextOnShutdown()
 			serverMgr.Stop()
-			nodeLoop.Stop()
+			err := nodeLoop.Stop()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error shutting down node: %s\n", err.Error())
+			}
 		}()
 
 		// Run the daemon until closed

--- a/rocketpool-daemon/watchtower/submit-rewards-tree-rolling.go
+++ b/rocketpool-daemon/watchtower/submit-rewards-tree-rolling.go
@@ -410,8 +410,7 @@ func (t *SubmitRewardsTree_Rolling) isExistingRewardsFileValid(rewardIndex uint6
 
 		var hasSubmitted bool
 		err = t.rp.Query(func(mc *batch.MultiCaller) error {
-			t.rewardsPool.GetTrustedNodeSubmittedSpecificRewards(mc, &hasSubmitted, nodeAddress, submission)
-			return nil
+			return t.rewardsPool.GetTrustedNodeSubmittedSpecificRewards(mc, &hasSubmitted, nodeAddress, submission)
 		}, nil)
 		if err != nil {
 			t.logger.Warn("Could not check if node has previously submitted rewards file; regenerating file...\n", slog.String(keys.FileKey, rewardsTreePath), log.Err(err))

--- a/rocketpool-daemon/watchtower/submit-scrub-minipools.go
+++ b/rocketpool-daemon/watchtower/submit-scrub-minipools.go
@@ -247,7 +247,7 @@ func (t *SubmitScrubMinipools) initializeMinipoolDetails(minipools []rpstate.Nat
 }
 
 // Step 1: Verify the Beacon Chain credentials for a minipool if they're present
-func (t *SubmitScrubMinipools) verifyBeaconWithdrawalCredentials(state *state.NetworkState) error {
+func (t *SubmitScrubMinipools) verifyBeaconWithdrawalCredentials(state *state.NetworkState) {
 	minipoolsToScrub := []minipool.IMinipool{}
 
 	// Get the withdrawal credentials on Beacon for each validator if they exist
@@ -281,8 +281,6 @@ func (t *SubmitScrubMinipools) verifyBeaconWithdrawalCredentials(state *state.Ne
 			t.logger.Error("ALERT: Couldn't scrub minipool", slog.String(keys.MinipoolKey, minipool.Common().Address.Hex()), log.Err(err))
 		}
 	}
-
-	return nil
 }
 
 // Get various elements needed to do eth1 prestake and deposit contract searches

--- a/shared/keys/keys.go
+++ b/shared/keys/keys.go
@@ -77,4 +77,5 @@ const (
 	SubmittedKey              string = "submitted"
 	NextKey                   string = "next"
 	TimeKey                   string = "time"
+	ModuleKey                 string = "module"
 )


### PR DESCRIPTION
The `alerting` package previously was stateless and simply recreated state every time any alert was called.

Now it is stateful, and only checks config on init(). Logging is done through a logger instead of through stdout.

Fixes `errcheck` issues and uses newest `rocketpool-go/v2` and `node-manager-core` commits which resolve upstream errcheck issues.

Enables all linters :tada: 