### PR TITLE
Add missing param.

### DIFF
--- a/shared/config/mev-boost-config.go
+++ b/shared/config/mev-boost-config.go
@@ -255,6 +255,7 @@ func (cfg *MevBoostConfig) GetTitle() string {
 // Get the Parameters for this config
 func (cfg *MevBoostConfig) GetParameters() []config.IParameter {
 	return []config.IParameter{
+		&cfg.Enable,
 		&cfg.Mode,
 		&cfg.SelectionMode,
 		&cfg.EnableRegulatedAllMev,


### PR DESCRIPTION
Adding a missing parameter on the mev-boost configuration.