### PR TITLE
Handle not in rp nodeset bug

### DIFF
--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -78,10 +78,9 @@ func getStatus(c *cli.Context) error {
 	// Onchain Voting Status
 	fmt.Printf("%s=== Onchain Voting ===%s\n", colorGreen, colorReset)
 	if response.IsVotingInitialized {
-		fmt.Printf("The node has %s%s%s been initialized for onchain voting.", colorBlue, response.AccountAddressFormatted, colorReset)
-
+		fmt.Printf("The node has %s%s%s been initialized for onchain voting.\n", colorBlue, response.AccountAddressFormatted, colorReset)
 	} else {
-		fmt.Println("The node has NOT been initialized for onchain voting. You need to run `rocketpool pdao initialize-voting` to participate in onchain votes.")
+		fmt.Printf("The node %s%s%s has NOT been initialized for onchain voting. You need to run `rocketpool pdao initialize-voting` to participate in onchain votes.\n", colorBlue, response.AccountAddressFormatted, colorReset)
 	}
 
 	if response.OnchainVotingDelegate == blankAddress {
@@ -93,10 +92,13 @@ func getStatus(c *cli.Context) error {
 	}
 	fmt.Printf("The node's local voting power: %.10f\n", eth.WeiToEth(response.VotingPower))
 
-	fmt.Printf("Total voting power delegated to the node: %.10f\n", eth.WeiToEth(response.TotalDelegatedVp))
+	if response.IsVotingInitialized != false {
+		fmt.Printf("Total voting power delegated to the node: %.10f\n", eth.WeiToEth(response.TotalDelegatedVp))
+	} else {
+		fmt.Print("The node must initialize onchain voting to be eligible to recieve delegated voting power.\n")
+	}
 
 	fmt.Printf("Network total initialized voting power: %.10f\n", eth.WeiToEth(response.SumVotingPower))
-
 	fmt.Println("")
 
 	// Claimable Bonds Status:
@@ -109,7 +111,7 @@ func getStatus(c *cli.Context) error {
 		}
 
 	} else {
-		fmt.Print("The node is NOT allowed to lock RPL to create governance proposals/challenges. Use 'rocketpool node  allow-rpl-locking, to allow RPL locking.\n")
+		fmt.Print("The node is NOT allowed to lock RPL to create governance proposals/challenges. Use 'rocketpool node allow-rpl-locking, to allow RPL locking.\n")
 	}
 	if len(claimableBonds) == 0 {
 		fmt.Println("You do not have any unlockable bonds or claimable rewards.")

--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rocket-pool/rocketpool-go/utils/strings"
 	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
 	"github.com/rocket-pool/smartnode/shared/types/api"
+	cliutils "github.com/rocket-pool/smartnode/shared/utils/cli"
 	"github.com/rocket-pool/smartnode/shared/utils/math"
 )
 
@@ -30,6 +31,18 @@ func getStatus(c *cli.Context) error {
 
 	// Get wallet status
 	walletStatus, err := rp.WalletStatus()
+	if err != nil {
+		return err
+	}
+
+	// Get the config
+	cfg, isNew, err := rp.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("Error loading configuration: %w", err)
+	}
+
+	// Print what network we're on
+	err = cliutils.PrintNetwork(cfg.GetNetwork(), isNew)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -1,6 +1,7 @@
 package pdao
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -26,6 +27,17 @@ func getStatus(c *cli.Context) error {
 	// Get RP client
 	rp := rocketpool.NewClientFromCtx(c)
 	defer rp.Close()
+
+	// Get wallet status
+	walletStatus, err := rp.WalletStatus()
+	if err != nil {
+		return err
+	}
+
+	// rp.PDAOStatus() will fail with an error, but we can short-circuit it here.
+	if !walletStatus.WalletInitialized {
+		return errors.New("The node wallet is not initialized.")
+	}
 
 	// Get PDAO status at the latest block
 	response, err := rp.PDAOStatus()

--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -117,10 +117,10 @@ func getStatus(c *cli.Context) error {
 	}
 	fmt.Printf("The node's local voting power: %.10f\n", eth.WeiToEth(response.VotingPower))
 
-	if response.IsVotingInitialized != false {
+	if response.IsNodeRegistered != false {
 		fmt.Printf("Total voting power delegated to the node: %.10f\n", eth.WeiToEth(response.TotalDelegatedVp))
 	} else {
-		fmt.Print("The node must initialize onchain voting to be eligible to recieve delegated voting power.\n")
+		fmt.Print("The node must register using 'rocketpool node register' to be eligible to receive delegated voting power.\n")
 	}
 
 	fmt.Printf("Network total initialized voting power: %.10f\n", eth.WeiToEth(response.SumVotingPower))

--- a/rocketpool/api/pdao/status.go
+++ b/rocketpool/api/pdao/status.go
@@ -49,7 +49,6 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	// Response
 	response := api.PDAOStatusResponse{}
 	response.NodeRPLLocked = big.NewInt(0)
@@ -164,11 +163,17 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	totalDelegatedVP, _, _, err := propMgr.GetArtifactsForVoting(response.BlockNumber, nodeAccount.Address)
-	if err != nil {
-		return nil, err
+
+	// Get the delegated voting power if voting is initialized
+	if response.IsVotingInitialized {
+		totalDelegatedVP, _, _, err := propMgr.GetArtifactsForVoting(response.BlockNumber, nodeAccount.Address)
+		if err != nil {
+			return nil, err
+		}
+		response.TotalDelegatedVp = totalDelegatedVP
+	} else {
+		response.TotalDelegatedVp = nil
 	}
-	response.TotalDelegatedVp = totalDelegatedVP
 
 	// Get the local tree
 	votingTree, err := propMgr.GetNetworkTree(response.BlockNumber, nil)

--- a/rocketpool/api/pdao/status.go
+++ b/rocketpool/api/pdao/status.go
@@ -116,6 +116,13 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 		return err
 	})
 
+	// Check if Node is registered
+	wg.Go(func() error {
+		var err error
+		response.IsNodeRegistered, err = node.GetNodeExists(rp, nodeAccount.Address, nil)
+		return err
+	})
+
 	// Get active and past votes from Snapshot, but treat errors as non-Fatal
 	if s != nil {
 		wg.Go(func() error {

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -426,6 +426,7 @@ type PDAOStatusResponse struct {
 	AccountAddressFormatted string         `json:"accountAddressFormatted"`
 	TotalDelegatedVp        *big.Int       `json:"totalDelegateVp"`
 	SumVotingPower          *big.Int       `json:"sumVotingPower"`
+	IsNodeRegistered        bool           `json:"isNodeRegistered"`
 }
 
 type PDAOCanSetSignallingAddressResponse struct {


### PR DESCRIPTION
- Fix "address is not in the RP node set" (when voting isn't initialized and you call `rp p s`). This causes the call to return instead of printing the rest of the menu.
```
ubuntu@v1stable:~$ rocketpool p s

error after requesting get-voting-power: address 0xa6073aEecB94FB769bB1b3754A0ef8b3bec36199 is not in the RP node set
```
- Add wallet not initialized check
- Add display for selected network

before:
```
tpan@tpan-meerkat:~$ rocketpool p s

error after requesting get-voting-power: Wallet is not initialized
```
after:
```
tpan@tpan-meerkat:~$ rocketpool p s

Your Smart Node is currently using the Holesky Test Network.

The node wallet is not initialized.
```

Also included some small changes to the `pdao status` menu output (e.g missing newlines) 
