### PR TITLE
Add check for nodes that registered pre-houston to onchain voting status.

### DIFF
--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -193,7 +193,9 @@ func getStatus(c *cli.Context) error {
 				fmt.Println("The node has NOT been initialized for onchain voting. You need to run `rocketpool pdao initialize-voting` to participate in onchain votes.")
 			}
 
-			if status.OnchainVotingDelegate == status.AccountAddress {
+			if status.OnchainVotingDelegate == blankAddress {
+				fmt.Println("The node doesn't have a delegate, which means it can vote directly on onchain proposals after it initializes voting.")
+			} else if status.OnchainVotingDelegate == status.AccountAddress {
 				fmt.Println("The node doesn't have a delegate, which means it can vote directly on onchain proposals. You can have another node represent you by running `rocketpool p svd <address>`.")
 			} else {
 				fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool onchain governance proposals.\n", colorBlue, status.OnchainVotingDelegateFormatted, colorReset)

--- a/rocketpool-cli/pdao/get-voting-power.go
+++ b/rocketpool-cli/pdao/get-voting-power.go
@@ -3,6 +3,7 @@ package pdao
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli"
 
 	"github.com/rocket-pool/rocketpool-go/utils/eth"
@@ -52,8 +53,13 @@ func getVotePower(c *cli.Context) error {
 	} else {
 		fmt.Println("The node has NOT been initialized for onchain voting. You need to run `rocketpool pdao initialize-voting` to participate in onchain votes.")
 	}
-	if status.OnchainVotingDelegate == status.AccountAddress {
-		fmt.Println("The node doesn't have a delegate, which means it can vote directly on onchain proposals.")
+
+	blankAddress := common.Address{}
+
+	if status.OnchainVotingDelegate == blankAddress {
+		fmt.Println("The node doesn't have a delegate, which means it can vote directly on onchain proposals after it initializes voting.")
+	} else if status.OnchainVotingDelegate == status.AccountAddress {
+		fmt.Println("The node doesn't have a delegate, which means it can vote directly on onchain proposals. You can have another node represent you by running `rocketpool p svd <address>`.")
 	} else {
 		fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool onchain governance proposals.\n", colorBlue, status.OnchainVotingDelegateFormatted, colorReset)
 	}


### PR DESCRIPTION
Nodes that registered pre-houston and haven't initialized voting default to `0x0000000000000000000000000000000000000000` as their delegate, which causes `rp n s` to display the wrong information. 

Before
```
=== Onchain Voting ===
The node has NOT been initialized for onchain voting. You need to run `rocketpool pdao initialize-voting` to participate in onchain votes.
The node has a voting delegate of 0x0000000000000000000000000000000000000000 which can represent it when voting on Rocket Pool onchain governance proposals.
The node is NOT allowed to lock RPL to create governance proposals/challenges.
```

After
```
=== Onchain Voting ===
The node has NOT been initialized for onchain voting. You need to run `rocketpool pdao initialize-voting` to participate in onchain votes.
The node doesn't have a delegate, which means it can vote directly on onchain proposals after it initializes voting.
The node is NOT allowed to lock RPL to create governance proposals/challenges.
```
