### PR TITLE
Add a test suite for cli commands, tests for `rocketpool minipool status`

### DIFF
--- a/rocketpool-cli/commands/commands.go
+++ b/rocketpool-cli/commands/commands.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/auction"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/minipool"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/network"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/node"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/odao"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/pdao"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/queue"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/security"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/service"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/wallet"
+	"github.com/urfave/cli/v2"
+)
+
+func RegisterCommands(app *cli.App) {
+	auction.RegisterCommands(app, "auction", []string{"a"})
+	minipool.RegisterCommands(app, "minipool", []string{"m"})
+	network.RegisterCommands(app, "network", []string{"e"})
+	node.RegisterCommands(app, "node", []string{"n"})
+	odao.RegisterCommands(app, "odao", []string{"o"})
+	pdao.RegisterCommands(app, "pdao", []string{"p"})
+	queue.RegisterCommands(app, "queue", []string{"q"})
+	security.RegisterCommands(app, "security", []string{"c"})
+	service.RegisterCommands(app, "service", []string{"s"})
+	wallet.RegisterCommands(app, "wallet", []string{"w"})
+}

--- a/rocketpool-cli/rocketpool-cli.go
+++ b/rocketpool-cli/rocketpool-cli.go
@@ -7,16 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/rocket-pool/smartnode/v2/assets"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/auction"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/minipool"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/network"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/node"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/odao"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/pdao"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/queue"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/security"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/service"
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/wallet"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/settings"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 )
@@ -98,16 +89,7 @@ func newCliApp() *cli.App {
 	app.Flags = utils.AppendFlags(app.Flags)
 
 	// Register commands
-	auction.RegisterCommands(app, "auction", []string{"a"})
-	minipool.RegisterCommands(app, "minipool", []string{"m"})
-	network.RegisterCommands(app, "network", []string{"e"})
-	node.RegisterCommands(app, "node", []string{"n"})
-	odao.RegisterCommands(app, "odao", []string{"o"})
-	pdao.RegisterCommands(app, "pdao", []string{"p"})
-	queue.RegisterCommands(app, "queue", []string{"q"})
-	security.RegisterCommands(app, "security", []string{"c"})
-	service.RegisterCommands(app, "service", []string{"s"})
-	wallet.RegisterCommands(app, "wallet", []string{"w"})
+	commands.RegisterCommands(app)
 
 	var snSettings *settings.SmartNodeSettings
 	app.Before = func(c *cli.Context) error {

--- a/rocketpool-cli/test/cli.go
+++ b/rocketpool-cli/test/cli.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/settings"
+	"github.com/urfave/cli/v2"
+)
+
+// CLITest provides a interface for testing rocketpool-cli commands against a mock daemon.
+type CLITest struct {
+	t *testing.T
+
+	TestDir string
+	App     *cli.App
+
+	commands uint
+}
+
+// CLITestResult contains artifacts of running a cli command
+type CLITestResult struct {
+	Error         error // Error returned by "run" if any
+	HTTPTraceFile *os.File
+}
+
+func NewCLITest(t *testing.T) *CLITest {
+	out := &CLITest{
+		t: t,
+	}
+
+	out.TestDir = t.TempDir()
+	t.Logf("CLI Test using %s as .rocketpool\n", out.TestDir)
+
+	out.App = cli.NewApp()
+	out.App.Name = "rocketpool-test"
+	// Add global flags
+	out.App.Flags = settings.AppendSmartNodeSettingsFlags(out.App.Flags)
+
+	// Register commands
+	commands.RegisterCommands(out.App)
+
+	out.App.Before = func(c *cli.Context) error {
+		_, err := settings.NewSmartNodeSettings(c)
+		if err != nil {
+			t.Fatal(err)
+			return err
+		}
+		return nil
+	}
+	out.App.After = func(c *cli.Context) error {
+		snSettings := settings.GetSmartNodeSettings(c)
+		if snSettings != nil && snSettings.HttpTraceFile != nil {
+			snSettings.HttpTraceFile.Close()
+		}
+		return nil
+	}
+
+	return out
+}
+
+func (cliTest *CLITest) Run(cmd ...string) *CLITestResult {
+	// Create a path for this command in the temp dir
+	cmdPath := filepath.Join(cliTest.TestDir, fmt.Sprintf("%d:%s", cliTest.commands, strings.Join(cmd[:min(len(cmd), 3)], "_")))
+	err := os.Mkdir(cmdPath, 0755)
+	if err != nil {
+		cliTest.t.Fatal(err)
+		return nil
+	}
+	cliTest.t.Logf("file artifacts for command '%s' will be saved in %s", strings.Join(cmd, " "), cmdPath)
+
+	// Make a trace file that can be opened
+	httpTraceFilePath := filepath.Join(cmdPath, "http-trace.txt")
+	httpTraceFile, err := os.Create(httpTraceFilePath)
+	if err != nil {
+		cliTest.t.Fatal(err)
+		return nil
+	}
+
+	// Prepend http trace path
+	cmd = append([]string{"--http-trace-path", httpTraceFilePath}, cmd...)
+	// Prepend config location
+	cmd = append([]string{"--config-path", cliTest.TestDir}, cmd...)
+	// Prepend expected test app name
+	cmd = append([]string{"rocketpool-test"}, cmd...)
+	cliTest.t.Logf("Running command %s\n", strings.Join(cmd, " "))
+	return &CLITestResult{
+		Error:         cliTest.App.Run(cmd),
+		HTTPTraceFile: httpTraceFile,
+	}
+}

--- a/rocketpool-cli/test/minipool/status_test.go
+++ b/rocketpool-cli/test/minipool/status_test.go
@@ -1,0 +1,33 @@
+package minipool
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/test"
+)
+
+type minipoolTest struct {
+	*test.CLITest
+}
+
+func newMinipoolTest(t *testing.T) *minipoolTest {
+	out := &minipoolTest{
+		test.NewCLITest(t),
+	}
+
+	return out
+}
+
+func TestMinipoolStatus(t *testing.T) {
+	cliTest := newMinipoolTest(t)
+	result := cliTest.Run("minipool", "status")
+	if result.Error == nil {
+		t.Fatal("running 'minipool status' without a mock response should produce an error")
+	}
+
+	errorstr := result.Error.Error()
+	if !strings.Contains(errorstr, "connect: connection refused") {
+		t.Fatalf("rocketpool-cli should return dial errors when unable to contact the api, got %s", errorstr)
+	}
+}

