### PR TITLE
Fix insufficentBalance comparison

### DIFF
--- a/rocketpool-daemon/api/node/send.go
+++ b/rocketpool-daemon/api/node/send.go
@@ -130,7 +130,7 @@ func (c *nodeSendContext) PrepareData(data *api.NodeSendData, opts *bind.Transac
 	}
 
 	// Check the balance
-	data.InsufficientBalance = (data.Balance.Cmp(common.Big0) == 0)
+	data.InsufficientBalance = (data.Balance.Cmp(c.amount) == -1)
 	data.CanSend = !(data.InsufficientBalance)
 
 	// Get the TX Info


### PR DESCRIPTION
Currently, InsufficientBalance check will always return false as long as there's a balance in the wallet. This PR updates the logic to compare the wallet balance against the transfer amount.