### PR TITLE
Allow submissions after consensus is reached.

### DIFF
--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -1,7 +1,6 @@
 package watchtower
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"strings"
@@ -139,57 +138,16 @@ func (t *submitNetworkBalances) run(state *state.NetworkState) error {
 	submissionIntervalInSeconds := int64(state.NetworkDetails.PricesSubmissionFrequency)
 	eth2Config := state.BeaconConfig
 
-	// Get the time of the latest block
-	latestEth1Block, err := t.rp.Client.HeaderByNumber(context.Background(), nil)
-	if err != nil {
-		return fmt.Errorf("Can't get the latest block time: %w", err)
-	}
-	latestBlockTimestamp := int64(latestEth1Block.Time)
-	// Calculate the next submission timestamp
-	submissionTimestamp, err := utils.FindNextSubmissionTimestamp(latestBlockTimestamp, referenceTimestamp, submissionIntervalInSeconds)
-	if err != nil {
-		return err
-	}
-
-	// Convert the submission timestamp to time.Time
-	nextSubmissionTime := time.Unix(submissionTimestamp, 0)
-
-	// Get the Beacon block corresponding to this time
-	genesisTime := time.Unix(int64(eth2Config.GenesisTime), 0)
-	timeSinceGenesis := nextSubmissionTime.Sub(genesisTime)
-	slotNumber := uint64(timeSinceGenesis.Seconds()) / eth2Config.SecondsPerSlot
-
 	// Log
 	t.log.Println("Checking for network balance checkpoint...")
-
-	// Search for the last existing EL block, going back up to 32 slots if the block is not found.
-	targetBlock, err := utils.FindLastBlockWithExecutionPayload(t.bc, slotNumber)
+	slotNumber, nextSubmissionTime, targetBlockHeader, err := utils.FindNextSubmissionTarget(t.rp, eth2Config, t.bc, t.ec, lastSubmissionBlock, referenceTimestamp, submissionIntervalInSeconds)
 	if err != nil {
 		return err
 	}
-
-	targetBlockNumber := targetBlock.ExecutionBlockNumber
+	targetBlockNumber := targetBlockHeader.Number.Uint64()
 
 	if targetBlockNumber < lastSubmissionBlock {
 		// No submission needed: target block older than the last submission
-		return nil
-	}
-
-	targetBlockHeader, err := t.ec.HeaderByNumber(context.Background(), big.NewInt(int64(targetBlockNumber)))
-	if err != nil {
-		return err
-	}
-
-	requiredEpoch := slotNumber / eth2Config.SlotsPerEpoch
-
-	// Check if the required epoch is finalized yet
-	beaconHead, err := t.bc.GetBeaconHead()
-	if err != nil {
-		return err
-	}
-	finalizedEpoch := beaconHead.FinalizedEpoch
-	if requiredEpoch > finalizedEpoch {
-		t.log.Printlnf("Balances must be reported for EL block %d, waiting until Epoch %d is finalized (currently %d)", targetBlockNumber, requiredEpoch, finalizedEpoch)
 		return nil
 	}
 

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -380,44 +380,32 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 
 	var targetBlockNumber uint64
 	var submissionTimestamp int64
-	// If consensus was reached within ~6 hours still try to submit as a liveness check
-	if latestEth1Block.Number.Uint64()-lastSubmissionBlock < 1800 {
-		// use the latest submission block/timestamp
-		submissionBlock, err := t.rp.Client.HeaderByNumber(context.Background(), big.NewInt(int64(lastSubmissionBlock)))
-		if err != nil {
-			return fmt.Errorf("can't get the block from the last submission, %w", err)
-		}
+	// Calculate the next submission timestamp
+	submissionTimestamp, err = utils.FindNextSubmissionTimestamp(latestBlockTimestamp, referenceTimestamp, submissionIntervalInSeconds)
+	if err != nil {
+		return err
+	}
+	// Get the Beacon slot corresponding to this time
+	genesisTime := (int64(eth2Config.GenesisTime))
+	timeSinceGenesis := submissionTimestamp - genesisTime
+	slotNumber := uint64(timeSinceGenesis) / eth2Config.SecondsPerSlot
 
-		submissionTimestamp = int64(submissionBlock.Time)
-		targetBlockNumber = lastSubmissionBlock
-	} else {
-		// Calculate the next submission timestamp
-		submissionTimestamp, err = utils.FindNextSubmissionTimestamp(latestBlockTimestamp, referenceTimestamp, submissionIntervalInSeconds)
-		if err != nil {
-			return err
-		}
-		// Get the Beacon slot corresponding to this time
-		genesisTime := (int64(eth2Config.GenesisTime))
-		timeSinceGenesis := submissionTimestamp - genesisTime
-		slotNumber := uint64(timeSinceGenesis) / eth2Config.SecondsPerSlot
-
-		// Search for the last existing EL block, going back up to 32 slots if the block is not found.
-		targetBlock, err := utils.FindLastBlockWithExecutionPayload(t.bc, slotNumber)
-		if err != nil {
-			return err
-		}
-		targetBlockNumber = targetBlock.ExecutionBlockNumber
-		// Check if the targetEpoch is finalized yet
-		targetEpoch := slotNumber / eth2Config.SlotsPerEpoch
-		beaconHead, err := t.bc.GetBeaconHead()
-		if err != nil {
-			return err
-		}
-		finalizedEpoch := beaconHead.FinalizedEpoch
-		if targetEpoch > finalizedEpoch {
-			t.log.Printlnf("Prices must be reported for EL block %d, waiting until Epoch %d is finalized (currently %d)", targetBlockNumber, targetEpoch, finalizedEpoch)
-			return nil
-		}
+	// Search for the last existing EL block, going back up to 32 slots if the block is not found.
+	targetBlock, err := utils.FindLastBlockWithExecutionPayload(t.bc, slotNumber)
+	if err != nil {
+		return err
+	}
+	targetBlockNumber = targetBlock.ExecutionBlockNumber
+	// Check if the targetEpoch is finalized yet
+	targetEpoch := slotNumber / eth2Config.SlotsPerEpoch
+	beaconHead, err := t.bc.GetBeaconHead()
+	if err != nil {
+		return err
+	}
+	finalizedEpoch := beaconHead.FinalizedEpoch
+	if targetEpoch > finalizedEpoch {
+		t.log.Printlnf("Prices must be reported for EL block %d, waiting until Epoch %d is finalized (currently %d)", targetBlockNumber, targetEpoch, finalizedEpoch)
+		return nil
 	}
 
 	if targetBlockNumber < lastSubmissionBlock {

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -241,11 +241,11 @@ type poolObserveResponse struct {
 // Submit RPL price task
 type submitRplPrice struct {
 	c         *cli.Context
-	log       log.ColorLogger
-	errLog    log.ColorLogger
+	log       *log.ColorLogger
+	errLog    *log.ColorLogger
 	cfg       *config.RocketPoolConfig
-	ec        rocketpool.ExecutionClient
 	w         *wallet.Wallet
+	ec        rocketpool.ExecutionClient
 	rp        *rocketpool.RocketPool
 	bc        beacon.Client
 	lock      *sync.Mutex
@@ -281,8 +281,8 @@ func newSubmitRplPrice(c *cli.Context, logger log.ColorLogger, errorLogger log.C
 	lock := &sync.Mutex{}
 	return &submitRplPrice{
 		c:      c,
-		log:    logger,
-		errLog: errorLogger,
+		log:    &logger,
+		errLog: &errorLogger,
 		cfg:    cfg,
 		ec:     ec,
 		w:      w,
@@ -371,42 +371,11 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 	submissionIntervalInSeconds := int64(state.NetworkDetails.PricesSubmissionFrequency)
 	eth2Config := state.BeaconConfig
 
-	// Get the time of the latest block
-	latestEth1Block, err := t.rp.Client.HeaderByNumber(context.Background(), nil)
-	if err != nil {
-		return fmt.Errorf("can't get the latest block time: %w", err)
-	}
-	latestBlockTimestamp := int64(latestEth1Block.Time)
-
-	var targetBlockNumber uint64
-	var submissionTimestamp int64
-	// Calculate the next submission timestamp
-	submissionTimestamp, err = utils.FindNextSubmissionTimestamp(latestBlockTimestamp, referenceTimestamp, submissionIntervalInSeconds)
+	_, nextSubmissionTime, targetBlockHeader, err := utils.FindNextSubmissionTarget(t.rp, eth2Config, t.bc, t.ec, lastSubmissionBlock, referenceTimestamp, submissionIntervalInSeconds)
 	if err != nil {
 		return err
 	}
-	// Get the Beacon slot corresponding to this time
-	genesisTime := (int64(eth2Config.GenesisTime))
-	timeSinceGenesis := submissionTimestamp - genesisTime
-	slotNumber := uint64(timeSinceGenesis) / eth2Config.SecondsPerSlot
-
-	// Search for the last existing EL block, going back up to 32 slots if the block is not found.
-	targetBlock, err := utils.FindLastBlockWithExecutionPayload(t.bc, slotNumber)
-	if err != nil {
-		return err
-	}
-	targetBlockNumber = targetBlock.ExecutionBlockNumber
-	// Check if the targetEpoch is finalized yet
-	targetEpoch := slotNumber / eth2Config.SlotsPerEpoch
-	beaconHead, err := t.bc.GetBeaconHead()
-	if err != nil {
-		return err
-	}
-	finalizedEpoch := beaconHead.FinalizedEpoch
-	if targetEpoch > finalizedEpoch {
-		t.log.Printlnf("Prices must be reported for EL block %d, waiting until Epoch %d is finalized (currently %d)", targetBlockNumber, targetEpoch, finalizedEpoch)
-		return nil
-	}
+	targetBlockNumber := targetBlockHeader.Number.Uint64()
 
 	if targetBlockNumber < lastSubmissionBlock {
 		// No submission needed: target block older than the last submission
@@ -442,8 +411,10 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		// Log
 		t.log.Printlnf("RPL price: %.6f ETH", mathutils.RoundDown(eth.WeiToEth(rplPrice), 6))
 
+		submissionTimestamp := uint64(nextSubmissionTime.Unix())
+
 		// Check if we have reported these specific values before
-		hasSubmittedSpecific, err := t.hasSubmittedSpecificBlockPrices(nodeAccount.Address, targetBlockNumber, uint64(submissionTimestamp), rplPrice)
+		hasSubmittedSpecific, err := t.hasSubmittedSpecificBlockPrices(nodeAccount.Address, targetBlockNumber, submissionTimestamp, rplPrice)
 		if err != nil {
 			t.handleError(fmt.Errorf("%s %w", logPrefix, err))
 			return
@@ -456,7 +427,7 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		}
 
 		// We haven't submitted these values, check if we've submitted any for this block so we can log it
-		hasSubmitted, err := t.hasSubmittedBlockPrices(nodeAccount.Address, targetBlockNumber, uint64(submissionTimestamp))
+		hasSubmitted, err := t.hasSubmittedBlockPrices(nodeAccount.Address, targetBlockNumber, submissionTimestamp)
 		if err != nil {
 			t.handleError(fmt.Errorf("%s %w", logPrefix, err))
 			return
@@ -469,7 +440,7 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 		t.log.Println("Submitting RPL price...")
 
 		// Submit RPL price
-		if err := t.submitRplPrice(targetBlockNumber, uint64(submissionTimestamp), rplPrice); err != nil {
+		if err := t.submitRplPrice(targetBlockNumber, submissionTimestamp, rplPrice); err != nil {
 			t.handleError(fmt.Errorf("%s could not submit RPL price: %w", logPrefix, err))
 			return
 		}
@@ -613,7 +584,7 @@ func (t *submitRplPrice) submitRplPrice(blockNumber uint64, slotTimestamp uint64
 
 	// Print the gas info
 	maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(t.cfg))
-	if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+	if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 		return nil
 	}
 
@@ -630,7 +601,7 @@ func (t *submitRplPrice) submitRplPrice(blockNumber uint64, slotTimestamp uint64
 	}
 
 	// Print TX info and wait for it to be included in a block
-	err = api.PrintAndWaitForTransaction(t.cfg, hash, t.rp.Client, &t.log)
+	err = api.PrintAndWaitForTransaction(t.cfg, hash, t.rp.Client, t.log)
 	if err != nil {
 		return err
 	}
@@ -752,7 +723,7 @@ func (t *submitRplPrice) submitOptimismPrice() error {
 
 		// Print the gas info
 		maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(t.cfg))
-		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 			return nil
 		}
 
@@ -770,7 +741,7 @@ func (t *submitRplPrice) submitOptimismPrice() error {
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, &t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}
@@ -892,7 +863,7 @@ func (t *submitRplPrice) submitPolygonPrice() error {
 
 		// Print the gas info
 		maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(t.cfg))
-		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 			return nil
 		}
 
@@ -910,7 +881,7 @@ func (t *submitRplPrice) submitPolygonPrice() error {
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, &t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}
@@ -1055,7 +1026,7 @@ func (t *submitRplPrice) submitArbitrumPrice(priceMessengerAddress string) error
 
 		// Print the gas info
 		maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(t.cfg))
-		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 			return nil
 		}
 
@@ -1073,7 +1044,7 @@ func (t *submitRplPrice) submitArbitrumPrice(priceMessengerAddress string) error
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, &t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}
@@ -1213,7 +1184,7 @@ func (t *submitRplPrice) submitZkSyncEraPrice() error {
 		}
 
 		// Print the gas info
-		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 			return nil
 		}
 
@@ -1231,7 +1202,7 @@ func (t *submitRplPrice) submitZkSyncEraPrice() error {
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, &t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}
@@ -1353,7 +1324,7 @@ func (t *submitRplPrice) submitBasePrice() error {
 
 		// Print the gas info
 		maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(t.cfg))
-		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 			return nil
 		}
 
@@ -1371,7 +1342,7 @@ func (t *submitRplPrice) submitBasePrice() error {
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, &t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}
@@ -1518,7 +1489,7 @@ func (t *submitRplPrice) submitScrollPrice() error {
 
 		// Print the gas info
 		maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(t.cfg))
-		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, &t.log, maxFee, 0) {
+		if !api.PrintAndCheckGasInfo(gasInfo, false, 0, t.log, maxFee, 0) {
 			return nil
 		}
 
@@ -1536,7 +1507,7 @@ func (t *submitRplPrice) submitScrollPrice() error {
 		}
 
 		// Print TX info and wait for it to be included in a block
-		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, &t.log)
+		err = api.PrintAndWaitForTransaction(t.cfg, tx.Hash(), t.rp.Client, t.log)
 		if err != nil {
 			return err
 		}

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,6 +1,6 @@
 package shared
 
-const RocketPoolVersion string = "1.13.6"
+const RocketPoolVersion string = "1.13.7-dev"
 
 const Logo string = `______           _        _    ______           _
 | ___ \         | |      | |   | ___ \         | |


### PR DESCRIPTION
At some point the Smart Node stopped doing submissions after the prices/balances consensus was reached. This PR restores the desired behavior, allowing oDAO nodes to make submissions after consensus is reached, as a way to monitor their liveness.