### PR TITLE
Refactor initialize-voting to initialize-voting-with-delegate 

### DIFF
--- a/rocketpool-cli/pdao/commands.go
+++ b/rocketpool-cli/pdao/commands.go
@@ -67,10 +67,22 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				},
 			},
 			{
+				Name:      "initialize-voting",
+				Aliases:   []string{"iv"},
+				Usage:     "Unlocks a node operator's voting power (only required for node operators who registered before governance structure was in place)",
+				UsageText: "rocketpool pdao initialize-voting",
+				Action: func(c *cli.Context) error {
+
+					// Run
+					return initializeVoting(c)
+
+				},
+			},
+			{
 				Name:      "initialize-voting-with-delegate",
 				Aliases:   []string{"ivd"},
 				Usage:     "Unlocks a node operator's voting power and sets the delegate (saves some gas by initializing and setting the delegate in one transaction)",
-				UsageText: "rocketpool pdao initialize-voting",
+				UsageText: "rocketpool pdao initialize-voting-with-delegate",
 				Action: func(c *cli.Context) error {
 
 					// Run
@@ -78,7 +90,6 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 				},
 			},
-
 			{
 				Name:      "set-signalling-address",
 				Aliases:   []string{"ssa"},

--- a/rocketpool-cli/pdao/commands.go
+++ b/rocketpool-cli/pdao/commands.go
@@ -67,14 +67,14 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				},
 			},
 			{
-				Name:      "initialize-voting",
-				Aliases:   []string{"iv"},
-				Usage:     "Unlocks a node operator's voting power (only required for node operators who registered before governance structure was in place)",
+				Name:      "initialize-voting-with-delegate",
+				Aliases:   []string{"ivd"},
+				Usage:     "Unlocks a node operator's voting power and sets the delegate (saves some gas by initializing and setting the delegate in one transaction)",
 				UsageText: "rocketpool pdao initialize-voting",
 				Action: func(c *cli.Context) error {
 
 					// Run
-					return initializeVoting(c)
+					return initializeVotingWithDelegate(c)
 
 				},
 			},

