### PR TITLE
Pass the selected minipool list, instead of every mp

### DIFF
--- a/rocketpool-daemon/api/minipool/close.go
+++ b/rocketpool-daemon/api/minipool/close.go
@@ -73,7 +73,7 @@ func (c *minipoolCloseContext) GetMinipoolDetails(mc *batch.MultiCaller, mp mini
 }
 
 func (c *minipoolCloseContext) PrepareData(addresses []common.Address, mps []minipool.IMinipool, data *types.BatchTxInfoData) (types.ResponseStatus, error) {
-	return prepareMinipoolBatchTxData(c.handler.ctx, c.handler.serviceProvider, addresses, data, c.CreateTx, "close")
+	return prepareMinipoolBatchTxData(c.handler.ctx, c.handler.serviceProvider, c.minipoolAddresses, data, c.CreateTx, "close")
 }
 
 func (c *minipoolCloseContext) CreateTx(mp minipool.IMinipool, opts *bind.TransactOpts) (types.ResponseStatus, *eth.TransactionInfo, error) {


### PR DESCRIPTION
Fixes a bug where the close minipool command would iterate over every minipool on a node.