### PR TITLE
Fix data type and heading color

### DIFF
--- a/rocketpool-cli/pdao/get-voting-power.go
+++ b/rocketpool-cli/pdao/get-voting-power.go
@@ -12,6 +12,7 @@ import (
 const (
 	colorBlue  string = "\033[36m"
 	colorReset string = "\033[0m"
+	colorGreen string = "\033[32m"
 )
 
 func getVotePower(c *cli.Context) error {
@@ -44,7 +45,7 @@ func getVotePower(c *cli.Context) error {
 	}
 
 	// Print Results
-	fmt.Println("== Node Voting Power ==")
+	fmt.Printf("%s== Node Voting Power ==%s\n", colorGreen, colorReset)
 	if status.IsVotingInitialized {
 		fmt.Println("The node has been initialized for onchain voting.")
 

--- a/rocketpool/api/pdao/get-voting-power.go
+++ b/rocketpool/api/pdao/get-voting-power.go
@@ -67,10 +67,10 @@ func getVotePower(c *cli.Context) (*api.GetPDAOVotePowerResponse, error) {
 	}
 
 	// Cast to uint32
-	blockNumber32 := uint32(blockNumber)
+	response.BlockNumber = uint32(blockNumber)
 
 	// Check voting power
-	response.VotingPower, err = network.GetVotingPower(rp, nodeAccount.Address, blockNumber32, nil)
+	response.VotingPower, err = network.GetVotingPower(rp, nodeAccount.Address, response.BlockNumber, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -410,5 +410,5 @@ type GetPDAOVotePowerResponse struct {
 	VotingPower                    *big.Int       `json:"votingPower"`
 	OnchainVotingDelegate          common.Address `json:"onchainVotingDelegate"`
 	OnchainVotingDelegateFormatted string         `json:"onchainVotingDelegateFormatted"`
-	BlockNumber                    uint64         `json:"blockNumber"`
+	BlockNumber                    uint32         `json:"blockNumber"`
 }


### PR DESCRIPTION
Implemented some suggestions Joe pointed out this morning:

- pdao `BlockNumber` response should be `uint32`
- populated response on L70

- added color to the heading to be consistent with other status menus. 