--- a/rocketpool-cli/test/minipool/status_test.go
+++ b/rocketpool-cli/test/minipool/status_test.go
@@ -1,6 +1,7 @@
 package minipool
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -27,7 +28,16 @@ func TestMinipoolStatus(t *testing.T) {
 	}
 
 	errorstr := result.Error.Error()
-	if !strings.Contains(errorstr, "connect: connection refused") {
-		t.Fatalf("rocketpool-cli should return dial errors when unable to contact the api, got %s", errorstr)
+	if !strings.Contains(errorstr, "no response defined, call CLITest.RepliesWith") {
+		t.Fatalf("rocketpool-cli should return expected errors when no mock response was provided, got %s", errorstr)
+	}
+
+	httpTrace, err := io.ReadAll(result.HTTPTraceFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(httpTrace), "GotFirstResponseByte") {
+		t.Fatalf("test should have successfully traced http request to mock, instead got: %s", string(httpTrace))
 	}
 }

--- a/rocketpool-cli/test/minipool/status_test.go
+++ b/rocketpool-cli/test/minipool/status_test.go
@@ -1,6 +1,7 @@
 package minipool
 
 import (
+	"math/big"
 	"strings"
 	"testing"
 
@@ -34,6 +35,52 @@ func TestMinipoolStatusNoMinipools(t *testing.T) {
 
 	// Cli output should mention no minipools available
 	expectedResponse := "The node does not have any minipools yet."
+	if !strings.Contains(result.Stdout, expectedResponse) {
+		t.Fatalf(`expected message "%s", got "%s"`, expectedResponse, result.Stdout)
+	}
+}
+
+func newMinipoolDetails() *api.MinipoolDetails {
+	out := new(api.MinipoolDetails)
+
+	// Avoid segfaults by initializing.
+	// TODO: we shouldn't use big.Int pointers in api request/response types.
+	out.Node.DepositBalance = big.NewInt(0)
+	out.Node.RefundBalance = big.NewInt(0)
+	out.User.DepositBalance = big.NewInt(0)
+
+	out.Balances.Eth = big.NewInt(0)
+	out.Balances.Reth = big.NewInt(0)
+	out.Balances.Rpl = big.NewInt(0)
+	out.Balances.FixedSupplyRpl = big.NewInt(0)
+
+	out.NodeShareOfEthBalance = big.NewInt(0)
+
+	out.Validator.Balance = big.NewInt(0)
+	out.Validator.NodeBalance = big.NewInt(0)
+
+	return out
+}
+
+func TestMinipoolStatusOnlyFinalized(t *testing.T) {
+	cliTest := newMinipoolTest(t)
+	response := types.ApiResponse[api.MinipoolStatusData]{
+		Data: &api.MinipoolStatusData{
+			Minipools: []api.MinipoolDetails{},
+		},
+	}
+	minipool1 := newMinipoolDetails()
+	minipool1.Finalised = true
+	response.Data.Minipools = append(response.Data.Minipools, *minipool1)
+	minipool2 := newMinipoolDetails()
+	minipool2.Finalised = true
+	response.Data.Minipools = append(response.Data.Minipools, *minipool2)
+	result := cliTest.RepliesWith(response).Run("minipool", "status")
+	if result.Error != nil {
+		t.Fatal(result.Error)
+	}
+
+	expectedResponse := "All of this node's minipools have been finalized."
 	if !strings.Contains(result.Stdout, expectedResponse) {
 		t.Fatalf(`expected message "%s", got "%s"`, expectedResponse, result.Stdout)
 	}


### PR DESCRIPTION
The test suite is simple still, and only really works for commands that result in a single http request to the daemon.

Merging is blocked by https://github.com/rocket-pool/smartnode/pull/595 and includes those commits, so maybe don't review this PR yet.