### PR TITLE
Refactor node and pdao status to reflect new snapshot signalling.

### DIFF
--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -147,13 +147,13 @@ func getStatus(c *cli.Context) error {
 			fmt.Println()
 		}
 
-		// Snapshot voting status
-		fmt.Printf("%s=== Snapshot Voting ===%s\n", colorGreen, colorReset)
+		// Signalling Status
+		fmt.Printf("%s=== Signalling on Snapshot ===%s\n", colorGreen, colorReset)
 		blankAddress := common.Address{}
-		if status.SnapshotVotingDelegate == blankAddress {
-			fmt.Println("The node does not currently have a voting delegate set, which means it can only vote directly on Snapshot proposals (using a hardware wallet with the node mnemonic loaded).\nRun `rocketpool n sv <address>` to vote from a different wallet or have a delegate represent you. (See https://delegates.rocketpool.net for options)")
+		if status.SignallingAddress == blankAddress {
+			fmt.Println("The node does not currently have a snapshot signalling address set")
 		} else {
-			fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, status.SnapshotVotingDelegateFormatted, colorReset)
+			fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, status.SignallingAddressAddressFormatted, colorReset)
 		}
 
 		if status.SnapshotResponse.Error != "" {

--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	colorReset        string = "\033[0m"
-	colorRed          string = "\033[31m"
-	colorGreen        string = "\033[32m"
-	colorYellow       string = "\033[33m"
-	smoothingPoolLink string = "https://docs.rocketpool.net/guides/redstone/whats-new.html#smoothing-pool"
-	maxAlertItems     int    = 3
+	colorReset            string = "\033[0m"
+	colorRed              string = "\033[31m"
+	colorGreen            string = "\033[32m"
+	colorYellow           string = "\033[33m"
+	smoothingPoolLink     string = "https://docs.rocketpool.net/guides/redstone/whats-new.html#smoothing-pool"
+	signallingAddressLink string = "https://docs.rocketpool.net/guides/houston/participate#setting-your-snapshot-signalling-address"
+	maxAlertItems         int    = 3
 )
 
 func getStatus(c *cli.Context) error {
@@ -151,7 +152,7 @@ func getStatus(c *cli.Context) error {
 		fmt.Printf("%s=== Signalling on Snapshot ===%s\n", colorGreen, colorReset)
 		blankAddress := common.Address{}
 		if status.SignallingAddress == blankAddress {
-			fmt.Println("The node does not currently have a snapshot signalling address set")
+			fmt.Printf("The node does not currently have a snapshot signalling address set.\nTo learn more about snapshot signalling, please visit %s.\n", signallingAddressLink)
 		} else {
 			fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, status.SignallingAddressAddressFormatted, colorReset)
 		}

--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -154,7 +154,7 @@ func getStatus(c *cli.Context) error {
 		if status.SignallingAddress == blankAddress {
 			fmt.Printf("The node does not currently have a snapshot signalling address set.\nTo learn more about snapshot signalling, please visit %s.\n", signallingAddressLink)
 		} else {
-			fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, status.SignallingAddressAddressFormatted, colorReset)
+			fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, status.SignallingAddressFormatted, colorReset)
 		}
 
 		if status.SnapshotResponse.Error != "" {

--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -71,13 +71,15 @@ func getStatus(c *cli.Context) error {
 	}
 	claimableBonds := claimableBondsResponse.ClaimableBonds
 
-	// Snapshot voting status
-	fmt.Printf("%s=== Snapshot Voting ===%s\n", colorGreen, colorReset)
+	fmt.Printf(response.SnapshotVotingDelegateFormatted)
+
+	// Signalling Status
+	fmt.Printf("%s=== Signalling on Snapshot ===%s\n", colorGreen, colorReset)
 	blankAddress := common.Address{}
-	if response.SnapshotVotingDelegate == blankAddress {
-		fmt.Println("The node does not currently have a voting delegate set, which means it can only vote directly on Snapshot proposals (using a hardware wallet with the node mnemonic loaded).\nRun `rocketpool n sv <address>` to vote from a different wallet or have a delegate represent you. (See https://delegates.rocketpool.net for options)")
+	if response.SignallingAddress == blankAddress {
+		fmt.Println("The node does not currently have a snapshot signalling address set")
 	} else {
-		fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, response.SnapshotVotingDelegateFormatted, colorReset)
+		fmt.Printf("The node can vote directly or override their delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, response.SignallingAddressAddressFormatted, colorReset)
 	}
 
 	if response.SnapshotResponse.Error != "" {

--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -18,9 +18,11 @@ import (
 )
 
 const (
-	colorBlue  string = "\033[36m"
-	colorReset string = "\033[0m"
-	colorGreen string = "\033[32m"
+	colorBlue             string = "\033[36m"
+	colorReset            string = "\033[0m"
+	colorGreen            string = "\033[32m"
+	signallingAddressLink string = "https://docs.rocketpool.net/guides/houston/participate#setting-your-snapshot-signalling-address"
+	challengeLink         string = "https://docs.rocketpool.net/guides/houston/pdao#challenge-process"
 )
 
 func getStatus(c *cli.Context) error {
@@ -77,7 +79,7 @@ func getStatus(c *cli.Context) error {
 	fmt.Printf("%s=== Signalling on Snapshot ===%s\n", colorGreen, colorReset)
 	blankAddress := common.Address{}
 	if response.SignallingAddress == blankAddress {
-		fmt.Println("The node does not currently have a snapshot signalling address set")
+		fmt.Printf("The node does not currently have a snapshot signalling address set.\nTo learn more about snapshot signalling, please visit %s.\n", signallingAddressLink)
 	} else {
 		fmt.Printf("The node can vote directly or override their delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, response.SignallingAddressAddressFormatted, colorReset)
 	}
@@ -153,7 +155,7 @@ func getStatus(c *cli.Context) error {
 	if response.VerifyEnabled {
 		fmt.Println("The node has PDAO proposal checking duties enabled. It will periodically check for proposals to challenge.")
 	} else {
-		fmt.Println("The node does not have PDAO proposal checking duties enabled (See https://docs.rocketpool.net/guides/houston/pdao#challenge-process to learn more about this duty).")
+		fmt.Printf("The node does not have PDAO proposal checking duties enabled (See %s to learn more about this duty).", challengeLink)
 	}
 	fmt.Println("")
 

--- a/rocketpool-cli/pdao/status.go
+++ b/rocketpool-cli/pdao/status.go
@@ -81,7 +81,7 @@ func getStatus(c *cli.Context) error {
 	if response.SignallingAddress == blankAddress {
 		fmt.Printf("The node does not currently have a snapshot signalling address set.\nTo learn more about snapshot signalling, please visit %s.\n", signallingAddressLink)
 	} else {
-		fmt.Printf("The node can vote directly or override their delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, response.SignallingAddressAddressFormatted, colorReset)
+		fmt.Printf("The node can vote directly or override their delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", colorBlue, response.SignallingAddressFormatted, colorReset)
 	}
 
 	if response.SnapshotResponse.Error != "" {

--- a/rocketpool/api/node/status.go
+++ b/rocketpool/api/node/status.go
@@ -138,7 +138,7 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 		var err error
 		response.SignallingAddress, err = reg.NodeToSigner(&bind.CallOpts{}, nodeAccount.Address)
 		if err == nil {
-			response.SignallingAddressAddressFormatted = formatResolvedAddress(c, response.SignallingAddress)
+			response.SignallingAddressFormatted = formatResolvedAddress(c, response.SignallingAddress)
 		}
 		return err
 	})

--- a/rocketpool/api/pdao/status.go
+++ b/rocketpool/api/pdao/status.go
@@ -80,7 +80,7 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 		var err error
 		response.SignallingAddress, err = reg.NodeToSigner(&bind.CallOpts{}, nodeAccount.Address)
 		if err == nil {
-			response.SignallingAddressAddressFormatted = formatResolvedAddress(c, response.SignallingAddress)
+			response.SignallingAddressFormatted = formatResolvedAddress(c, response.SignallingAddress)
 		}
 		return err
 	})

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -83,9 +83,9 @@ type NodeStatusResponse struct {
 		ProposalVotes           []SnapshotProposalVote `json:"proposalVotes"`
 		ActiveSnapshotProposals []SnapshotProposal     `json:"activeSnapshotProposals"`
 	} `json:"snapshotResponse"`
-	Alerts                            []NodeAlert    `json:"alerts"`
-	SignallingAddress                 common.Address `json:"signallingAddress"`
-	SignallingAddressAddressFormatted string         `json:"signallingAddressAddressFormatted"`
+	Alerts                     []NodeAlert    `json:"alerts"`
+	SignallingAddress          common.Address `json:"signallingAddress"`
+	SignallingAddressFormatted string         `json:"signallingAddressFormatted"`
 }
 
 type NodeAlert struct {

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -83,7 +83,9 @@ type NodeStatusResponse struct {
 		ProposalVotes           []SnapshotProposalVote `json:"proposalVotes"`
 		ActiveSnapshotProposals []SnapshotProposal     `json:"activeSnapshotProposals"`
 	} `json:"snapshotResponse"`
-	Alerts []NodeAlert `json:"alerts"`
+	Alerts                            []NodeAlert    `json:"alerts"`
+	SignallingAddress                 common.Address `json:"signallingAddress"`
+	SignallingAddressAddressFormatted string         `json:"signallingAddressAddressFormatted"`
 }
 
 type NodeAlert struct {

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -433,13 +433,15 @@ type PDAOStatusResponse struct {
 		ProposalVotes           []SnapshotProposalVote `json:"proposalVotes"`
 		ActiveSnapshotProposals []SnapshotProposal     `json:"activeSnapshotProposals"`
 	} `json:"snapshotResponse"`
-	IsRPLLockingAllowed     bool           `json:"isRPLLockingAllowed"`
-	NodeRPLLocked           *big.Int       `json:"nodeRPLLocked"`
-	AccountAddress          common.Address `json:"accountAddress"`
-	AccountAddressFormatted string         `json:"accountAddressFormatted"`
-	TotalDelegatedVp        *big.Int       `json:"totalDelegateVp"`
-	SumVotingPower          *big.Int       `json:"sumVotingPower"`
-	IsNodeRegistered        bool           `json:"isNodeRegistered"`
+	IsRPLLockingAllowed               bool           `json:"isRPLLockingAllowed"`
+	NodeRPLLocked                     *big.Int       `json:"nodeRPLLocked"`
+	AccountAddress                    common.Address `json:"accountAddress"`
+	AccountAddressFormatted           string         `json:"accountAddressFormatted"`
+	TotalDelegatedVp                  *big.Int       `json:"totalDelegateVp"`
+	SumVotingPower                    *big.Int       `json:"sumVotingPower"`
+	IsNodeRegistered                  bool           `json:"isNodeRegistered"`
+	SignallingAddress                 common.Address `json:"signallingAddress"`
+	SignallingAddressAddressFormatted string         `json:"SignallingAddressFormatted"`
 }
 
 type PDAOCanSetSignallingAddressResponse struct {

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -433,15 +433,15 @@ type PDAOStatusResponse struct {
 		ProposalVotes           []SnapshotProposalVote `json:"proposalVotes"`
 		ActiveSnapshotProposals []SnapshotProposal     `json:"activeSnapshotProposals"`
 	} `json:"snapshotResponse"`
-	IsRPLLockingAllowed               bool           `json:"isRPLLockingAllowed"`
-	NodeRPLLocked                     *big.Int       `json:"nodeRPLLocked"`
-	AccountAddress                    common.Address `json:"accountAddress"`
-	AccountAddressFormatted           string         `json:"accountAddressFormatted"`
-	TotalDelegatedVp                  *big.Int       `json:"totalDelegateVp"`
-	SumVotingPower                    *big.Int       `json:"sumVotingPower"`
-	IsNodeRegistered                  bool           `json:"isNodeRegistered"`
-	SignallingAddress                 common.Address `json:"signallingAddress"`
-	SignallingAddressAddressFormatted string         `json:"SignallingAddressFormatted"`
+	IsRPLLockingAllowed        bool           `json:"isRPLLockingAllowed"`
+	NodeRPLLocked              *big.Int       `json:"nodeRPLLocked"`
+	AccountAddress             common.Address `json:"accountAddress"`
+	AccountAddressFormatted    string         `json:"accountAddressFormatted"`
+	TotalDelegatedVp           *big.Int       `json:"totalDelegateVp"`
+	SumVotingPower             *big.Int       `json:"sumVotingPower"`
+	IsNodeRegistered           bool           `json:"isNodeRegistered"`
+	SignallingAddress          common.Address `json:"signallingAddress"`
+	SignallingAddressFormatted string         `json:"SignallingAddressFormatted"`
 }
 
 type PDAOCanSetSignallingAddressResponse struct {


### PR DESCRIPTION
With a signalling address set: 
```
=== Signalling on Snapshot ===
The node has a voting delegate of 0xcaB549EdE082592D10FE6a238e7e8914aD3a074d which can represent it when voting on Rocket Pool Snapshot governance proposals.
Rocket Pool has no Snapshot governance proposals being voted on.
```
Without a signalling address set: 
```
=== Signalling on Snapshot ===
The node does not currently have a snapshot signalling address set
Rocket Pool has no Snapshot governance proposals being voted on.
```

~TO-DO refine the message for when snapshot signalling is not set~