--- a/rocketpool-cli/pdao/initialize-voting-with-delegate.go
+++ b/rocketpool-cli/pdao/initialize-voting-with-delegate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-func initializeVoting(c *cli.Context) error {
+func initializeVotingWithDelegate(c *cli.Context) error {
 	// Get RP client
 	rp, err := rocketpool.NewClientFromCtx(c).WithReady()
 	if err != nil {

--- a/rocketpool-cli/pdao/initialize-voting.go
+++ b/rocketpool-cli/pdao/initialize-voting.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-func initializeVotingWithDelegate(c *cli.Context) error {
+func initializeVoting(c *cli.Context) error {
 	// Get RP client
 	rp, err := rocketpool.NewClientFromCtx(c).WithReady()
 	if err != nil {
@@ -17,17 +17,7 @@ func initializeVotingWithDelegate(c *cli.Context) error {
 	}
 	defer rp.Close()
 
-	// Get the address
-	delegateAddressString := c.String("address")
-	if delegateAddressString == "" {
-		delegateAddressString = cliutils.Prompt("Please enter the delegate's address:", "^0x[0-9a-fA-F]{40}$", "Invalid member address")
-	}
-	delegateAddress, err := cliutils.ValidateAddress("delegateAddress", delegateAddressString)
-	if err != nil {
-		return err
-	}
-
-	resp, err := rp.CanInitializeVotingWithDelegate(delegateAddress)
+	resp, err := rp.CanInitializeVoting()
 	if err != nil {
 		return fmt.Errorf("error calling get-voting-initialized: %w", err)
 	}
@@ -50,7 +40,7 @@ func initializeVotingWithDelegate(c *cli.Context) error {
 	}
 
 	// Initialize voting
-	response, err := rp.InitializeVotingWithDelegate(delegateAddress)
+	response, err := rp.InitializeVoting()
 	if err != nil {
 		return fmt.Errorf("error calling initialize-voting: %w", err)
 	}

--- a/rocketpool/api/pdao/commands.go
+++ b/rocketpool/api/pdao/commands.go
@@ -923,10 +923,10 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 				},
 			},
 			{
-				Name:      "can-initialize-voting",
-				Aliases:   []string{"civ"},
+				Name:      "can-initialize-voting-with-delegate",
+				Aliases:   []string{"civd"},
 				Usage:     "Checks if voting can be initialized.",
-				UsageText: "rocketpool api pdao can-initialize-voting delegate-address",
+				UsageText: "rocketpool api pdao can-initialize-voting-with-delegate delegate-address",
 				Action: func(c *cli.Context) error {
 
 					// Validate args
@@ -940,16 +940,16 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 					}
 
 					// Run
-					api.PrintResponse(canNodeInitializeVoting(c, delegateAddress))
+					api.PrintResponse(canNodeInitializeVotingWithDelegate(c, delegateAddress))
 					return nil
 
 				},
 			},
 			{
-				Name:      "initialize-voting",
-				Aliases:   []string{"iv"},
-				Usage:     "Initialize voting.",
-				UsageText: "rocketpool api pdao initialize-voting delegate-address",
+				Name:      "initialize-voting-with-delegate",
+				Aliases:   []string{"ivd"},
+				Usage:     "Initialize voting with delegate.",
+				UsageText: "rocketpool api pdao initialize-voting-with-delegate delegate-address",
 				Action: func(c *cli.Context) error {
 
 					// Validate args
@@ -963,11 +963,49 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 					}
 
 					// Run
-					api.PrintResponse(nodeInitializeVoting(c, delegateAddress))
+					api.PrintResponse(nodeInitializeVotingWithDelegate(c, delegateAddress))
 					return nil
 
 				},
 			},
+
+			// {
+			// 	Name:      "can-initialize-voting",
+			// 	Aliases:   []string{"civ"},
+			// 	Usage:     "Checks if voting can be initialized.",
+			// 	UsageText: "rocketpool api pdao can-initialize-voting delegate-address",
+			// 	Action: func(c *cli.Context) error {
+
+			// 		// Validate args
+			// 		if err := cliutils.ValidateArgCount(c, 0); err != nil {
+			// 			return err
+			// 		}
+
+			// 		// Run
+			// 		api.PrintResponse(canNodeInitializeVoting(c))
+			// 		return nil
+
+			// 	},
+			// },
+			// {
+			// 	Name:      "initialize-voting",
+			// 	Aliases:   []string{"iv"},
+			// 	Usage:     "Initialize voting.",
+			// 	UsageText: "rocketpool api pdao initialize-voting delegate-address",
+			// 	Action: func(c *cli.Context) error {
+
+			// 		// Validate args
+			// 		if err := cliutils.ValidateArgCount(c, 0); err != nil {
+			// 			return err
+			// 		}
+
+			// 		// Run
+			// 		api.PrintResponse(nodeInitializeVoting(c))
+			// 		return nil
+
+			// 	},
+			// },
+
 			{
 				Name:      "estimate-set-voting-delegate-gas",
 				Usage:     "Estimate the gas required to set an on-chain voting delegate",

--- a/rocketpool/api/pdao/commands.go
+++ b/rocketpool/api/pdao/commands.go
@@ -968,44 +968,42 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 
 				},
 			},
+			{
+				Name:      "can-initialize-voting",
+				Aliases:   []string{"civ"},
+				Usage:     "Checks if voting can be initialized.",
+				UsageText: "rocketpool api pdao can-initialize-voting delegate-address",
+				Action: func(c *cli.Context) error {
 
-			// {
-			// 	Name:      "can-initialize-voting",
-			// 	Aliases:   []string{"civ"},
-			// 	Usage:     "Checks if voting can be initialized.",
-			// 	UsageText: "rocketpool api pdao can-initialize-voting delegate-address",
-			// 	Action: func(c *cli.Context) error {
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
 
-			// 		// Validate args
-			// 		if err := cliutils.ValidateArgCount(c, 0); err != nil {
-			// 			return err
-			// 		}
+					// Run
+					api.PrintResponse(canNodeInitializeVoting(c))
+					return nil
 
-			// 		// Run
-			// 		api.PrintResponse(canNodeInitializeVoting(c))
-			// 		return nil
+				},
+			},
+			{
+				Name:      "initialize-voting",
+				Aliases:   []string{"iv"},
+				Usage:     "Initialize voting.",
+				UsageText: "rocketpool api pdao initialize-voting delegate-address",
+				Action: func(c *cli.Context) error {
 
-			// 	},
-			// },
-			// {
-			// 	Name:      "initialize-voting",
-			// 	Aliases:   []string{"iv"},
-			// 	Usage:     "Initialize voting.",
-			// 	UsageText: "rocketpool api pdao initialize-voting delegate-address",
-			// 	Action: func(c *cli.Context) error {
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
 
-			// 		// Validate args
-			// 		if err := cliutils.ValidateArgCount(c, 0); err != nil {
-			// 			return err
-			// 		}
+					// Run
+					api.PrintResponse(nodeInitializeVoting(c))
+					return nil
 
-			// 		// Run
-			// 		api.PrintResponse(nodeInitializeVoting(c))
-			// 		return nil
-
-			// 	},
-			// },
-
+				},
+			},
 			{
 				Name:      "estimate-set-voting-delegate-gas",
 				Usage:     "Estimate the gas required to set an on-chain voting delegate",

--- a/rocketpool/api/pdao/initialize-voting-with-delegate.go
+++ b/rocketpool/api/pdao/initialize-voting-with-delegate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rocket-pool/smartnode/shared/utils/eth1"
 )
 
-func canNodeInitializeVoting(c *cli.Context, delegateAddress common.Address) (*api.PDAOCanInitializeVotingResponse, error) {
+func canNodeInitializeVotingWithDelegate(c *cli.Context, delegateAddress common.Address) (*api.PDAOCanInitializeVotingResponse, error) {
 
 	// Get services
 	if err := services.RequireNodeWallet(c); err != nil {
@@ -60,7 +60,7 @@ func canNodeInitializeVoting(c *cli.Context, delegateAddress common.Address) (*a
 	return &response, nil
 }
 
-func nodeInitializeVoting(c *cli.Context, delegateAddress common.Address) (*api.PDAOInitializeVotingResponse, error) {
+func nodeInitializeVotingWithDelegate(c *cli.Context, delegateAddress common.Address) (*api.PDAOInitializeVotingResponse, error) {
 
 	// Get services
 	if err := services.RequireNodeWallet(c); err != nil {

--- a/rocketpool/api/pdao/initialize-voting.go
+++ b/rocketpool/api/pdao/initialize-voting.go
@@ -1,0 +1,109 @@
+package pdao
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+
+	"github.com/rocket-pool/rocketpool-go/network"
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+	"github.com/rocket-pool/smartnode/shared/utils/eth1"
+)
+
+func canNodeInitializeVoting(c *cli.Context) (*api.PDAOCanInitializeVotingResponse, error) {
+
+	// Get services
+	if err := services.RequireNodeWallet(c); err != nil {
+		return nil, err
+	}
+	if err := services.RequireRocketStorage(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+	rp, err := services.GetRocketPool(c)
+	if err != nil {
+		return nil, err
+	}
+	nodeAccount, err := w.GetNodeAccount()
+	if err != nil {
+		return nil, err
+	}
+
+	// Response
+	response := api.PDAOCanInitializeVotingResponse{}
+
+	isInitialized, err := network.GetVotingInitialized(rp, nodeAccount.Address, nil)
+	if isInitialized {
+		return nil, fmt.Errorf("voting already initialized")
+	}
+
+	// Get transactor
+	opts, err := w.GetNodeAccountTransactor()
+	if err != nil {
+		return nil, err
+	}
+
+	gasInfo, err := network.EstimateInitializeVotingGas(rp, opts)
+	if err != nil {
+		return nil, fmt.Errorf("Could not estimate the gas required to claim RPL: %w", err)
+	}
+	response.GasInfo = gasInfo
+
+	return &response, nil
+}
+
+func nodeInitializeVoting(c *cli.Context) (*api.PDAOInitializeVotingResponse, error) {
+
+	// Get services
+	if err := services.RequireNodeWallet(c); err != nil {
+		return nil, err
+	}
+	if err := services.RequireRocketStorage(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+	rp, err := services.GetRocketPool(c)
+	if err != nil {
+		return nil, err
+	}
+	nodeAccount, err := w.GetNodeAccount()
+	if err != nil {
+		return nil, err
+	}
+
+	// Response
+	response := api.PDAOInitializeVotingResponse{}
+
+	isInitialized, err := network.GetVotingInitialized(rp, nodeAccount.Address, nil)
+	if isInitialized {
+		return nil, fmt.Errorf("voting already initialized")
+	}
+
+	// Get transactor
+	opts, err := w.GetNodeAccountTransactor()
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the provided pending TX if requested
+	err = eth1.CheckForNonceOverride(c, opts)
+	if err != nil {
+		return nil, fmt.Errorf("Error checking for nonce override: %w", err)
+	}
+
+	hash, err := network.InitializeVoting(rp, opts)
+	if err != nil {
+		return nil, fmt.Errorf("Error initializing voting: %w", err)
+	}
+	response.TxHash = hash
+
+	return &response, nil
+
+}

--- a/shared/services/rocketpool/pdao.go
+++ b/shared/services/rocketpool/pdao.go
@@ -656,8 +656,8 @@ func (c *Client) GetCurrentVotingDelegate() (api.PDAOCurrentVotingDelegateRespon
 }
 
 // CanInitializeVoting fetches whether the node's is initialized for on-chain voting
-func (c *Client) CanInitializeVoting(delegateAddress common.Address) (api.PDAOCanInitializeVotingResponse, error) {
-	responseBytes, err := c.callAPI(fmt.Sprintf("pdao can-initialize-voting %s", delegateAddress.Hex()))
+func (c *Client) CanInitializeVoting() (api.PDAOCanInitializeVotingResponse, error) {
+	responseBytes, err := c.callAPI("pdao can-initialize-voting")
 	if err != nil {
 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not call can-initialize-voting: %w", err)
 	}
@@ -672,8 +672,8 @@ func (c *Client) CanInitializeVoting(delegateAddress common.Address) (api.PDAOCa
 }
 
 // InitializeVoting unlocks the node's voting power
-func (c *Client) InitializeVoting(delegateAddress common.Address) (api.PDAOInitializeVotingResponse, error) {
-	responseBytes, err := c.callAPI(fmt.Sprintf("pdao initialize-voting %s", delegateAddress.Hex()))
+func (c *Client) InitializeVoting() (api.PDAOInitializeVotingResponse, error) {
+	responseBytes, err := c.callAPI("pdao initialize-voting")
 	if err != nil {
 		return api.PDAOInitializeVotingResponse{}, fmt.Errorf("could not call initialize-voting: %w", err)
 	}
@@ -687,23 +687,23 @@ func (c *Client) InitializeVoting(delegateAddress common.Address) (api.PDAOIniti
 	return response, nil
 }
 
-// // CanInitializeVoting fetches whether the node's is initialized for on-chain voting
-// func (c *Client) CanInitializeVotingWithDelegate(delegateAddress common.Address) (api.PDAOCanInitializeVotingResponse, error) {
-// 	responseBytes, err := c.callAPI(fmt.Sprintf("pdao can-initialize-voting-with-delegate %s", delegateAddress.Hex()))
-// 	if err != nil {
-// 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not call can-initialize-voting-with-delegate: %w", err)
-// 	}
-// 	var response api.PDAOCanInitializeVotingResponse
-// 	if err := json.Unmarshal(responseBytes, &response); err != nil {
-// 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not decode can-initialize-voting-with-delegate response: %w", err)
-// 	}
-// 	if response.Error != "" {
-// 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("error after requesting can-initialize-voting-with-delegate: %s", response.Error)
-// 	}
-// 	return response, nil
-// }
+// CanInitializeVotingWithDelegate fetches whether the node's is initialized for on-chain voting
+func (c *Client) CanInitializeVotingWithDelegate(delegateAddress common.Address) (api.PDAOCanInitializeVotingResponse, error) {
+	responseBytes, err := c.callAPI(fmt.Sprintf("pdao can-initialize-voting-with-delegate %s", delegateAddress.Hex()))
+	if err != nil {
+		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not call can-initialize-voting-with-delegate: %w", err)
+	}
+	var response api.PDAOCanInitializeVotingResponse
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not decode can-initialize-voting-with-delegate response: %w", err)
+	}
+	if response.Error != "" {
+		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("error after requesting can-initialize-voting-with-delegate: %s", response.Error)
+	}
+	return response, nil
+}
 
-// InitializeVoting unlocks the node's voting power
+// InitializeVotingWithDelegate unlocks the node's voting power and sets the delegate in one transaction
 func (c *Client) InitializeVotingWithDelegate(delegateAddress common.Address) (api.PDAOInitializeVotingWithDelegateResponse, error) {
 	responseBytes, err := c.callAPI(fmt.Sprintf("pdao initialize-voting-with-delegate %s", delegateAddress.Hex()))
 	if err != nil {

--- a/shared/services/rocketpool/pdao.go
+++ b/shared/services/rocketpool/pdao.go
@@ -687,6 +687,38 @@ func (c *Client) InitializeVoting(delegateAddress common.Address) (api.PDAOIniti
 	return response, nil
 }
 
+// // CanInitializeVoting fetches whether the node's is initialized for on-chain voting
+// func (c *Client) CanInitializeVotingWithDelegate(delegateAddress common.Address) (api.PDAOCanInitializeVotingResponse, error) {
+// 	responseBytes, err := c.callAPI(fmt.Sprintf("pdao can-initialize-voting-with-delegate %s", delegateAddress.Hex()))
+// 	if err != nil {
+// 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not call can-initialize-voting-with-delegate: %w", err)
+// 	}
+// 	var response api.PDAOCanInitializeVotingResponse
+// 	if err := json.Unmarshal(responseBytes, &response); err != nil {
+// 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("could not decode can-initialize-voting-with-delegate response: %w", err)
+// 	}
+// 	if response.Error != "" {
+// 		return api.PDAOCanInitializeVotingResponse{}, fmt.Errorf("error after requesting can-initialize-voting-with-delegate: %s", response.Error)
+// 	}
+// 	return response, nil
+// }
+
+// InitializeVoting unlocks the node's voting power
+func (c *Client) InitializeVotingWithDelegate(delegateAddress common.Address) (api.PDAOInitializeVotingWithDelegateResponse, error) {
+	responseBytes, err := c.callAPI(fmt.Sprintf("pdao initialize-voting-with-delegate %s", delegateAddress.Hex()))
+	if err != nil {
+		return api.PDAOInitializeVotingWithDelegateResponse{}, fmt.Errorf("could not call initialize-voting-with-delegate: %w", err)
+	}
+	var response api.PDAOInitializeVotingWithDelegateResponse
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return api.PDAOInitializeVotingWithDelegateResponse{}, fmt.Errorf("could not decode initialize-voting-with-delegate response: %w", err)
+	}
+	if response.Error != "" {
+		return api.PDAOInitializeVotingWithDelegateResponse{}, fmt.Errorf("error after requesting initialize-voting-with-delegate: %s", response.Error)
+	}
+	return response, nil
+}
+
 // CanSetSignallingAddress fetches gas info and if a node can set the signalling address
 func (c *Client) CanSetSignallingAddress(signallingAddress common.Address, signature string) (api.PDAOCanSetSignallingAddressResponse, error) {
 	responseBytes, err := c.callAPI(fmt.Sprintf("pdao can-set-signalling-address %s %s", signallingAddress.Hex(), signature))

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -391,6 +391,19 @@ type PDAOCurrentVotingDelegateResponse struct {
 	VotingDelegate common.Address `json:"votingDelegate"`
 }
 
+type PDAOCanInitializeVotingWithDelegateResponse struct {
+	Status            string             `json:"status"`
+	Error             string             `json:"error"`
+	VotingInitialized bool               `json:"votingInitialized"`
+	GasInfo           rocketpool.GasInfo `json:"gasInfo"`
+}
+
+type PDAOInitializeVotingWithDelegateResponse struct {
+	Status string      `json:"status"`
+	Error  string      `json:"error"`
+	TxHash common.Hash `json:"txHash"`
+}
+
 type PDAOCanInitializeVotingResponse struct {
 	Status            string             `json:"status"`
 	Error             string             `json:"error"`


### PR DESCRIPTION
```
USAGE:
   rocketpool pdao command [command options] [arguments...]

COMMANDS:
   initialize-voting, iv                 Unlocks a node operator's voting power (only required for node operators who registered before governance structure was in place)
   initialize-voting-with-delegate, ivd  Unlocks a node operator's voting power and sets the delegate (saves some gas by initializing and setting the delegate in one transaction)
```
Added two seperate commands (one for initializing voting, another for initializing voting and setting the delegate in one transaction).