### PR TITLE
fix: An error would occur starting the smartnode when alerting was enabled but metrics was not

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -523,7 +523,11 @@ func startService(c *cli.Context, ignoreConfigSuggestion bool) error {
 		if err != nil {
 			return err
 		}
+	}
 
+	// Update the Alertmanager configuration files even if metrics is disabled; as smartnode sends some alerts directly
+	alertingEnabled := cfg.Alertmanager.EnableAlerting.Value.(bool)
+	if alertingEnabled {
 		err = cfg.Alertmanager.UpdateConfigurationFiles(rp.ConfigPath())
 		if err != nil {
 			return err


### PR DESCRIPTION
When enabling alerting in the TUI but not enabling Metrics, the following error would occur starting smartnode:

```sh
$ ./rp-run.sh s start

Validator client [lodestar] was previously used - no slashing prevention delay necessary.
[+] Running 8/8
 ✔ Container rocketpool_alertmanager  Created                                                                                                             0.0s 
 ✔ Container rocketpool_addon_gww     Started                                                                                                             0.0s 
 ✔ Container rocketpool_watchtower    Started                                                                                                             0.0s 
 ✔ Container rocketpool_eth2          Started                                                                                                             0.0s 
 ✔ Container rocketpool_eth1          Started                                                                                                             0.0s 
 ✔ Container rocketpool_api           Started                                                                                                             0.0s 
 ✔ Container rocketpool_node          Started                                                                                                             0.0s 
 ✔ Container rocketpool_validator     Started                                                                                                             0.0s 
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/scott/.rocketpool/alerting/alertmanager.yml" to rootfs at "/etc/alertmanager/alertmanager.yml": mount /home/scott/.rocketpool/alerting/alertmanager.yml:/etc/alertmanager/alertmanager.yml (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
exit status 1
exit status 1
```

Doing the same command to start it with the same config after this fix:

```sh
scott@debprime (master *): ~/src/rocket-pool/smartnode$ ./rp-run.sh s start

Validator client [lodestar] was previously used - no slashing prevention delay necessary.
[+] Running 8/8
 ✔ Container rocketpool_node          Started                                                                                                             0.0s 
 ✔ Container rocketpool_alertmanager  Started                                                                                                             0.0s 
 ✔ Container rocketpool_addon_gww     Started                                                                                                             0.0s 
 ✔ Container rocketpool_eth2          Started                                                                                                             0.0s 
 ✔ Container rocketpool_eth1          Started                                                                                                             0.0s 
 ✔ Container rocketpool_api           Started                                                                                                             0.0s 
 ✔ Container rocketpool_watchtower    Started                                                                                                             0.0s 
 ✔ Container rocketpool_validator     Started                                                                                                             0.0s 
```

This was uncovered in the support channel at https://discord.com/channels/405159462932971535/468923220607762485/1232740280067948695
