### PR TITLE
Add coverage reports to CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,8 +8,11 @@ on:
       - main
       - v2*
   pull_request:
+    types: [opened, reopened, synchronize]
 permissions:
   contents: read
+  # Needed to leave comments
+  pull-requests: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,4 +21,42 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.21.8
-      - run: go test ./...
+      - run: go test ./... -coverprofile=./cover.out -coverpkg=./...
+      # upload the plaintext coverage report
+      - name: Upload txt coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: ./cover.out
+      # convert the plaintext coverage report to html
+      - run: go tool cover -html cover.out -o cover.html
+      # upload the html coverage report
+      - name: Upload html coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-html
+          path: ./cover.html
+        id: html-upload-step
+    outputs:
+      artifact-url: ${{ steps.html-upload-step.outputs.artifact-url }}
+
+  coverage:
+    name: "Analyze coverage report"
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'rocket-pool/smartnode'
+    runs-on: ubuntu-latest
+    needs: build # only run if the previous job finished successfully
+    steps:
+      - name: Leave a comment with a link
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '[Coverage Report](${{ needs.build.outputs.artifact-url }})'
+            })
+      - uses: fgrosse/go-coverage-report@ff33f0f3f96d20ecb97198100852d2af288094ff
+        with:
+          coverage-artifact-name: "code-coverage"
+          coverage-file-name: "cover.out"


### PR DESCRIPTION
Unfortunately for security reasons, there's no comments across forks, but this will be the output for team members who make PRs:

![image](https://github.com/user-attachments/assets/82cb23e8-fdab-4f82-95b8-d20a11e6ac40)

Clicking the URL downloads a .zip file with a `go tool` coverage report html file which can be viewed by the author and the reviewers:
![image](https://github.com/user-attachments/assets/b40811f1-65b8-4324-bded-7add65091de9)

There's no coverage enforcement in the actions right now. We can add some later if we get to the point where it's feasible.