### PR TITLE
Replace snapshot voting delegate with signalling address

### DIFF
--- a/rocketpool/api/node/status.go
+++ b/rocketpool/api/node/status.go
@@ -203,19 +203,8 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 		wg.Go(func() error {
 			var err error
 			r := &response.SnapshotResponse
-			if cfg.Smartnode.GetSnapshotDelegationAddress() != "" {
-				idHash := cfg.Smartnode.GetVotingSnapshotID()
-				response.SnapshotVotingDelegate, err = s.Delegation(nil, nodeAccount.Address, idHash)
-				if err != nil {
-					r.Error = err.Error()
-					return nil
-				}
-				blankAddress := common.Address{}
-				if response.SnapshotVotingDelegate != blankAddress {
-					response.SnapshotVotingDelegateFormatted = formatResolvedAddress(c, response.SnapshotVotingDelegate)
-				}
-
-				votedProposals, err := GetSnapshotVotedProposals(cfg.Smartnode.GetSnapshotApiDomain(), cfg.Smartnode.GetSnapshotID(), nodeAccount.Address, response.SnapshotVotingDelegate)
+			if cfg.Smartnode.GetRocketSignerRegistryAddress() != "" {
+				votedProposals, err := GetSnapshotVotedProposals(cfg.Smartnode.GetSnapshotApiDomain(), cfg.Smartnode.GetSnapshotID(), nodeAccount.Address, response.SignallingAddress)
 				if err != nil {
 					r.Error = err.Error()
 					return nil

--- a/rocketpool/api/node/status.go
+++ b/rocketpool/api/node/status.go
@@ -56,10 +56,6 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err := services.GetSnapshotDelegation(c)
-	if err != nil {
-		return nil, err
-	}
 	reg, err := services.GetRocketSignerRegistry(c)
 	if err != nil {
 		return nil, err
@@ -133,16 +129,6 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 		return err
 	})
 
-	// Get the node's signalling address
-	wg.Go(func() error {
-		var err error
-		response.SignallingAddress, err = reg.NodeToSigner(&bind.CallOpts{}, nodeAccount.Address)
-		if err == nil {
-			response.SignallingAddressFormatted = formatResolvedAddress(c, response.SignallingAddress)
-		}
-		return err
-	})
-
 	// Get the node onchain voting delegate
 	wg.Go(func() error {
 		var err error
@@ -199,11 +185,20 @@ func getStatus(c *cli.Context) (*api.NodeStatusResponse, error) {
 	})
 
 	// Get active and past votes from Snapshot, but treat errors as non-Fatal
-	if s != nil {
+	if reg != nil {
 		wg.Go(func() error {
 			var err error
 			r := &response.SnapshotResponse
 			if cfg.Smartnode.GetRocketSignerRegistryAddress() != "" {
+				response.SignallingAddress, err = reg.NodeToSigner(&bind.CallOpts{}, nodeAccount.Address)
+				if err != nil {
+					r.Error = err.Error()
+					return nil
+				}
+				blankAddress := common.Address{}
+				if response.SignallingAddress != blankAddress {
+					response.SignallingAddressFormatted = formatResolvedAddress(c, response.SignallingAddress)
+				}
 				votedProposals, err := GetSnapshotVotedProposals(cfg.Smartnode.GetSnapshotApiDomain(), cfg.Smartnode.GetSnapshotID(), nodeAccount.Address, response.SignallingAddress)
 				if err != nil {
 					r.Error = err.Error()

--- a/rocketpool/api/pdao/status.go
+++ b/rocketpool/api/pdao/status.go
@@ -137,7 +137,7 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 			if cfg.Smartnode.GetRocketSignerRegistryAddress() != "" {
 				response.SignallingAddress, err = reg.NodeToSigner(&bind.CallOpts{}, nodeAccount.Address)
 				if err != nil {
-					r.Error = "test"
+					r.Error = err.Error()
 					return nil
 				}
 				blankAddress := common.Address{}
@@ -146,7 +146,7 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 				}
 				votedProposals, err := GetSnapshotVotedProposals(cfg.Smartnode.GetSnapshotApiDomain(), cfg.Smartnode.GetSnapshotID(), nodeAccount.Address, response.SignallingAddress)
 				if err != nil {
-					r.Error = "test1"
+					r.Error = err.Error()
 					return nil
 				}
 				r.ProposalVotes = votedProposals.Data.Votes

--- a/rocketpool/api/pdao/status.go
+++ b/rocketpool/api/pdao/status.go
@@ -148,19 +148,8 @@ func getStatus(c *cli.Context) (*api.PDAOStatusResponse, error) {
 		wg.Go(func() error {
 			var err error
 			r := &response.SnapshotResponse
-			if cfg.Smartnode.GetSnapshotDelegationAddress() != "" {
-				idHash := cfg.Smartnode.GetVotingSnapshotID()
-				response.SnapshotVotingDelegate, err = s.Delegation(nil, nodeAccount.Address, idHash)
-				if err != nil {
-					r.Error = err.Error()
-					return nil
-				}
-				blankAddress := common.Address{}
-				if response.SnapshotVotingDelegate != blankAddress {
-					response.SnapshotVotingDelegateFormatted = formatResolvedAddress(c, response.SnapshotVotingDelegate)
-				}
-
-				votedProposals, err := GetSnapshotVotedProposals(cfg.Smartnode.GetSnapshotApiDomain(), cfg.Smartnode.GetSnapshotID(), nodeAccount.Address, response.SnapshotVotingDelegate)
+			if cfg.Smartnode.GetRocketSignerRegistryAddress() != "" {
+				votedProposals, err := GetSnapshotVotedProposals(cfg.Smartnode.GetSnapshotApiDomain(), cfg.Smartnode.GetSnapshotID(), nodeAccount.Address, response.SignallingAddress)
 				if err != nil {
 					r.Error = err.Error()
 					return nil

--- a/shared/services/config/smartnode-config.go
+++ b/shared/services/config/smartnode-config.go
@@ -562,7 +562,7 @@ func NewSmartnodeConfig(cfg *RocketPoolConfig) *SmartnodeConfig {
 		snapshotApiDomain: map[config.Network]string{
 			config.Network_Mainnet: "hub.snapshot.org",
 			config.Network_Devnet:  "",
-			config.Network_Holesky: "",
+			config.Network_Holesky: "hub.snapshot.org",
 		},
 
 		previousRewardsPoolAddresses: map[config.Network][]common.Address{

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -49,8 +49,6 @@ type NodeStatusResponse struct {
 	PendingMaximumRplStake                   *big.Int        `json:"pendingMaximumRplStake"`
 	PendingBorrowedCollateralRatio           float64         `json:"pendingBorrowedCollateralRatio"`
 	PendingBondedCollateralRatio             float64         `json:"pendingBondedCollateralRatio"`
-	SnapshotVotingDelegate                   common.Address  `json:"snapshotVotingDelegate"`
-	SnapshotVotingDelegateFormatted          string          `json:"snapshotVotingDelegateFormatted"`
 	IsVotingInitialized                      bool            `json:"isVotingInitialized"`
 	OnchainVotingDelegate                    common.Address  `json:"onchainVotingDelegate"`
 	OnchainVotingDelegateFormatted           string          `json:"onchainVotingDelegateFormatted"`

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -418,17 +418,15 @@ type PDAOInitializeVotingResponse struct {
 }
 
 type PDAOStatusResponse struct {
-	Status                          string         `json:"status"`
-	Error                           string         `json:"error"`
-	VotingPower                     *big.Int       `json:"votingPower"`
-	OnchainVotingDelegate           common.Address `json:"onchainVotingDelegate"`
-	OnchainVotingDelegateFormatted  string         `json:"onchainVotingDelegateFormatted"`
-	BlockNumber                     uint32         `json:"blockNumber"`
-	VerifyEnabled                   bool           `json:"verifyEnabled"`
-	IsVotingInitialized             bool           `json:"isVotingInitialized"`
-	SnapshotVotingDelegate          common.Address `json:"snapshotVotingDelegate"`
-	SnapshotVotingDelegateFormatted string         `json:"snapshotVotingDelegateFormatted"`
-	SnapshotResponse                struct {
+	Status                         string         `json:"status"`
+	Error                          string         `json:"error"`
+	VotingPower                    *big.Int       `json:"votingPower"`
+	OnchainVotingDelegate          common.Address `json:"onchainVotingDelegate"`
+	OnchainVotingDelegateFormatted string         `json:"onchainVotingDelegateFormatted"`
+	BlockNumber                    uint32         `json:"blockNumber"`
+	VerifyEnabled                  bool           `json:"verifyEnabled"`
+	IsVotingInitialized            bool           `json:"isVotingInitialized"`
+	SnapshotResponse               struct {
 		Error                   string                 `json:"error"`
 		ProposalVotes           []SnapshotProposalVote `json:"proposalVotes"`
 		ActiveSnapshotProposals []SnapshotProposal     `json:"activeSnapshotProposals"`


### PR DESCRIPTION
`SnapshotVotingDelegate` is being deprecated in favor of `SignallingAddress`

This goroutine checks if `GetSnapshotDelegationAddress()` exists, adds `SnapshotVotingDelegate` to the response then queries snapshot. 

With this PR, the goroutine checks if `GetRocketSignerRegistryAddress()` exists, then queries snapshot (`SignallingAddress` is already added to the response further up in the file).