### PR TITLE
Add dynamic settings / resource loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prysmaticlabs/prysm/v5 v5.0.3
 	github.com/rivo/tview v0.0.0-20230208211350-7dfff1ce7854 // DO NOT UPGRADE
-	github.com/rocket-pool/node-manager-core v0.5.2-0.20240711145202-d927402794fc
+	github.com/rocket-pool/node-manager-core v0.5.2-0.20240711200335-f1075a55d8b0
 	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/tyler-smith/go-bip39 v1.1.0
@@ -174,5 +174,3 @@ require (
 )
 
 replace github.com/wealdtech/go-merkletree v1.0.1-0.20190605192610-2bb163c2ea2a => github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd
-
-//replace github.com/rocket-pool/node-manager-core => ../node-manager-core

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prysmaticlabs/prysm/v5 v5.0.3
 	github.com/rivo/tview v0.0.0-20230208211350-7dfff1ce7854 // DO NOT UPGRADE
-	github.com/rocket-pool/node-manager-core v0.5.2-0.20240711200335-f1075a55d8b0
+	github.com/rocket-pool/node-manager-core v0.5.2-0.20240722141309-0a3f0e72cf11
 	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/tyler-smith/go-bip39 v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prysmaticlabs/prysm/v5 v5.0.3
 	github.com/rivo/tview v0.0.0-20230208211350-7dfff1ce7854 // DO NOT UPGRADE
-	github.com/rocket-pool/node-manager-core v0.5.0
+	github.com/rocket-pool/node-manager-core v0.5.2-0.20240711145202-d927402794fc
 	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b
 	github.com/shirou/gopsutil/v3 v3.24.3
 	github.com/tyler-smith/go-bip39 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/rocket-pool/batch-query v1.0.0 h1:5HejmT1n1fIdLIqUhTNwbkG2PGOPl3IVjCp
 github.com/rocket-pool/batch-query v1.0.0/go.mod h1:d1CmxShzk0fioJ4yX0eFGhz2an1odnW/LZ2cp3eDGIQ=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20240711200335-f1075a55d8b0 h1:p7fqmcIAHQQM7ejqCRUj8Rakk4NTl+p+ZTtzI/XEFj4=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20240711200335-f1075a55d8b0/go.mod h1:Clii5aca9PvR4HoAlUs8dh2OsJbDDnJ4yL5EaQE1gSo=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20240722141309-0a3f0e72cf11 h1:R8vudK2R4YjlsVOeNHc74ePM27ISYwrh5g2Pr1fNQo4=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20240722141309-0a3f0e72cf11/go.mod h1:Clii5aca9PvR4HoAlUs8dh2OsJbDDnJ4yL5EaQE1gSo=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b h1:39UmJzNR71/OMIzblEY9wq+3nojGa/gQOJJpLBa6XcE=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b/go.mod h1:pcY43H/m5pjr7zacrsKVaXnXfKKi1UV08VDPUwxbJkc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/rocket-pool/batch-query v1.0.0 h1:5HejmT1n1fIdLIqUhTNwbkG2PGOPl3IVjCp
 github.com/rocket-pool/batch-query v1.0.0/go.mod h1:d1CmxShzk0fioJ4yX0eFGhz2an1odnW/LZ2cp3eDGIQ=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
-github.com/rocket-pool/node-manager-core v0.5.0 h1:98PnHb67mgOKTHMQlRql5KINYM+5NGYV3n4GYChZuec=
-github.com/rocket-pool/node-manager-core v0.5.0/go.mod h1:Clii5aca9PvR4HoAlUs8dh2OsJbDDnJ4yL5EaQE1gSo=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20240711145202-d927402794fc h1:nZL+ydUj3G+Z3pEgFaEa0pAYLgSCgfea1ZKzLOOMcJM=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20240711145202-d927402794fc/go.mod h1:Clii5aca9PvR4HoAlUs8dh2OsJbDDnJ4yL5EaQE1gSo=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b h1:39UmJzNR71/OMIzblEY9wq+3nojGa/gQOJJpLBa6XcE=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b/go.mod h1:pcY43H/m5pjr7zacrsKVaXnXfKKi1UV08VDPUwxbJkc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/rocket-pool/batch-query v1.0.0 h1:5HejmT1n1fIdLIqUhTNwbkG2PGOPl3IVjCp
 github.com/rocket-pool/batch-query v1.0.0/go.mod h1:d1CmxShzk0fioJ4yX0eFGhz2an1odnW/LZ2cp3eDGIQ=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20240711145202-d927402794fc h1:nZL+ydUj3G+Z3pEgFaEa0pAYLgSCgfea1ZKzLOOMcJM=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20240711145202-d927402794fc/go.mod h1:Clii5aca9PvR4HoAlUs8dh2OsJbDDnJ4yL5EaQE1gSo=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20240711200335-f1075a55d8b0 h1:p7fqmcIAHQQM7ejqCRUj8Rakk4NTl+p+ZTtzI/XEFj4=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20240711200335-f1075a55d8b0/go.mod h1:Clii5aca9PvR4HoAlUs8dh2OsJbDDnJ4yL5EaQE1gSo=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b h1:39UmJzNR71/OMIzblEY9wq+3nojGa/gQOJJpLBa6XcE=
 github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b/go.mod h1:pcY43H/m5pjr7zacrsKVaXnXfKKi1UV08VDPUwxbJkc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=

--- a/install/deploy/networks/devnet.yml
+++ b/install/deploy/networks/devnet.yml
@@ -1,0 +1,41 @@
+key: devnet
+name: Devnet
+description: This is a development network used by Rocket Pool engineers to test new features and contract upgrades before they are promoted to a Testnet for staging. You should not use this network unless invited to do so by the developers.
+networkResources:
+  ethNetworkName: holesky
+  chainID: 17000
+  genesisForkVersion: 0x01017000
+  multicallAddress: 0x0540b786f03c9491f3a2ab4b0e3ae4ecd4f63ce7
+  balanceBatcherAddress: 0xfAa2e7C84eD801dd9D27Ac1ed957274530796140
+  txWatchUrl: https://holesky.etherscan.io/tx
+  flashbotsProtectUrl: https://rpc-holesky.flashbots.net/
+smartNodeResources:
+		stakeUrl:                       "TBD"
+		storageAddress:                 0xf04de123993761Bb9F08c9C39112b0E0b0eccE50
+		rethAddress:                    0x4be7161080b5d890500194cee2c40B1428002Bd3
+		rplTokenAddress:                0x59A1a7AebCbF103B3C4f85261fbaC166117E1979
+		v1_0_0_RewardsPoolAddress:      null
+		v1_0_0_ClaimNodeAddress:        null
+		v1_0_0_ClaimTrustedNodeAddress: null
+		v1_0_0_MinipoolManagerAddress:  null
+		v1_1_0_NetworkPricesAddress:    null
+		v1_1_0_NodeStakingAddress:      null
+		v1_1_0_NodeDepositAddress:      null
+		v1_1_0_MinipoolQueueAddress:    null
+		v1_1_0_MinipoolFactoryAddress:  null
+		v1_2_0_NetworkPricesAddress:    0xBba3FBCD4Bdbfc79118B1B31218602E5A71B426c
+		v1_2_0_NetworkBalancesAddress:  0xBe8Dc8CA5f339c196Aef634DfcDFbA61E30DC743
+		snapshotDelegationAddress:      null
+		snapshotApiDomain:              ""
+		previousRewardsPoolAddresses:
+		  - 0x4d581a552490fb6fce5F978e66560C8b7E481818
+		PreviousProtocolDaoVerifierAddresses: []
+		OptimismPriceMessengerAddress:        null
+		PolygonPriceMessengerAddress:         null
+		ArbitrumPriceMessengerAddress:        null
+		ArbitrumPriceMessengerAddressV2:      null
+		ZkSyncEraPriceMessengerAddress:       null
+		BasePriceMessengerAddress:            null
+		ScrollPriceMessengerAddress:          null
+		ScrollFeeEstimatorAddress:            null
+		RplTwapPoolAddress:                   0x7bb10d2a3105ed5cc150c099a06cafe43d8aa15d

--- a/install/deploy/networks/holesky.yml
+++ b/install/deploy/networks/holesky.yml
@@ -1,0 +1,41 @@
+key: holesky
+name: Holesky Testnet
+description: This is the Holešky (Holešovice) test network, which is the next generation of long-lived testnets for Ethereum. It uses free fake ETH and free fake RPL to make fake validators.\nUse this if you want to practice running the Smart Node in a free, safe environment before moving to Mainnet.
+networkResources:
+  ethNetworkName: holesky
+  chainID: 17000
+  genesisForkVersion: 0x01017000
+  multicallAddress: 0x0540b786f03c9491f3a2ab4b0e3ae4ecd4f63ce7
+  balanceBatcherAddress: 0xfAa2e7C84eD801dd9D27Ac1ed957274530796140
+  txWatchUrl: https://holesky.etherscan.io/tx
+  flashbotsProtectUrl: https://rpc-holesky.flashbots.net/
+smartNodeResources:
+		stakeUrl:                       "https://testnet.rocketpool.net"
+		storageAddress:                 0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1
+		rethAddress:                    0x7322c24752f79c05FFD1E2a6FCB97020C1C264F1
+		rplTokenAddress:                0x1Cc9cF5586522c6F483E84A19c3C2B0B6d027bF0
+		v1_0_0_RewardsPoolAddress:      null
+		v1_0_0_ClaimNodeAddress:        null
+		v1_0_0_ClaimTrustedNodeAddress: null
+		v1_0_0_MinipoolManagerAddress:  null
+		v1_1_0_NetworkPricesAddress:    null
+		v1_1_0_NodeStakingAddress:      null
+		v1_1_0_NodeDepositAddress:      null
+		v1_1_0_MinipoolQueueAddress:    null
+		v1_1_0_MinipoolFactoryAddress:  null
+		v1_2_0_NetworkPricesAddress:    0x029d946F28F93399a5b0D09c879FC8c94E596AEb
+		v1_2_0_NetworkBalancesAddress:  0x9294Fc6F03c64Cc217f5BE8697EA3Ed2De77e2F8
+		snapshotDelegationAddress:      null
+		snapshotApiDomain:              ""
+		previousRewardsPoolAddresses:
+		  - 0x4a625C617a44E60F74E3fe3bf6d6333b63766e91
+		PreviousProtocolDaoVerifierAddresses: []
+		OptimismPriceMessengerAddress:        null
+		PolygonPriceMessengerAddress:         null
+		ArbitrumPriceMessengerAddress:        null
+		ArbitrumPriceMessengerAddressV2:      null
+		ZkSyncEraPriceMessengerAddress:       null
+		BasePriceMessengerAddress:            null
+		ScrollPriceMessengerAddress:          null
+		ScrollFeeEstimatorAddress:            null
+		RplTwapPoolAddress:                   0x7bb10d2a3105ed5cc150c099a06cafe43d8aa15d

--- a/install/deploy/networks/mainnet.yml
+++ b/install/deploy/networks/mainnet.yml
@@ -1,0 +1,41 @@
+key: mainnet
+name: Ethereum Mainnet
+description: This is the real Ethereum main network, using real ETH and real RPL to make real validators.
+networkResources:
+  ethNetworkName: mainnet
+  chainID: 1
+  genesisForkVersion: 0x00000000
+  multicallAddress: 0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696
+  balanceBatcherAddress: 0xb1f8e55c7f64d203c1400b9d8555d050f94adf39
+  txWatchUrl: https://etherscan.io/tx
+  flashbotsProtectUrl: https://rpc.flashbots.net/
+smartNodeResources:
+		stakeUrl:                       "https://stake.rocketpool.net"
+		storageAddress:                 0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46
+		rethAddress:                    0xae78736Cd615f374D3085123A210448E74Fc6393
+		rplTokenAddress:                0xD33526068D116cE69F19A9ee46F0bd304F21A51f
+		v1_0_0_RewardsPoolAddress:      0xA3a18348e6E2d3897B6f2671bb8c120e36554802
+		v1_0_0_ClaimNodeAddress:        0x899336A2a86053705E65dB61f52C686dcFaeF548
+		v1_0_0_ClaimTrustedNodeAddress: 0x6af730deB0463b432433318dC8002C0A4e9315e8
+		v1_0_0_MinipoolManagerAddress:  0x6293B8abC1F36aFB22406Be5f96D893072A8cF3a
+		v1_1_0_NetworkPricesAddress:    0xd3f500F550F46e504A4D2153127B47e007e11166
+		v1_1_0_NodeStakingAddress:      0xA73ec45Fe405B5BFCdC0bF4cbc9014Bb32a01cd2
+		v1_1_0_NodeDepositAddress:      0x1Cc9cF5586522c6F483E84A19c3C2B0B6d027bF0
+		v1_1_0_MinipoolQueueAddress:    0x5870dA524635D1310Dc0e6F256Ce331012C9C19E
+		v1_1_0_MinipoolFactoryAddress:  0x54705f80D7C51Fcffd9C659ce3f3C9a7dCCf5788
+		v1_2_0_NetworkPricesAddress:    0x751826b107672360b764327631cC5764515fFC37
+		v1_2_0_NetworkBalancesAddress:  0x07FCaBCbe4ff0d80c2b1eb42855C0131b6cba2F4
+		snapshotDelegationAddress:      0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446
+		snapshotApiDomain:              "hub.snapshot.org"
+		previousRewardsPoolAddresses:
+		  - 0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1
+		PreviousProtocolDaoVerifierAddresses: []
+		OptimismPriceMessengerAddress:        0xdddcf2c25d50ec22e67218e873d46938650d03a7
+		PolygonPriceMessengerAddress:         0xb1029Ac2Be4e08516697093e2AFeC435057f3511
+		ArbitrumPriceMessengerAddress:        0x05330300f829AD3fC8f33838BC88CFC4093baD53
+		ArbitrumPriceMessengerAddressV2:      0x312FcFB03eC9B1Ea38CB7BFCd26ee7bC3b505aB1
+		ZkSyncEraPriceMessengerAddress:       0x6cf6CB29754aEBf88AF12089224429bD68b0b8c8
+		BasePriceMessengerAddress:            0x64A5856869C06B0188C84A5F83d712bbAc03517d
+		ScrollPriceMessengerAddress:          0x0f22dc9b9c03757d4676539203d7549c8f22c15c
+		ScrollFeeEstimatorAddress:            0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B
+		RplTwapPoolAddress:                   0xe42318ea3b998e8355a3da364eb9d48ec725eb45

--- a/install/deploy/templates/eth2.tmpl
+++ b/install/deploy/templates/eth2.tmpl
@@ -48,7 +48,7 @@ services:
       - BITFLY_NODE_METRICS_ENDPOINT={{.Metrics.BitflyNodeMetrics.Endpoint}}
       - BITFLY_NODE_METRICS_MACHINE_NAME={{.Metrics.BitflyNodeMetrics.MachineName}}
       - MEV_BOOST_URL={{.MevBoostUrl}}
-      - RETH_ADDRESS={{.GetRocketPoolResources.RethAddress.Hex}}
+      - RETH_ADDRESS={{.GetResources.RethAddress.Hex}}
       {{- /* Client-specific values */}}
       {{- if eq .LocalBeaconClient.BeaconNode.String "teku"}}
       - TEKU_JVM_HEAP_SIZE={{.LocalBeaconClient.Teku.JvmHeapSize}}

--- a/install/deploy/templates/node.tmpl
+++ b/install/deploy/templates/node.tmpl
@@ -19,6 +19,8 @@ services:
     command:
       - --user-dir
       - "{{.RocketPoolDirectory}}"
+      - --settings-folder
+      - "/usr/share/rocketpool/networks"
       - --ip
       - "0.0.0.0" # Open to all Docker traffic
       - --port

--- a/rocketpool-cli/client/utils.go
+++ b/rocketpool-cli/client/utils.go
@@ -20,14 +20,23 @@ func SyncRatioToPercent(in float64) float64 {
 	return math.Min(99.99, in*100)
 }
 
+// Load the Smart Node settings from the network settings files on disk
+func LoadSmartNodeSettings(networksDir string) ([]*config.SmartNodeSettings, error) {
+	settings, err := config.LoadSettingsFiles(networksDir)
+	if err != nil {
+		return nil, fmt.Errorf("error loading Smart Node settings files from [%s]: %w", networksDir, err)
+	}
+	return settings, nil
+}
+
 // Loads a config without updating it if it exists
-func LoadConfigFromFile(path string) (*config.SmartNodeConfig, error) {
+func LoadConfigFromFile(path string, networks []*config.SmartNodeSettings) (*config.SmartNodeConfig, error) {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
 
-	cfg, err := config.LoadFromFile(path)
+	cfg, err := config.LoadFromFile(path, networks)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool-cli/commands/node/set-primary-withdrawal-address.go
+++ b/rocketpool-cli/commands/node/set-primary-withdrawal-address.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/terminal"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
+	snconfig "github.com/rocket-pool/smartnode/v2/shared/config"
 )
 
 const (
@@ -125,7 +126,7 @@ func setPrimaryWithdrawalAddress(c *cli.Context, withdrawalAddressOrENS string) 
 		stakeUrl := ""
 		config, _, err := rp.LoadConfig()
 		if err == nil {
-			rs := config.GetRocketPoolResources()
+			rs := snconfig.NewRocketPoolResources(config.Network.Value)
 			stakeUrl = rs.StakeUrl
 		}
 		if stakeUrl != "" {

--- a/rocketpool-cli/commands/node/set-primary-withdrawal-address.go
+++ b/rocketpool-cli/commands/node/set-primary-withdrawal-address.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/terminal"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
-	snconfig "github.com/rocket-pool/smartnode/v2/shared/config"
 )
 
 const (
@@ -126,8 +125,12 @@ func setPrimaryWithdrawalAddress(c *cli.Context, withdrawalAddressOrENS string) 
 		stakeUrl := ""
 		config, _, err := rp.LoadConfig()
 		if err == nil {
-			rs := snconfig.NewRocketPoolResources(config.Network.Value)
-			stakeUrl = rs.StakeUrl
+			res, err := config.GetResources()
+			if err != nil {
+				fmt.Printf("Warning: couldn't read resources from config file so the stake URL will be unavailable (%s).\n", err.Error())
+			} else {
+				stakeUrl = res.StakeUrl
+			}
 		}
 		if stakeUrl != "" {
 			fmt.Printf("The node's primary withdrawal address update to %s is now pending.\n"+

--- a/rocketpool-cli/commands/node/set-rpl-withdrawal-address.go
+++ b/rocketpool-cli/commands/node/set-rpl-withdrawal-address.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/terminal"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
-	snconfig "github.com/rocket-pool/smartnode/v2/shared/config"
 )
 
 const (
@@ -142,8 +141,12 @@ func setRplWithdrawalAddress(c *cli.Context, withdrawalAddressOrEns string) erro
 		stakeUrl := ""
 		config, _, err := rp.LoadConfig()
 		if err == nil {
-			rs := snconfig.NewRocketPoolResources(config.Network.Value)
-			stakeUrl = rs.StakeUrl
+			res, err := config.GetResources()
+			if err != nil {
+				fmt.Printf("Warning: couldn't read resources from config file so the stake URL will be unavailable (%s).\n", err.Error())
+			} else {
+				stakeUrl = res.StakeUrl
+			}
 		}
 		if stakeUrl != "" {
 			fmt.Printf("The node's RPL withdrawal address update to %s is now pending.\n"+

--- a/rocketpool-cli/commands/node/set-rpl-withdrawal-address.go
+++ b/rocketpool-cli/commands/node/set-rpl-withdrawal-address.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/terminal"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
+	snconfig "github.com/rocket-pool/smartnode/v2/shared/config"
 )
 
 const (
@@ -141,7 +142,7 @@ func setRplWithdrawalAddress(c *cli.Context, withdrawalAddressOrEns string) erro
 		stakeUrl := ""
 		config, _, err := rp.LoadConfig()
 		if err == nil {
-			rs := config.GetRocketPoolResources()
+			rs := snconfig.NewRocketPoolResources(config.Network.Value)
 			stakeUrl = rs.StakeUrl
 		}
 		if stakeUrl != "" {

--- a/rocketpool-cli/commands/service/commands.go
+++ b/rocketpool-cli/commands/service/commands.go
@@ -113,7 +113,7 @@ func createFlagsFromConfigParams(prefix string, section config.IConfigSection, c
 // Register commands
 func RegisterCommands(app *cli.App, name string, aliases []string) {
 	// Create config flags from parameters
-	cfgTemplate := snCfg.NewSmartNodeConfig("", false)
+	cfgTemplate, _ := snCfg.NewSmartNodeConfig("", false, []*snCfg.SmartNodeSettings{})
 	network := cfgTemplate.Network.Value
 	configFlags := createFlagsFromConfigParams("", cfgTemplate, []cli.Flag{
 		installUpdateDefaultsFlag,

--- a/rocketpool-cli/commands/service/get-config-yaml.go
+++ b/rocketpool-cli/commands/service/get-config-yaml.go
@@ -10,7 +10,7 @@ import (
 
 // Generate a YAML file that shows the current configuration schema, including all of the parameters and their descriptions
 func getConfigYaml(c *cli.Context) error {
-	cfg := config.NewSmartNodeConfig("", false)
+	cfg, _ := config.NewSmartNodeConfig("", false, []*config.SmartNodeSettings{})
 	bytes, err := yaml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("error serializing configuration schema: %w", err)

--- a/rocketpool-cli/rocketpool-cli.go
+++ b/rocketpool-cli/rocketpool-cli.go
@@ -126,7 +126,6 @@ func newCliApp() *cli.App {
 		}
 		return nil
 	}
-
 	app.After = func(c *cli.Context) error {
 		// Close http tracer if any was created
 		snSettings = settings.GetSmartNodeSettings(c)

--- a/rocketpool-cli/settings/smartnode_settings.go
+++ b/rocketpool-cli/settings/smartnode_settings.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -16,6 +17,15 @@ import (
 const (
 	traceMode           os.FileMode = 0644
 	defaultConfigFolder string      = ".rocketpool"
+
+	// System dir path for Linux
+	linuxSystemDir string = "/usr/share/rocketpool"
+
+	// Subfolders under the system dir
+	scriptsDir        string = "scripts"
+	templatesDir      string = "templates"
+	overrideSourceDir string = "override"
+	networksDir       string = "networks"
 )
 
 var (
@@ -99,6 +109,18 @@ type SmartNodeSettings struct {
 
 	// The HTTP trace file if tracing is enabled
 	HttpTraceFile *os.File
+
+	// The system path for Smart Node scripts used in the Docker containers
+	ScriptsDir string
+
+	// The system path for Smart Node templates
+	TemplatesDir string
+
+	// The system path for the source files to put in the user's override directory
+	OverrideSourceDir string
+
+	// The system path for built-in network settings and resource definitions
+	NetworksDir string
 }
 
 // Get the Smart Node settings from a CLI context
@@ -169,6 +191,19 @@ func NewSmartNodeSettings(c *cli.Context) (*SmartNodeSettings, error) {
 			return nil, fmt.Errorf("error opening HTTP trace file [%s]: %w", httpTracePath, err)
 		}
 	}
+
+	var systemDir string
+	switch runtime.GOOS {
+	// This is where to add different paths for different OS's like macOS
+	default:
+		// By default just use the Linux path
+		systemDir = linuxSystemDir
+	}
+
+	snSettings.ScriptsDir = filepath.Join(systemDir, scriptsDir)
+	snSettings.TemplatesDir = filepath.Join(systemDir, templatesDir)
+	snSettings.OverrideSourceDir = filepath.Join(systemDir, overrideSourceDir)
+	snSettings.NetworksDir = filepath.Join(systemDir, networksDir)
 
 	c.App.Metadata[contextMetadataName] = snSettings
 

--- a/rocketpool-cli/utils/utils.go
+++ b/rocketpool-cli/utils/utils.go
@@ -92,17 +92,21 @@ func printTransactionHashImpl(rp *client.Client, hash common.Hash, finalMessage 
 func getTxWatchUrl(rp *client.Client) string {
 	cfg, isNew, err := rp.LoadConfig()
 	if err != nil {
-		fmt.Printf("Warning: couldn't read config file so the transaction URL will be unavailable (%s).\n", err)
+		fmt.Printf("Warning: couldn't read config file so the transaction URL will be unavailable (%s).\n", err.Error())
 		return ""
 	}
 
 	if isNew {
-		fmt.Print("Settings file not found. Please run `rocketpool service config` to set up your Smartnode.")
+		fmt.Print("Settings file not found. Please run `rocketpool service config` to set up your Smart Node.")
 		return ""
 	}
 
-	rs := snCfg.NewRocketPoolResources(cfg.Network.Value)
-	return rs.TxWatchUrl
+	res, err := cfg.GetResources()
+	if err != nil {
+		fmt.Printf("Warning: couldn't read resources from config file so the transaction URL will be unavailable (%s).\n", err.Error())
+		return ""
+	}
+	return res.TxWatchUrl
 }
 
 // Convert a Unix datetime to a string, or `---` if it's zero

--- a/rocketpool-cli/utils/utils.go
+++ b/rocketpool-cli/utils/utils.go
@@ -101,7 +101,7 @@ func getTxWatchUrl(rp *client.Client) string {
 		return ""
 	}
 
-	rs := cfg.GetNetworkResources()
+	rs := snCfg.NewRocketPoolResources(cfg.Network.Value)
 	return rs.TxWatchUrl
 }
 

--- a/rocketpool-daemon/api/auction/bid-lot.go
+++ b/rocketpool-daemon/api/auction/bid-lot.go
@@ -41,7 +41,7 @@ func (f *auctionBidContextFactory) Create(args url.Values) (*auctionBidContext, 
 
 func (f *auctionBidContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionBidContext, api.AuctionBidOnLotData](
-		router, "lots/bid", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "lots/bid", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/bid-lot.go
+++ b/rocketpool-daemon/api/auction/bid-lot.go
@@ -41,7 +41,7 @@ func (f *auctionBidContextFactory) Create(args url.Values) (*auctionBidContext, 
 
 func (f *auctionBidContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionBidContext, api.AuctionBidOnLotData](
-		router, "lots/bid", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "lots/bid", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/claim-lot.go
+++ b/rocketpool-daemon/api/auction/claim-lot.go
@@ -44,7 +44,7 @@ func (f *auctionClaimContextFactory) Create(args url.Values) (*auctionClaimConte
 
 func (f *auctionClaimContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionClaimContext, types.DataBatch[api.AuctionClaimFromLotData]](
-		router, "lots/claim", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "lots/claim", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/claim-lot.go
+++ b/rocketpool-daemon/api/auction/claim-lot.go
@@ -44,7 +44,7 @@ func (f *auctionClaimContextFactory) Create(args url.Values) (*auctionClaimConte
 
 func (f *auctionClaimContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionClaimContext, types.DataBatch[api.AuctionClaimFromLotData]](
-		router, "lots/claim", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "lots/claim", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/create-lot.go
+++ b/rocketpool-daemon/api/auction/create-lot.go
@@ -36,7 +36,7 @@ func (f *auctionCreateContextFactory) Create(args url.Values) (*auctionCreateCon
 
 func (f *auctionCreateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionCreateContext, api.AuctionCreateLotData](
-		router, "lots/create", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "lots/create", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/create-lot.go
+++ b/rocketpool-daemon/api/auction/create-lot.go
@@ -36,7 +36,7 @@ func (f *auctionCreateContextFactory) Create(args url.Values) (*auctionCreateCon
 
 func (f *auctionCreateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionCreateContext, api.AuctionCreateLotData](
-		router, "lots/create", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "lots/create", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/handler.go
+++ b/rocketpool-daemon/api/auction/handler.go
@@ -13,11 +13,11 @@ import (
 type AuctionHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewAuctionHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *AuctionHandler {
+func NewAuctionHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *AuctionHandler {
 	h := &AuctionHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/auction/lots.go
+++ b/rocketpool-daemon/api/auction/lots.go
@@ -34,7 +34,7 @@ func (f *auctionLotContextFactory) Create(args url.Values) (*auctionLotContext, 
 
 func (f *auctionLotContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionLotContext, api.AuctionLotsData](
-		router, "lots", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "lots", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/lots.go
+++ b/rocketpool-daemon/api/auction/lots.go
@@ -34,7 +34,7 @@ func (f *auctionLotContextFactory) Create(args url.Values) (*auctionLotContext, 
 
 func (f *auctionLotContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionLotContext, api.AuctionLotsData](
-		router, "lots", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "lots", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/recover-lot.go
+++ b/rocketpool-daemon/api/auction/recover-lot.go
@@ -43,7 +43,7 @@ func (f *auctionRecoverContextFactory) Create(args url.Values) (*auctionRecoverC
 
 func (f *auctionRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionRecoverContext, types.DataBatch[api.AuctionRecoverRplFromLotData]](
-		router, "lots/recover", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "lots/recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/recover-lot.go
+++ b/rocketpool-daemon/api/auction/recover-lot.go
@@ -43,7 +43,7 @@ func (f *auctionRecoverContextFactory) Create(args url.Values) (*auctionRecoverC
 
 func (f *auctionRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionRecoverContext, types.DataBatch[api.AuctionRecoverRplFromLotData]](
-		router, "lots/recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "lots/recover", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/status.go
+++ b/rocketpool-daemon/api/auction/status.go
@@ -37,7 +37,7 @@ func (f *auctionStatusContextFactory) Create(args url.Values) (*auctionStatusCon
 
 func (f *auctionStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionStatusContext, api.AuctionStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/auction/status.go
+++ b/rocketpool-daemon/api/auction/status.go
@@ -37,7 +37,7 @@ func (f *auctionStatusContextFactory) Create(args url.Values) (*auctionStatusCon
 
 func (f *auctionStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*auctionStatusContext, api.AuctionStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/begin-reduce-bond.go
+++ b/rocketpool-daemon/api/minipool/begin-reduce-bond.go
@@ -37,7 +37,7 @@ func (f *minipoolBeginReduceBondContextFactory) Create(args url.Values) (*minipo
 
 func (f *minipoolBeginReduceBondContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolBeginReduceBondContext, types.BatchTxInfoData](
-		router, "begin-reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "begin-reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/begin-reduce-bond.go
+++ b/rocketpool-daemon/api/minipool/begin-reduce-bond.go
@@ -37,7 +37,7 @@ func (f *minipoolBeginReduceBondContextFactory) Create(args url.Values) (*minipo
 
 func (f *minipoolBeginReduceBondContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolBeginReduceBondContext, types.BatchTxInfoData](
-		router, "begin-reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "begin-reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/can-change-withdrawal-creds.go
+++ b/rocketpool-daemon/api/minipool/can-change-withdrawal-creds.go
@@ -46,7 +46,7 @@ func (f *minipoolCanChangeCredsContextFactory) Create(args url.Values) (*minipoo
 
 func (f *minipoolCanChangeCredsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolCanChangeCredsContext, api.MinipoolCanChangeWithdrawalCredentialsData](
-		router, "change-withdrawal-creds/verify", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "change-withdrawal-creds/verify", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/can-change-withdrawal-creds.go
+++ b/rocketpool-daemon/api/minipool/can-change-withdrawal-creds.go
@@ -46,7 +46,7 @@ func (f *minipoolCanChangeCredsContextFactory) Create(args url.Values) (*minipoo
 
 func (f *minipoolCanChangeCredsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolCanChangeCredsContext, api.MinipoolCanChangeWithdrawalCredentialsData](
-		router, "change-withdrawal-creds/verify", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "change-withdrawal-creds/verify", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/change-withdrawal-creds.go
+++ b/rocketpool-daemon/api/minipool/change-withdrawal-creds.go
@@ -43,7 +43,7 @@ func (f *minipoolChangeCredsContextFactory) Create(args url.Values) (*minipoolCh
 
 func (f *minipoolChangeCredsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolChangeCredsContext, types.SuccessData](
-		router, "change-withdrawal-creds", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "change-withdrawal-creds", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/change-withdrawal-creds.go
+++ b/rocketpool-daemon/api/minipool/change-withdrawal-creds.go
@@ -43,7 +43,7 @@ func (f *minipoolChangeCredsContextFactory) Create(args url.Values) (*minipoolCh
 
 func (f *minipoolChangeCredsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolChangeCredsContext, types.SuccessData](
-		router, "change-withdrawal-creds", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "change-withdrawal-creds", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/close-details.go
+++ b/rocketpool-daemon/api/minipool/close-details.go
@@ -61,9 +61,9 @@ func (c *MinipoolCloseDetailsContext) GetState(node *node.Node, mc *batch.MultiC
 	node.IsFeeDistributorInitialized.AddToQuery(mc)
 }
 
-func (c *MinipoolCloseDetailsContext) CheckState(node *node.Node, response *api.MinipoolCloseDetailsData) bool {
-	response.IsFeeDistributorInitialized = node.IsFeeDistributorInitialized.Get()
-	return response.IsFeeDistributorInitialized
+func (c *MinipoolCloseDetailsContext) CheckState(node *node.Node, data *api.MinipoolCloseDetailsData) bool {
+	data.IsFeeDistributorInitialized = node.IsFeeDistributorInitialized.Get()
+	return data.IsFeeDistributorInitialized
 }
 
 func (c *MinipoolCloseDetailsContext) GetMinipoolDetails(mc *batch.MultiCaller, mp minipool.IMinipool, index int) {

--- a/rocketpool-daemon/api/minipool/dissolve.go
+++ b/rocketpool-daemon/api/minipool/dissolve.go
@@ -34,7 +34,7 @@ func (f *minipoolDissolveContextFactory) Create(args url.Values) (*minipoolDisso
 
 func (f *minipoolDissolveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolDissolveContext, types.BatchTxInfoData](
-		router, "dissolve", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "dissolve", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/dissolve.go
+++ b/rocketpool-daemon/api/minipool/dissolve.go
@@ -34,7 +34,7 @@ func (f *minipoolDissolveContextFactory) Create(args url.Values) (*minipoolDisso
 
 func (f *minipoolDissolveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolDissolveContext, types.BatchTxInfoData](
-		router, "dissolve", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "dissolve", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/distribute.go
+++ b/rocketpool-daemon/api/minipool/distribute.go
@@ -35,7 +35,7 @@ func (f *minipoolDistributeContextFactory) Create(args url.Values) (*minipoolDis
 
 func (f *minipoolDistributeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolDistributeContext, types.BatchTxInfoData](
-		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/distribute.go
+++ b/rocketpool-daemon/api/minipool/distribute.go
@@ -35,7 +35,7 @@ func (f *minipoolDistributeContextFactory) Create(args url.Values) (*minipoolDis
 
 func (f *minipoolDistributeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolDistributeContext, types.BatchTxInfoData](
-		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/exit.go
+++ b/rocketpool-daemon/api/minipool/exit.go
@@ -43,7 +43,7 @@ func (f *minipoolExitContextFactory) Create(args url.Values) (*minipoolExitConte
 
 func (f *minipoolExitContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolExitContext, types.SuccessData](
-		router, "exit", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "exit", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/exit.go
+++ b/rocketpool-daemon/api/minipool/exit.go
@@ -43,7 +43,7 @@ func (f *minipoolExitContextFactory) Create(args url.Values) (*minipoolExitConte
 
 func (f *minipoolExitContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolExitContext, types.SuccessData](
-		router, "exit", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "exit", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/handler.go
+++ b/rocketpool-daemon/api/minipool/handler.go
@@ -13,11 +13,11 @@ import (
 type MinipoolHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewMinipoolHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *MinipoolHandler {
+func NewMinipoolHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *MinipoolHandler {
 	h := &MinipoolHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/minipool/import-key.go
+++ b/rocketpool-daemon/api/minipool/import-key.go
@@ -45,7 +45,7 @@ func (f *minipoolImportKeyContextFactory) Create(args url.Values) (*minipoolImpo
 
 func (f *minipoolImportKeyContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolImportKeyContext, types.SuccessData](
-		router, "import-key", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "import-key", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/import-key.go
+++ b/rocketpool-daemon/api/minipool/import-key.go
@@ -45,7 +45,7 @@ func (f *minipoolImportKeyContextFactory) Create(args url.Values) (*minipoolImpo
 
 func (f *minipoolImportKeyContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*minipoolImportKeyContext, types.SuccessData](
-		router, "import-key", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "import-key", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/minipool-context.go
+++ b/rocketpool-daemon/api/minipool/minipool-context.go
@@ -58,7 +58,7 @@ func RegisterMinipoolRoute[ContextType IMinipoolCallContext[DataType], DataType 
 	factory IMinipoolCallContextFactory[ContextType, DataType],
 	ctx context.Context,
 	logger *log.Logger,
-	serviceProvider *services.ServiceProvider,
+	serviceProvider services.ISmartNodeServiceProvider,
 ) {
 	router.HandleFunc(fmt.Sprintf("/%s", functionName), func(w http.ResponseWriter, r *http.Request) {
 		var err error
@@ -97,7 +97,7 @@ func RegisterMinipoolRoute[ContextType IMinipoolCallContext[DataType], DataType 
 }
 
 // Create a scaffolded generic minipool query, with caller-specific functionality where applicable
-func runMinipoolRoute[DataType any](ctx context.Context, mpContext IMinipoolCallContext[DataType], serviceProvider *services.ServiceProvider) (types.ResponseStatus, *types.ApiResponse[DataType], error) {
+func runMinipoolRoute[DataType any](ctx context.Context, mpContext IMinipoolCallContext[DataType], serviceProvider services.ISmartNodeServiceProvider) (types.ResponseStatus, *types.ApiResponse[DataType], error) {
 	// Get the services
 	w := serviceProvider.GetWallet()
 	q := serviceProvider.GetQueryManager()

--- a/rocketpool-daemon/api/minipool/promote.go
+++ b/rocketpool-daemon/api/minipool/promote.go
@@ -35,7 +35,7 @@ func (f *minipoolPromoteContextFactory) Create(args url.Values) (*minipoolPromot
 
 func (f *minipoolPromoteContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolPromoteContext, types.BatchTxInfoData](
-		router, "promote", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "promote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/promote.go
+++ b/rocketpool-daemon/api/minipool/promote.go
@@ -35,7 +35,7 @@ func (f *minipoolPromoteContextFactory) Create(args url.Values) (*minipoolPromot
 
 func (f *minipoolPromoteContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolPromoteContext, types.BatchTxInfoData](
-		router, "promote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "promote", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/reduce-bond.go
+++ b/rocketpool-daemon/api/minipool/reduce-bond.go
@@ -35,7 +35,7 @@ func (f *minipoolReduceBondContextFactory) Create(args url.Values) (*minipoolRed
 
 func (f *minipoolReduceBondContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolReduceBondContext, types.BatchTxInfoData](
-		router, "reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/reduce-bond.go
+++ b/rocketpool-daemon/api/minipool/reduce-bond.go
@@ -35,7 +35,7 @@ func (f *minipoolReduceBondContextFactory) Create(args url.Values) (*minipoolRed
 
 func (f *minipoolReduceBondContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolReduceBondContext, types.BatchTxInfoData](
-		router, "reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "reduce-bond", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/refund.go
+++ b/rocketpool-daemon/api/minipool/refund.go
@@ -34,7 +34,7 @@ func (f *minipoolRefundContextFactory) Create(args url.Values) (*minipoolRefundC
 
 func (f *minipoolRefundContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolRefundContext, types.BatchTxInfoData](
-		router, "refund", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "refund", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/refund.go
+++ b/rocketpool-daemon/api/minipool/refund.go
@@ -34,7 +34,7 @@ func (f *minipoolRefundContextFactory) Create(args url.Values) (*minipoolRefundC
 
 func (f *minipoolRefundContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolRefundContext, types.BatchTxInfoData](
-		router, "refund", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "refund", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/rescue-dissolved.go
+++ b/rocketpool-daemon/api/minipool/rescue-dissolved.go
@@ -44,7 +44,7 @@ func (f *minipoolRescueDissolvedContextFactory) Create(args url.Values) (*minipo
 
 func (f *minipoolRescueDissolvedContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolRescueDissolvedContext, types.BatchTxInfoData](
-		router, "rescue-dissolved", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rescue-dissolved", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/rescue-dissolved.go
+++ b/rocketpool-daemon/api/minipool/rescue-dissolved.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rocket-pool/node-manager-core/api/server"
 	"github.com/rocket-pool/node-manager-core/api/types"
 	beacon "github.com/rocket-pool/node-manager-core/beacon"
-	"github.com/rocket-pool/node-manager-core/config"
 	"github.com/rocket-pool/node-manager-core/eth"
 	nmc_validator "github.com/rocket-pool/node-manager-core/node/validator"
 	"github.com/rocket-pool/node-manager-core/node/wallet"
@@ -21,6 +20,7 @@ import (
 	"github.com/rocket-pool/rocketpool-go/v2/minipool"
 	"github.com/rocket-pool/rocketpool-go/v2/rocketpool"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-daemon/common/validator"
+	"github.com/rocket-pool/smartnode/v2/shared/config"
 )
 
 // ===============
@@ -44,7 +44,7 @@ func (f *minipoolRescueDissolvedContextFactory) Create(args url.Values) (*minipo
 
 func (f *minipoolRescueDissolvedContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolRescueDissolvedContext, types.BatchTxInfoData](
-		router, "rescue-dissolved", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rescue-dissolved", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -60,7 +60,7 @@ type minipoolRescueDissolvedContext struct {
 	w                 *wallet.Wallet
 	vMgr              *validator.ValidatorManager
 	bc                beacon.IBeaconClient
-	rs                *config.NetworkResources
+	rs                *config.RocketPoolResources
 
 	mpMgr *minipool.MinipoolManager
 }
@@ -76,7 +76,7 @@ func (c *minipoolRescueDissolvedContext) PrepareData(data *types.BatchTxInfoData
 	c.vMgr = sp.GetValidatorManager()
 	c.w = sp.GetWallet()
 	c.bc = sp.GetBeaconClient()
-	c.rs = sp.GetNetworkResources()
+	c.rs = sp.GetResources()
 
 	// Requirements
 	status, err := sp.RequireNodeRegistered(c.handler.ctx)

--- a/rocketpool-daemon/api/minipool/rescue-dissolved.go
+++ b/rocketpool-daemon/api/minipool/rescue-dissolved.go
@@ -60,7 +60,7 @@ type minipoolRescueDissolvedContext struct {
 	w                 *wallet.Wallet
 	vMgr              *validator.ValidatorManager
 	bc                beacon.IBeaconClient
-	rs                *config.RocketPoolResources
+	res               *config.MergedResources
 
 	mpMgr *minipool.MinipoolManager
 }
@@ -76,7 +76,7 @@ func (c *minipoolRescueDissolvedContext) PrepareData(data *types.BatchTxInfoData
 	c.vMgr = sp.GetValidatorManager()
 	c.w = sp.GetWallet()
 	c.bc = sp.GetBeaconClient()
-	c.rs = sp.GetResources()
+	c.res = sp.GetResources()
 
 	// Requirements
 	status, err := sp.RequireNodeRegistered(c.handler.ctx)
@@ -140,7 +140,7 @@ func (c *minipoolRescueDissolvedContext) getDepositTx(minipoolAddress common.Add
 
 	// Get validator deposit data
 	amountGwei := big.NewInt(0).Div(amount, big.NewInt(1e9)).Uint64()
-	depositData, err := nmc_validator.GetDepositData(validatorKey, withdrawalCredentials, c.rs.GenesisForkVersion, amountGwei, c.rs.EthNetworkName)
+	depositData, err := nmc_validator.GetDepositData(validatorKey, withdrawalCredentials, c.res.GenesisForkVersion, amountGwei, c.res.EthNetworkName)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool-daemon/api/minipool/rollback-delegates.go
+++ b/rocketpool-daemon/api/minipool/rollback-delegates.go
@@ -34,7 +34,7 @@ func (f *minipoolRollbackDelegatesContextFactory) Create(args url.Values) (*mini
 
 func (f *minipoolRollbackDelegatesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolRollbackDelegatesContext, types.BatchTxInfoData](
-		router, "delegate/rollback", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "delegate/rollback", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/rollback-delegates.go
+++ b/rocketpool-daemon/api/minipool/rollback-delegates.go
@@ -34,7 +34,7 @@ func (f *minipoolRollbackDelegatesContextFactory) Create(args url.Values) (*mini
 
 func (f *minipoolRollbackDelegatesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolRollbackDelegatesContext, types.BatchTxInfoData](
-		router, "delegate/rollback", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "delegate/rollback", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/set-use-latest-delegates.go
+++ b/rocketpool-daemon/api/minipool/set-use-latest-delegates.go
@@ -35,7 +35,7 @@ func (f *minipoolSetUseLatestDelegatesContextFactory) Create(args url.Values) (*
 
 func (f *minipoolSetUseLatestDelegatesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolSetUseLatestDelegatesContext, types.BatchTxInfoData](
-		router, "delegate/set-use-latest", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "delegate/set-use-latest", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/set-use-latest-delegates.go
+++ b/rocketpool-daemon/api/minipool/set-use-latest-delegates.go
@@ -35,7 +35,7 @@ func (f *minipoolSetUseLatestDelegatesContextFactory) Create(args url.Values) (*
 
 func (f *minipoolSetUseLatestDelegatesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolSetUseLatestDelegatesContext, types.BatchTxInfoData](
-		router, "delegate/set-use-latest", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "delegate/set-use-latest", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/stake.go
+++ b/rocketpool-daemon/api/minipool/stake.go
@@ -39,7 +39,7 @@ func (f *minipoolStakeContextFactory) Create(args url.Values) (*minipoolStakeCon
 
 func (f *minipoolStakeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolStakeContext, types.BatchTxInfoData](
-		router, "stake", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "stake", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -56,7 +56,7 @@ func (c *minipoolStakeContext) PrepareData(data *types.BatchTxInfoData, opts *bi
 	sp := c.handler.serviceProvider
 	rp := sp.GetRocketPool()
 	vMgr := sp.GetValidatorManager()
-	rs := sp.GetNetworkResources()
+	rs := sp.GetResources()
 
 	// Requirements
 	status, err := sp.RequireNodeRegistered(c.handler.ctx)

--- a/rocketpool-daemon/api/minipool/stake.go
+++ b/rocketpool-daemon/api/minipool/stake.go
@@ -39,7 +39,7 @@ func (f *minipoolStakeContextFactory) Create(args url.Values) (*minipoolStakeCon
 
 func (f *minipoolStakeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolStakeContext, types.BatchTxInfoData](
-		router, "stake", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "stake", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/upgrade-delegates.go
+++ b/rocketpool-daemon/api/minipool/upgrade-delegates.go
@@ -34,7 +34,7 @@ func (f *minipoolUpgradeDelegatesContextFactory) Create(args url.Values) (*minip
 
 func (f *minipoolUpgradeDelegatesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolUpgradeDelegatesContext, types.BatchTxInfoData](
-		router, "delegate/upgrade", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "delegate/upgrade", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/upgrade-delegates.go
+++ b/rocketpool-daemon/api/minipool/upgrade-delegates.go
@@ -34,7 +34,7 @@ func (f *minipoolUpgradeDelegatesContextFactory) Create(args url.Values) (*minip
 
 func (f *minipoolUpgradeDelegatesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolUpgradeDelegatesContext, types.BatchTxInfoData](
-		router, "delegate/upgrade", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "delegate/upgrade", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/utils.go
+++ b/rocketpool-daemon/api/minipool/utils.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Get transaction info for an operation on all of the provided minipools, using the common minipool API (for version-agnostic functions)
-func prepareMinipoolBatchTxData(ctx context.Context, sp *services.ServiceProvider, minipoolAddresses []common.Address, data *types.BatchTxInfoData, txCreator func(mp minipool.IMinipool, opts *bind.TransactOpts) (types.ResponseStatus, *eth.TransactionInfo, error), txName string) (types.ResponseStatus, error) {
+func prepareMinipoolBatchTxData(ctx context.Context, sp services.ISmartNodeServiceProvider, minipoolAddresses []common.Address, data *types.BatchTxInfoData, txCreator func(mp minipool.IMinipool, opts *bind.TransactOpts) (types.ResponseStatus, *eth.TransactionInfo, error), txName string) (types.ResponseStatus, error) {
 	// Requirements
 	status, err := sp.RequireNodeRegistered(ctx)
 	if err != nil {

--- a/rocketpool-daemon/api/minipool/vanity.go
+++ b/rocketpool-daemon/api/minipool/vanity.go
@@ -42,7 +42,7 @@ func (f *minipoolVanityContextFactory) Create(args url.Values) (*minipoolVanityC
 
 func (f *minipoolVanityContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolVanityContext, api.MinipoolVanityArtifactsData](
-		router, "vanity-artifacts", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "vanity-artifacts", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/minipool/vanity.go
+++ b/rocketpool-daemon/api/minipool/vanity.go
@@ -42,7 +42,7 @@ func (f *minipoolVanityContextFactory) Create(args url.Values) (*minipoolVanityC
 
 func (f *minipoolVanityContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*minipoolVanityContext, api.MinipoolVanityArtifactsData](
-		router, "vanity-artifacts", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "vanity-artifacts", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/dao-proposals.go
+++ b/rocketpool-daemon/api/network/dao-proposals.go
@@ -34,7 +34,7 @@ func (f *networkProposalContextFactory) Create(args url.Values) (*networkProposa
 
 func (f *networkProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkProposalContext, api.NetworkDaoProposalsData](
-		router, "dao-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "dao-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -50,6 +50,7 @@ func (c *networkProposalContext) PrepareData(data *api.NetworkDaoProposalsData, 
 	sp := c.handler.serviceProvider
 	rp := sp.GetRocketPool()
 	cfg := sp.GetConfig()
+	res := sp.GetResources()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
 	snapshot := sp.GetSnapshotDelegation()
 
@@ -75,7 +76,7 @@ func (c *networkProposalContext) PrepareData(data *api.NetworkDaoProposalsData, 
 	}
 
 	// Get snapshot proposals
-	snapshotResponse, err := voting.GetSnapshotProposals(cfg, data.AccountAddress, data.VotingDelegate, true)
+	snapshotResponse, err := voting.GetSnapshotProposals(cfg, res, data.AccountAddress, data.VotingDelegate, true)
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error getting snapshot proposals: %w", err)
 	}

--- a/rocketpool-daemon/api/network/dao-proposals.go
+++ b/rocketpool-daemon/api/network/dao-proposals.go
@@ -34,7 +34,7 @@ func (f *networkProposalContextFactory) Create(args url.Values) (*networkProposa
 
 func (f *networkProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkProposalContext, api.NetworkDaoProposalsData](
-		router, "dao-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "dao-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/delegate.go
+++ b/rocketpool-daemon/api/network/delegate.go
@@ -29,7 +29,7 @@ func (f *networkDelegateContextFactory) Create(args url.Values) (*networkDelegat
 
 func (f *networkDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkDelegateContext, api.NetworkLatestDelegateData](
-		router, "latest-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "latest-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/delegate.go
+++ b/rocketpool-daemon/api/network/delegate.go
@@ -29,7 +29,7 @@ func (f *networkDelegateContextFactory) Create(args url.Values) (*networkDelegat
 
 func (f *networkDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkDelegateContext, api.NetworkLatestDelegateData](
-		router, "latest-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "latest-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/deposit-contract-info.go
+++ b/rocketpool-daemon/api/network/deposit-contract-info.go
@@ -34,7 +34,7 @@ func (f *networkDepositInfoContextFactory) Create(args url.Values) (*networkDepo
 
 func (f *networkDepositInfoContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkDepositInfoContext, api.NetworkDepositContractInfoData](
-		router, "deposit-contract-info", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "deposit-contract-info", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -51,6 +51,7 @@ func (c *networkDepositInfoContext) PrepareData(data *api.NetworkDepositContract
 	sp := c.handler.serviceProvider
 	rp := sp.GetRocketPool()
 	cfg := sp.GetConfig()
+	res := sp.GetResources()
 	bc := sp.GetBeaconClient()
 	ctx := c.handler.ctx
 
@@ -70,7 +71,7 @@ func (c *networkDepositInfoContext) PrepareData(data *api.NetworkDepositContract
 	}
 
 	// Get the deposit contract info
-	info, err := rputils.GetDepositContractInfo(ctx, rp, cfg, bc)
+	info, err := rputils.GetDepositContractInfo(ctx, rp, cfg, res, bc)
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error getting deposit contract info: %w", err)
 	}

--- a/rocketpool-daemon/api/network/deposit-contract-info.go
+++ b/rocketpool-daemon/api/network/deposit-contract-info.go
@@ -34,7 +34,7 @@ func (f *networkDepositInfoContextFactory) Create(args url.Values) (*networkDepo
 
 func (f *networkDepositInfoContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkDepositInfoContext, api.NetworkDepositContractInfoData](
-		router, "deposit-contract-info", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "deposit-contract-info", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/download-rewards.go
+++ b/rocketpool-daemon/api/network/download-rewards.go
@@ -33,7 +33,7 @@ func (f *networkDownloadRewardsContextFactory) Create(args url.Values) (*network
 
 func (f *networkDownloadRewardsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkDownloadRewardsContext, types.SuccessData](
-		router, "download-rewards-file", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "download-rewards-file", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/download-rewards.go
+++ b/rocketpool-daemon/api/network/download-rewards.go
@@ -33,7 +33,7 @@ func (f *networkDownloadRewardsContextFactory) Create(args url.Values) (*network
 
 func (f *networkDownloadRewardsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkDownloadRewardsContext, types.SuccessData](
-		router, "download-rewards-file", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "download-rewards-file", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -51,6 +51,7 @@ func (c *networkDownloadRewardsContext) PrepareData(data *types.SuccessData, opt
 	sp := c.handler.serviceProvider
 	rp := sp.GetRocketPool()
 	cfg := sp.GetConfig()
+	res := sp.GetResources()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
 
 	// Requirements
@@ -60,7 +61,7 @@ func (c *networkDownloadRewardsContext) PrepareData(data *types.SuccessData, opt
 	}
 
 	// Get the event info for the interval
-	intervalInfo, err := rewards.GetIntervalInfo(rp, cfg, nodeAddress, c.interval, nil)
+	intervalInfo, err := rewards.GetIntervalInfo(rp, cfg, res, nodeAddress, c.interval, nil)
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error getting interval %d info: %w", c.interval, err)
 	}

--- a/rocketpool-daemon/api/network/generate-rewards.go
+++ b/rocketpool-daemon/api/network/generate-rewards.go
@@ -33,7 +33,7 @@ func (f *networkGenerateRewardsContextFactory) Create(args url.Values) (*network
 
 func (f *networkGenerateRewardsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkGenerateRewardsContext, types.SuccessData](
-		router, "generate-rewards-tree", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "generate-rewards-tree", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/generate-rewards.go
+++ b/rocketpool-daemon/api/network/generate-rewards.go
@@ -33,7 +33,7 @@ func (f *networkGenerateRewardsContextFactory) Create(args url.Values) (*network
 
 func (f *networkGenerateRewardsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*networkGenerateRewardsContext, types.SuccessData](
-		router, "generate-rewards-tree", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "generate-rewards-tree", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/handler.go
+++ b/rocketpool-daemon/api/network/handler.go
@@ -13,11 +13,11 @@ import (
 type NetworkHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewNetworkHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *NetworkHandler {
+func NewNetworkHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *NetworkHandler {
 	h := &NetworkHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/network/node-fee.go
+++ b/rocketpool-daemon/api/network/node-fee.go
@@ -34,7 +34,7 @@ func (f *networkFeeContextFactory) Create(args url.Values) (*networkFeeContext, 
 
 func (f *networkFeeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkFeeContext, api.NetworkNodeFeeData](
-		router, "node-fee", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "node-fee", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/node-fee.go
+++ b/rocketpool-daemon/api/network/node-fee.go
@@ -34,7 +34,7 @@ func (f *networkFeeContextFactory) Create(args url.Values) (*networkFeeContext, 
 
 func (f *networkFeeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkFeeContext, api.NetworkNodeFeeData](
-		router, "node-fee", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "node-fee", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/rewards-file-info.go
+++ b/rocketpool-daemon/api/network/rewards-file-info.go
@@ -38,7 +38,7 @@ func (f *networkRewardsFileContextFactory) Create(args url.Values) (*networkRewa
 
 func (f *networkRewardsFileContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkRewardsFileContext, api.NetworkRewardsFileData](
-		router, "rewards-file-info", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rewards-file-info", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/rewards-file-info.go
+++ b/rocketpool-daemon/api/network/rewards-file-info.go
@@ -38,7 +38,7 @@ func (f *networkRewardsFileContextFactory) Create(args url.Values) (*networkRewa
 
 func (f *networkRewardsFileContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkRewardsFileContext, api.NetworkRewardsFileData](
-		router, "rewards-file-info", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rewards-file-info", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/rpl-price.go
+++ b/rocketpool-daemon/api/network/rpl-price.go
@@ -35,7 +35,7 @@ func (f *networkPriceContextFactory) Create(args url.Values) (*networkPriceConte
 
 func (f *networkPriceContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkPriceContext, api.NetworkRplPriceData](
-		router, "rpl-price", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rpl-price", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/rpl-price.go
+++ b/rocketpool-daemon/api/network/rpl-price.go
@@ -35,7 +35,7 @@ func (f *networkPriceContextFactory) Create(args url.Values) (*networkPriceConte
 
 func (f *networkPriceContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkPriceContext, api.NetworkRplPriceData](
-		router, "rpl-price", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rpl-price", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/stats.go
+++ b/rocketpool-daemon/api/network/stats.go
@@ -40,7 +40,7 @@ func (f *networkStatsContextFactory) Create(args url.Values) (*networkStatsConte
 
 func (f *networkStatsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkStatsContext, api.NetworkStatsData](
-		router, "stats", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "stats", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/stats.go
+++ b/rocketpool-daemon/api/network/stats.go
@@ -40,7 +40,7 @@ func (f *networkStatsContextFactory) Create(args url.Values) (*networkStatsConte
 
 func (f *networkStatsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkStatsContext, api.NetworkStatsData](
-		router, "stats", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "stats", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/timezones.go
+++ b/rocketpool-daemon/api/network/timezones.go
@@ -33,7 +33,7 @@ func (f *networkTimezoneContextFactory) Create(args url.Values) (*networkTimezon
 
 func (f *networkTimezoneContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkTimezoneContext, api.NetworkTimezonesData](
-		router, "timezone-map", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "timezone-map", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/network/timezones.go
+++ b/rocketpool-daemon/api/network/timezones.go
@@ -33,7 +33,7 @@ func (f *networkTimezoneContextFactory) Create(args url.Values) (*networkTimezon
 
 func (f *networkTimezoneContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*networkTimezoneContext, api.NetworkTimezonesData](
-		router, "timezone-map", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "timezone-map", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/balance.go
+++ b/rocketpool-daemon/api/node/balance.go
@@ -28,7 +28,7 @@ func (f *nodeBalanceContextFactory) Create(args url.Values) (*nodeBalanceContext
 
 func (f *nodeBalanceContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeBalanceContext, api.NodeBalanceData](
-		router, "balance", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "balance", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/balance.go
+++ b/rocketpool-daemon/api/node/balance.go
@@ -28,7 +28,7 @@ func (f *nodeBalanceContextFactory) Create(args url.Values) (*nodeBalanceContext
 
 func (f *nodeBalanceContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeBalanceContext, api.NodeBalanceData](
-		router, "balance", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "balance", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/burn.go
+++ b/rocketpool-daemon/api/node/burn.go
@@ -40,7 +40,7 @@ func (f *nodeBurnContextFactory) Create(args url.Values) (*nodeBurnContext, erro
 
 func (f *nodeBurnContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeBurnContext, api.NodeBurnData](
-		router, "burn", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "burn", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/burn.go
+++ b/rocketpool-daemon/api/node/burn.go
@@ -40,7 +40,7 @@ func (f *nodeBurnContextFactory) Create(args url.Values) (*nodeBurnContext, erro
 
 func (f *nodeBurnContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeBurnContext, api.NodeBurnData](
-		router, "burn", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "burn", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/check-collateral.go
+++ b/rocketpool-daemon/api/node/check-collateral.go
@@ -30,7 +30,7 @@ func (f *nodeCheckCollateralContextFactory) Create(args url.Values) (*nodeCheckC
 
 func (f *nodeCheckCollateralContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeCheckCollateralContext, api.NodeCheckCollateralData](
-		router, "check-collateral", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "check-collateral", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/check-collateral.go
+++ b/rocketpool-daemon/api/node/check-collateral.go
@@ -30,7 +30,7 @@ func (f *nodeCheckCollateralContextFactory) Create(args url.Values) (*nodeCheckC
 
 func (f *nodeCheckCollateralContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeCheckCollateralContext, api.NodeCheckCollateralData](
-		router, "check-collateral", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "check-collateral", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/claim-and-stake.go
+++ b/rocketpool-daemon/api/node/claim-and-stake.go
@@ -43,7 +43,7 @@ func (f *nodeClaimAndStakeContextFactory) Create(args url.Values) (*nodeClaimAnd
 
 func (f *nodeClaimAndStakeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeClaimAndStakeContext, types.TxInfoData](
-		router, "claim-and-stake", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "claim-and-stake", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/claim-and-stake.go
+++ b/rocketpool-daemon/api/node/claim-and-stake.go
@@ -43,7 +43,7 @@ func (f *nodeClaimAndStakeContextFactory) Create(args url.Values) (*nodeClaimAnd
 
 func (f *nodeClaimAndStakeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeClaimAndStakeContext, types.TxInfoData](
-		router, "claim-and-stake", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "claim-and-stake", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -62,6 +62,7 @@ func (c *nodeClaimAndStakeContext) PrepareData(data *types.TxInfoData, opts *bin
 	sp := c.handler.serviceProvider
 	rp := sp.GetRocketPool()
 	cfg := sp.GetConfig()
+	res := sp.GetResources()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
 
 	// Requirements
@@ -83,7 +84,7 @@ func (c *nodeClaimAndStakeContext) PrepareData(data *types.TxInfoData, opts *bin
 
 	// Populate the interval info for each one
 	for _, index := range c.indices {
-		intervalInfo, err := rprewards.GetIntervalInfo(rp, cfg, nodeAddress, index.Uint64(), nil)
+		intervalInfo, err := rprewards.GetIntervalInfo(rp, cfg, res, nodeAddress, index.Uint64(), nil)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error getting interval info for interval %d: %w", index, err)
 		}

--- a/rocketpool-daemon/api/node/clear-snapshot-delegate.go
+++ b/rocketpool-daemon/api/node/clear-snapshot-delegate.go
@@ -28,7 +28,7 @@ func (f *nodeClearSnapshotDelegateContextFactory) Create(args url.Values) (*node
 
 func (f *nodeClearSnapshotDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeClearSnapshotDelegateContext, types.TxInfoData](
-		router, "snapshot-delegate/clear", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "snapshot-delegate/clear", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/clear-snapshot-delegate.go
+++ b/rocketpool-daemon/api/node/clear-snapshot-delegate.go
@@ -28,7 +28,7 @@ func (f *nodeClearSnapshotDelegateContextFactory) Create(args url.Values) (*node
 
 func (f *nodeClearSnapshotDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeClearSnapshotDelegateContext, types.TxInfoData](
-		router, "snapshot-delegate/clear", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "snapshot-delegate/clear", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/confirm-primary-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/confirm-primary-withdrawal-address.go
@@ -32,7 +32,7 @@ func (f *nodeConfirmPrimaryWithdrawalAddressContextFactory) Create(args url.Valu
 
 func (f *nodeConfirmPrimaryWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeConfirmPrimaryWithdrawalAddressContext, api.NodeConfirmPrimaryWithdrawalAddressData](
-		router, "primary-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "primary-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/confirm-primary-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/confirm-primary-withdrawal-address.go
@@ -32,7 +32,7 @@ func (f *nodeConfirmPrimaryWithdrawalAddressContextFactory) Create(args url.Valu
 
 func (f *nodeConfirmPrimaryWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeConfirmPrimaryWithdrawalAddressContext, api.NodeConfirmPrimaryWithdrawalAddressData](
-		router, "primary-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "primary-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/confirm-rpl-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/confirm-rpl-withdrawal-address.go
@@ -32,7 +32,7 @@ func (f *nodeConfirmRplWithdrawalAddressContextFactory) Create(args url.Values) 
 
 func (f *nodeConfirmRplWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeConfirmRplWithdrawalAddressContext, api.NodeConfirmRplWithdrawalAddressData](
-		router, "rpl-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rpl-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/confirm-rpl-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/confirm-rpl-withdrawal-address.go
@@ -32,7 +32,7 @@ func (f *nodeConfirmRplWithdrawalAddressContextFactory) Create(args url.Values) 
 
 func (f *nodeConfirmRplWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeConfirmRplWithdrawalAddressContext, api.NodeConfirmRplWithdrawalAddressData](
-		router, "rpl-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rpl-withdrawal-address/confirm", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/create-vacant-minipool.go
+++ b/rocketpool-daemon/api/node/create-vacant-minipool.go
@@ -49,7 +49,7 @@ func (f *nodeCreateVacantMinipoolContextFactory) Create(args url.Values) (*nodeC
 
 func (f *nodeCreateVacantMinipoolContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeCreateVacantMinipoolContext, api.NodeCreateVacantMinipoolData](
-		router, "create-vacant-minipool", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "create-vacant-minipool", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/create-vacant-minipool.go
+++ b/rocketpool-daemon/api/node/create-vacant-minipool.go
@@ -49,7 +49,7 @@ func (f *nodeCreateVacantMinipoolContextFactory) Create(args url.Values) (*nodeC
 
 func (f *nodeCreateVacantMinipoolContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeCreateVacantMinipoolContext, api.NodeCreateVacantMinipoolData](
-		router, "create-vacant-minipool", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "create-vacant-minipool", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -60,6 +60,7 @@ func (f *nodeCreateVacantMinipoolContextFactory) RegisterRoute(router *mux.Route
 type nodeCreateVacantMinipoolContext struct {
 	handler *NodeHandler
 	cfg     *config.SmartNodeConfig
+	res     *config.RocketPoolResources
 	rp      *rocketpool.RocketPool
 	bc      beacon.IBeaconClient
 
@@ -76,6 +77,7 @@ type nodeCreateVacantMinipoolContext struct {
 func (c *nodeCreateVacantMinipoolContext) Initialize() (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.rp = sp.GetRocketPool()
 	c.bc = sp.GetBeaconClient()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
@@ -162,7 +164,7 @@ func (c *nodeCreateVacantMinipoolContext) PrepareData(data *api.NodeCreateVacant
 		return types.ResponseStatus_Success, nil
 	}
 	// Make sure the BN is on the correct chain
-	depositContractInfo, err := rputils.GetDepositContractInfo(ctx, c.rp, c.cfg, c.bc)
+	depositContractInfo, err := rputils.GetDepositContractInfo(ctx, c.rp, c.cfg, c.res, c.bc)
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error verifying the EL and BC are on the same chain: %w", err)
 	}

--- a/rocketpool-daemon/api/node/create-vacant-minipool.go
+++ b/rocketpool-daemon/api/node/create-vacant-minipool.go
@@ -60,7 +60,7 @@ func (f *nodeCreateVacantMinipoolContextFactory) RegisterRoute(router *mux.Route
 type nodeCreateVacantMinipoolContext struct {
 	handler *NodeHandler
 	cfg     *config.SmartNodeConfig
-	res     *config.RocketPoolResources
+	res     *config.MergedResources
 	rp      *rocketpool.RocketPool
 	bc      beacon.IBeaconClient
 

--- a/rocketpool-daemon/api/node/deposit.go
+++ b/rocketpool-daemon/api/node/deposit.go
@@ -53,7 +53,7 @@ func (f *nodeDepositContextFactory) Create(args url.Values) (*nodeDepositContext
 
 func (f *nodeDepositContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeDepositContext, api.NodeDepositData](
-		router, "deposit", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "deposit", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/deposit.go
+++ b/rocketpool-daemon/api/node/deposit.go
@@ -64,7 +64,7 @@ func (f *nodeDepositContextFactory) RegisterRoute(router *mux.Router) {
 type nodeDepositContext struct {
 	handler *NodeHandler
 	cfg     *config.SmartNodeConfig
-	res     *config.RocketPoolResources
+	res     *config.MergedResources
 	rp      *rocketpool.RocketPool
 	bc      beacon.IBeaconClient
 	w       *nodewallet.Wallet

--- a/rocketpool-daemon/api/node/distribute.go
+++ b/rocketpool-daemon/api/node/distribute.go
@@ -35,7 +35,7 @@ func (f *nodeDistributeContextFactory) Create(args url.Values) (*nodeDistributeC
 
 func (f *nodeDistributeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeDistributeContext, api.NodeDistributeData](
-		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/distribute.go
+++ b/rocketpool-daemon/api/node/distribute.go
@@ -35,7 +35,7 @@ func (f *nodeDistributeContextFactory) Create(args url.Values) (*nodeDistributeC
 
 func (f *nodeDistributeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeDistributeContext, api.NodeDistributeData](
-		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "distribute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/get-rewards-info.go
+++ b/rocketpool-daemon/api/node/get-rewards-info.go
@@ -50,7 +50,7 @@ func (f *nodeGetRewardsInfoContextFactory) RegisterRoute(router *mux.Router) {
 type nodeGetRewardsInfoContext struct {
 	handler *NodeHandler
 	cfg     *config.SmartNodeConfig
-	res     *config.RocketPoolResources
+	res     *config.MergedResources
 	rp      *rocketpool.RocketPool
 
 	node        *node.Node

--- a/rocketpool-daemon/api/node/get-rewards-info.go
+++ b/rocketpool-daemon/api/node/get-rewards-info.go
@@ -39,7 +39,7 @@ func (f *nodeGetRewardsInfoContextFactory) Create(args url.Values) (*nodeGetRewa
 
 func (f *nodeGetRewardsInfoContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeGetRewardsInfoContext, api.NodeGetRewardsInfoData](
-		router, "get-rewards-info", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "get-rewards-info", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -50,6 +50,7 @@ func (f *nodeGetRewardsInfoContextFactory) RegisterRoute(router *mux.Router) {
 type nodeGetRewardsInfoContext struct {
 	handler *NodeHandler
 	cfg     *config.SmartNodeConfig
+	res     *config.RocketPoolResources
 	rp      *rocketpool.RocketPool
 
 	node        *node.Node
@@ -61,6 +62,7 @@ type nodeGetRewardsInfoContext struct {
 func (c *nodeGetRewardsInfoContext) Initialize() (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.rp = sp.GetRocketPool()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
 
@@ -119,7 +121,7 @@ func (c *nodeGetRewardsInfoContext) PrepareData(data *api.NodeGetRewardsInfoData
 
 	// Get the info for each unclaimed interval
 	for _, unclaimedInterval := range claimStatus.Unclaimed {
-		intervalInfo, err := rprewards.GetIntervalInfo(c.rp, c.cfg, c.node.Address, unclaimedInterval, nil)
+		intervalInfo, err := rprewards.GetIntervalInfo(c.rp, c.cfg, c.res, c.node.Address, unclaimedInterval, nil)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error getting interval %d info: %w", unclaimedInterval, err)
 		}

--- a/rocketpool-daemon/api/node/get-rewards-info.go
+++ b/rocketpool-daemon/api/node/get-rewards-info.go
@@ -39,7 +39,7 @@ func (f *nodeGetRewardsInfoContextFactory) Create(args url.Values) (*nodeGetRewa
 
 func (f *nodeGetRewardsInfoContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeGetRewardsInfoContext, api.NodeGetRewardsInfoData](
-		router, "get-rewards-info", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "get-rewards-info", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/get-snapshot-proposals.go
+++ b/rocketpool-daemon/api/node/get-snapshot-proposals.go
@@ -37,7 +37,7 @@ func (f *nodeGetSnapshotProposalsContextFactory) Create(args url.Values) (*nodeG
 
 func (f *nodeGetSnapshotProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeGetSnapshotProposalsContext, api.NodeGetSnapshotProposalsData](
-		router, "get-snapshot-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "get-snapshot-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -54,6 +54,7 @@ type nodeGetSnapshotProposalsContext struct {
 func (c *nodeGetSnapshotProposalsContext) PrepareData(data *api.NodeGetSnapshotProposalsData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
 	cfg := sp.GetConfig()
+	res := sp.GetResources()
 	rp := sp.GetRocketPool()
 	snapshot := sp.GetSnapshotDelegation()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
@@ -77,6 +78,6 @@ func (c *nodeGetSnapshotProposalsContext) PrepareData(data *api.NodeGetSnapshotP
 		return types.ResponseStatus_Error, fmt.Errorf("error getting snapshot delegate: %w", err)
 	}
 
-	data.Proposals, err = voting.GetSnapshotProposals(cfg, nodeAddress, delegate, c.activeOnly)
+	data.Proposals, err = voting.GetSnapshotProposals(cfg, res, nodeAddress, delegate, c.activeOnly)
 	return types.ResponseStatus_Success, err
 }

--- a/rocketpool-daemon/api/node/get-snapshot-proposals.go
+++ b/rocketpool-daemon/api/node/get-snapshot-proposals.go
@@ -37,7 +37,7 @@ func (f *nodeGetSnapshotProposalsContextFactory) Create(args url.Values) (*nodeG
 
 func (f *nodeGetSnapshotProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeGetSnapshotProposalsContext, api.NodeGetSnapshotProposalsData](
-		router, "get-snapshot-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "get-snapshot-proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/get-snapshot-voting-power.go
+++ b/rocketpool-daemon/api/node/get-snapshot-voting-power.go
@@ -29,7 +29,7 @@ func (f *nodeGetSnapshotVotingPowerContextFactory) Create(args url.Values) (*nod
 
 func (f *nodeGetSnapshotVotingPowerContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeGetSnapshotVotingPowerContext, api.NodeGetSnapshotVotingPowerData](
-		router, "get-snapshot-voting-power", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "get-snapshot-voting-power", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/get-snapshot-voting-power.go
+++ b/rocketpool-daemon/api/node/get-snapshot-voting-power.go
@@ -29,7 +29,7 @@ func (f *nodeGetSnapshotVotingPowerContextFactory) Create(args url.Values) (*nod
 
 func (f *nodeGetSnapshotVotingPowerContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeGetSnapshotVotingPowerContext, api.NodeGetSnapshotVotingPowerData](
-		router, "get-snapshot-voting-power", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "get-snapshot-voting-power", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -44,6 +44,7 @@ type nodeGetSnapshotVotingPowerContext struct {
 func (c *nodeGetSnapshotVotingPowerContext) PrepareData(data *api.NodeGetSnapshotVotingPowerData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
 	cfg := sp.GetConfig()
+	res := sp.GetResources()
 	nodeAddress, _ := sp.GetWallet().GetAddress()
 
 	// Requirements
@@ -56,7 +57,7 @@ func (c *nodeGetSnapshotVotingPowerContext) PrepareData(data *api.NodeGetSnapsho
 		return types.ResponseStatus_InvalidChainState, err
 	}
 
-	data.VotingPower, err = voting.GetSnapshotVotingPower(cfg, nodeAddress)
+	data.VotingPower, err = voting.GetSnapshotVotingPower(cfg, res, nodeAddress)
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}

--- a/rocketpool-daemon/api/node/handler.go
+++ b/rocketpool-daemon/api/node/handler.go
@@ -13,11 +13,11 @@ import (
 type NodeHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewNodeHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *NodeHandler {
+func NewNodeHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *NodeHandler {
 	h := &NodeHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/node/initialize-fee-distributor.go
+++ b/rocketpool-daemon/api/node/initialize-fee-distributor.go
@@ -33,7 +33,7 @@ func (f *nodeInitializeFeeDistributorContextFactory) Create(args url.Values) (*n
 
 func (f *nodeInitializeFeeDistributorContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeInitializeFeeDistributorContext, api.NodeInitializeFeeDistributorData](
-		router, "initialize-fee-distributor", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "initialize-fee-distributor", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/initialize-fee-distributor.go
+++ b/rocketpool-daemon/api/node/initialize-fee-distributor.go
@@ -33,7 +33,7 @@ func (f *nodeInitializeFeeDistributorContextFactory) Create(args url.Values) (*n
 
 func (f *nodeInitializeFeeDistributorContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeInitializeFeeDistributorContext, api.NodeInitializeFeeDistributorData](
-		router, "initialize-fee-distributor", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "initialize-fee-distributor", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/register.go
+++ b/rocketpool-daemon/api/node/register.go
@@ -39,7 +39,7 @@ func (f *nodeRegisterContextFactory) Create(args url.Values) (*nodeRegisterConte
 
 func (f *nodeRegisterContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeRegisterContext, api.NodeRegisterData](
-		router, "register", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "register", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/register.go
+++ b/rocketpool-daemon/api/node/register.go
@@ -39,7 +39,7 @@ func (f *nodeRegisterContextFactory) Create(args url.Values) (*nodeRegisterConte
 
 func (f *nodeRegisterContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeRegisterContext, api.NodeRegisterData](
-		router, "register", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "register", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/resolve-ens.go
+++ b/rocketpool-daemon/api/node/resolve-ens.go
@@ -37,7 +37,7 @@ func (f *nodeResolveEnsContextFactory) Create(args url.Values) (*nodeResolveEnsC
 
 func (f *nodeResolveEnsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeResolveEnsContext, api.NodeResolveEnsData](
-		router, "resolve-ens", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "resolve-ens", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/resolve-ens.go
+++ b/rocketpool-daemon/api/node/resolve-ens.go
@@ -37,7 +37,7 @@ func (f *nodeResolveEnsContextFactory) Create(args url.Values) (*nodeResolveEnsC
 
 func (f *nodeResolveEnsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeResolveEnsContext, api.NodeResolveEnsData](
-		router, "resolve-ens", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "resolve-ens", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/rewards.go
+++ b/rocketpool-daemon/api/node/rewards.go
@@ -44,7 +44,7 @@ func (f *nodeRewardsContextFactory) Create(args url.Values) (*nodeRewardsContext
 
 func (f *nodeRewardsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeRewardsContext, api.NodeRewardsData](
-		router, "rewards", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rewards", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/send.go
+++ b/rocketpool-daemon/api/node/send.go
@@ -43,7 +43,7 @@ func (f *nodeSendContextFactory) Create(args url.Values) (*nodeSendContext, erro
 
 func (f *nodeSendContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSendContext, api.NodeSendData](
-		router, "send", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "send", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/send.go
+++ b/rocketpool-daemon/api/node/send.go
@@ -43,7 +43,7 @@ func (f *nodeSendContextFactory) Create(args url.Values) (*nodeSendContext, erro
 
 func (f *nodeSendContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSendContext, api.NodeSendData](
-		router, "send", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "send", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-primary-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/set-primary-withdrawal-address.go
@@ -39,7 +39,7 @@ func (f *nodeSetPrimaryWithdrawalAddressContextFactory) Create(args url.Values) 
 
 func (f *nodeSetPrimaryWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetPrimaryWithdrawalAddressContext, api.NodeSetPrimaryWithdrawalAddressData](
-		router, "primary-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "primary-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-primary-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/set-primary-withdrawal-address.go
@@ -39,7 +39,7 @@ func (f *nodeSetPrimaryWithdrawalAddressContextFactory) Create(args url.Values) 
 
 func (f *nodeSetPrimaryWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetPrimaryWithdrawalAddressContext, api.NodeSetPrimaryWithdrawalAddressData](
-		router, "primary-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "primary-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-rpl-locking-allowed.go
+++ b/rocketpool-daemon/api/node/set-rpl-locking-allowed.go
@@ -38,7 +38,7 @@ func (f *nodeSetRplLockingAllowedContextFactory) Create(args url.Values) (*nodeS
 
 func (f *nodeSetRplLockingAllowedContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetRplLockingAllowedContext, api.NodeSetRplLockingAllowedData](
-		router, "set-rpl-locking-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "set-rpl-locking-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-rpl-locking-allowed.go
+++ b/rocketpool-daemon/api/node/set-rpl-locking-allowed.go
@@ -38,7 +38,7 @@ func (f *nodeSetRplLockingAllowedContextFactory) Create(args url.Values) (*nodeS
 
 func (f *nodeSetRplLockingAllowedContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetRplLockingAllowedContext, api.NodeSetRplLockingAllowedData](
-		router, "set-rpl-locking-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "set-rpl-locking-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-rpl-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/set-rpl-withdrawal-address.go
@@ -40,7 +40,7 @@ func (f *nodeSetRplWithdrawalAddressContextFactory) Create(args url.Values) (*no
 
 func (f *nodeSetRplWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetRplWithdrawalAddressContext, api.NodeSetRplWithdrawalAddressData](
-		router, "rpl-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rpl-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-rpl-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/set-rpl-withdrawal-address.go
@@ -40,7 +40,7 @@ func (f *nodeSetRplWithdrawalAddressContextFactory) Create(args url.Values) (*no
 
 func (f *nodeSetRplWithdrawalAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetRplWithdrawalAddressContext, api.NodeSetRplWithdrawalAddressData](
-		router, "rpl-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rpl-withdrawal-address/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-snapshot-delegate.go
+++ b/rocketpool-daemon/api/node/set-snapshot-delegate.go
@@ -34,7 +34,7 @@ func (f *nodeSetSnapshotDelegateContextFactory) Create(args url.Values) (*nodeSe
 
 func (f *nodeSetSnapshotDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSetSnapshotDelegateContext, types.TxInfoData](
-		router, "snapshot-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "snapshot-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-snapshot-delegate.go
+++ b/rocketpool-daemon/api/node/set-snapshot-delegate.go
@@ -34,7 +34,7 @@ func (f *nodeSetSnapshotDelegateContextFactory) Create(args url.Values) (*nodeSe
 
 func (f *nodeSetSnapshotDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSetSnapshotDelegateContext, types.TxInfoData](
-		router, "snapshot-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "snapshot-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-sp-registration-status.go
+++ b/rocketpool-daemon/api/node/set-sp-registration-status.go
@@ -39,7 +39,7 @@ func (f *nodeSetSmoothingPoolRegistrationStatusContextFactory) Create(args url.V
 
 func (f *nodeSetSmoothingPoolRegistrationStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetSmoothingPoolRegistrationStatusContext, api.NodeSetSmoothingPoolRegistrationStatusData](
-		router, "set-smoothing-pool-registration-state", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "set-smoothing-pool-registration-state", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-sp-registration-status.go
+++ b/rocketpool-daemon/api/node/set-sp-registration-status.go
@@ -39,7 +39,7 @@ func (f *nodeSetSmoothingPoolRegistrationStatusContextFactory) Create(args url.V
 
 func (f *nodeSetSmoothingPoolRegistrationStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSetSmoothingPoolRegistrationStatusContext, api.NodeSetSmoothingPoolRegistrationStatusData](
-		router, "set-smoothing-pool-registration-state", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "set-smoothing-pool-registration-state", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-stake-rpl-for-allowed.go
+++ b/rocketpool-daemon/api/node/set-stake-rpl-for-allowed.go
@@ -37,7 +37,7 @@ func (f *nodeSetStakeRplForAllowedContextFactory) Create(args url.Values) (*node
 
 func (f *nodeSetStakeRplForAllowedContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSetStakeRplForAllowedContext, api.NodeSetStakeRplForAllowedData](
-		router, "set-stake-rpl-for-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "set-stake-rpl-for-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-stake-rpl-for-allowed.go
+++ b/rocketpool-daemon/api/node/set-stake-rpl-for-allowed.go
@@ -37,7 +37,7 @@ func (f *nodeSetStakeRplForAllowedContextFactory) Create(args url.Values) (*node
 
 func (f *nodeSetStakeRplForAllowedContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSetStakeRplForAllowedContext, api.NodeSetStakeRplForAllowedData](
-		router, "set-stake-rpl-for-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "set-stake-rpl-for-allowed", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-timezone.go
+++ b/rocketpool-daemon/api/node/set-timezone.go
@@ -35,7 +35,7 @@ func (f *nodeSetTimezoneContextFactory) Create(args url.Values) (*nodeSetTimezon
 
 func (f *nodeSetTimezoneContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSetTimezoneContext, types.TxInfoData](
-		router, "set-timezone", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "set-timezone", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/set-timezone.go
+++ b/rocketpool-daemon/api/node/set-timezone.go
@@ -35,7 +35,7 @@ func (f *nodeSetTimezoneContextFactory) Create(args url.Values) (*nodeSetTimezon
 
 func (f *nodeSetTimezoneContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*nodeSetTimezoneContext, types.TxInfoData](
-		router, "set-timezone", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "set-timezone", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/stake-rpl.go
+++ b/rocketpool-daemon/api/node/stake-rpl.go
@@ -41,7 +41,7 @@ func (f *nodeStakeRplContextFactory) Create(args url.Values) (*nodeStakeRplConte
 
 func (f *nodeStakeRplContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeStakeRplContext, api.NodeStakeRplData](
-		router, "stake-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "stake-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/stake-rpl.go
+++ b/rocketpool-daemon/api/node/stake-rpl.go
@@ -41,7 +41,7 @@ func (f *nodeStakeRplContextFactory) Create(args url.Values) (*nodeStakeRplConte
 
 func (f *nodeStakeRplContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeStakeRplContext, api.NodeStakeRplData](
-		router, "stake-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "stake-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/status.go
+++ b/rocketpool-daemon/api/node/status.go
@@ -66,7 +66,7 @@ func (f *nodeStatusContextFactory) RegisterRoute(router *mux.Router) {
 type nodeStatusContext struct {
 	handler  *NodeHandler
 	cfg      *config.SmartNodeConfig
-	res      *config.RocketPoolResources
+	res      *config.MergedResources
 	rp       *rocketpool.RocketPool
 	ec       eth.IExecutionClient
 	bc       beacon.IBeaconClient

--- a/rocketpool-daemon/api/node/status.go
+++ b/rocketpool-daemon/api/node/status.go
@@ -55,7 +55,7 @@ func (f *nodeStatusContextFactory) Create(args url.Values) (*nodeStatusContext, 
 
 func (f *nodeStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeStatusContext, api.NodeStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/swap-rpl.go
+++ b/rocketpool-daemon/api/node/swap-rpl.go
@@ -40,7 +40,7 @@ func (f *nodeSwapRplContextFactory) Create(args url.Values) (*nodeSwapRplContext
 
 func (f *nodeSwapRplContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSwapRplContext, api.NodeSwapRplData](
-		router, "swap-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "swap-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/swap-rpl.go
+++ b/rocketpool-daemon/api/node/swap-rpl.go
@@ -40,7 +40,7 @@ func (f *nodeSwapRplContextFactory) Create(args url.Values) (*nodeSwapRplContext
 
 func (f *nodeSwapRplContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeSwapRplContext, api.NodeSwapRplData](
-		router, "swap-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "swap-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/withdraw-eth.go
+++ b/rocketpool-daemon/api/node/withdraw-eth.go
@@ -40,7 +40,7 @@ func (f *nodeWithdrawEthContextFactory) Create(args url.Values) (*nodeWithdrawEt
 
 func (f *nodeWithdrawEthContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeWithdrawEthContext, api.NodeWithdrawEthData](
-		router, "withdraw-eth", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "withdraw-eth", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/withdraw-eth.go
+++ b/rocketpool-daemon/api/node/withdraw-eth.go
@@ -40,7 +40,7 @@ func (f *nodeWithdrawEthContextFactory) Create(args url.Values) (*nodeWithdrawEt
 
 func (f *nodeWithdrawEthContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeWithdrawEthContext, api.NodeWithdrawEthData](
-		router, "withdraw-eth", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "withdraw-eth", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/withdraw-rpl.go
+++ b/rocketpool-daemon/api/node/withdraw-rpl.go
@@ -42,7 +42,7 @@ func (f *nodeWithdrawRplContextFactory) Create(args url.Values) (*nodeWithdrawRp
 
 func (f *nodeWithdrawRplContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeWithdrawRplContext, api.NodeWithdrawRplData](
-		router, "withdraw-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "withdraw-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/node/withdraw-rpl.go
+++ b/rocketpool-daemon/api/node/withdraw-rpl.go
@@ -42,7 +42,7 @@ func (f *nodeWithdrawRplContextFactory) Create(args url.Values) (*nodeWithdrawRp
 
 func (f *nodeWithdrawRplContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*nodeWithdrawRplContext, api.NodeWithdrawRplData](
-		router, "withdraw-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "withdraw-rpl", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/cancel-proposal.go
+++ b/rocketpool-daemon/api/odao/cancel-proposal.go
@@ -40,7 +40,7 @@ func (f *oracleDaoCancelProposalContextFactory) Create(args url.Values) (*oracle
 
 func (f *oracleDaoCancelProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoCancelProposalContext, api.OracleDaoCancelProposalData](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/cancel-proposal.go
+++ b/rocketpool-daemon/api/odao/cancel-proposal.go
@@ -40,7 +40,7 @@ func (f *oracleDaoCancelProposalContextFactory) Create(args url.Values) (*oracle
 
 func (f *oracleDaoCancelProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoCancelProposalContext, api.OracleDaoCancelProposalData](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/execute-proposals.go
+++ b/rocketpool-daemon/api/odao/execute-proposals.go
@@ -44,7 +44,7 @@ func (f *oracleDaoExecuteProposalsContextFactory) Create(args url.Values) (*orac
 
 func (f *oracleDaoExecuteProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoExecuteProposalsContext, types.DataBatch[api.OracleDaoExecuteProposalData]](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/execute-proposals.go
+++ b/rocketpool-daemon/api/odao/execute-proposals.go
@@ -44,7 +44,7 @@ func (f *oracleDaoExecuteProposalsContextFactory) Create(args url.Values) (*orac
 
 func (f *oracleDaoExecuteProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoExecuteProposalsContext, types.DataBatch[api.OracleDaoExecuteProposalData]](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/handler.go
+++ b/rocketpool-daemon/api/odao/handler.go
@@ -13,11 +13,11 @@ import (
 type OracleDaoHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewOracleDaoHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *OracleDaoHandler {
+func NewOracleDaoHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *OracleDaoHandler {
 	h := &OracleDaoHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/odao/join.go
+++ b/rocketpool-daemon/api/odao/join.go
@@ -38,7 +38,7 @@ func (f *oracleDaoJoinContextFactory) Create(args url.Values) (*oracleDaoJoinCon
 
 func (f *oracleDaoJoinContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoJoinContext, api.OracleDaoJoinData](
-		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/join.go
+++ b/rocketpool-daemon/api/odao/join.go
@@ -38,7 +38,7 @@ func (f *oracleDaoJoinContextFactory) Create(args url.Values) (*oracleDaoJoinCon
 
 func (f *oracleDaoJoinContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoJoinContext, api.OracleDaoJoinData](
-		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/leave.go
+++ b/rocketpool-daemon/api/odao/leave.go
@@ -40,7 +40,7 @@ func (f *oracleDaoLeaveContextFactory) Create(args url.Values) (*oracleDaoLeaveC
 
 func (f *oracleDaoLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoLeaveContext, api.OracleDaoLeaveData](
-		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/leave.go
+++ b/rocketpool-daemon/api/odao/leave.go
@@ -40,7 +40,7 @@ func (f *oracleDaoLeaveContextFactory) Create(args url.Values) (*oracleDaoLeaveC
 
 func (f *oracleDaoLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoLeaveContext, api.OracleDaoLeaveData](
-		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/members.go
+++ b/rocketpool-daemon/api/odao/members.go
@@ -32,7 +32,7 @@ func (f *oracleDaoMembersContextFactory) Create(args url.Values) (*oracleDaoMemb
 
 func (f *oracleDaoMembersContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoMembersContext, api.OracleDaoMembersData](
-		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/members.go
+++ b/rocketpool-daemon/api/odao/members.go
@@ -32,7 +32,7 @@ func (f *oracleDaoMembersContextFactory) Create(args url.Values) (*oracleDaoMemb
 
 func (f *oracleDaoMembersContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoMembersContext, api.OracleDaoMembersData](
-		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/proposals.go
+++ b/rocketpool-daemon/api/odao/proposals.go
@@ -38,7 +38,7 @@ func (f *oracleDaoProposalsContextFactory) Create(args url.Values) (*oracleDaoPr
 
 func (f *oracleDaoProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposalsContext, api.OracleDaoProposalsData](
-		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/proposals.go
+++ b/rocketpool-daemon/api/odao/proposals.go
@@ -38,7 +38,7 @@ func (f *oracleDaoProposalsContextFactory) Create(args url.Values) (*oracleDaoPr
 
 func (f *oracleDaoProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposalsContext, api.OracleDaoProposalsData](
-		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-invite.go
+++ b/rocketpool-daemon/api/odao/propose-invite.go
@@ -43,7 +43,7 @@ func (f *oracleDaoProposeInviteContextFactory) Create(args url.Values) (*oracleD
 
 func (f *oracleDaoProposeInviteContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeInviteContext, api.OracleDaoProposeInviteData](
-		router, "propose-invite", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "propose-invite", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-invite.go
+++ b/rocketpool-daemon/api/odao/propose-invite.go
@@ -43,7 +43,7 @@ func (f *oracleDaoProposeInviteContextFactory) Create(args url.Values) (*oracleD
 
 func (f *oracleDaoProposeInviteContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeInviteContext, api.OracleDaoProposeInviteData](
-		router, "propose-invite", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "propose-invite", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-kick.go
+++ b/rocketpool-daemon/api/odao/propose-kick.go
@@ -43,7 +43,7 @@ func (f *oracleDaoProposeKickContextFactory) Create(args url.Values) (*oracleDao
 
 func (f *oracleDaoProposeKickContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeKickContext, api.OracleDaoProposeKickData](
-		router, "propose-kick", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "propose-kick", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-kick.go
+++ b/rocketpool-daemon/api/odao/propose-kick.go
@@ -43,7 +43,7 @@ func (f *oracleDaoProposeKickContextFactory) Create(args url.Values) (*oracleDao
 
 func (f *oracleDaoProposeKickContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeKickContext, api.OracleDaoProposeKickData](
-		router, "propose-kick", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "propose-kick", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-leave.go
+++ b/rocketpool-daemon/api/odao/propose-leave.go
@@ -35,7 +35,7 @@ func (f *oracleDaoProposeLeaveContextFactory) Create(args url.Values) (*oracleDa
 
 func (f *oracleDaoProposeLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeLeaveContext, api.OracleDaoProposeLeaveData](
-		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-leave.go
+++ b/rocketpool-daemon/api/odao/propose-leave.go
@@ -35,7 +35,7 @@ func (f *oracleDaoProposeLeaveContextFactory) Create(args url.Values) (*oracleDa
 
 func (f *oracleDaoProposeLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeLeaveContext, api.OracleDaoProposeLeaveData](
-		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-settings.go
+++ b/rocketpool-daemon/api/odao/propose-settings.go
@@ -42,7 +42,7 @@ func (f *oracleDaoProposeSettingContextFactory) Create(args url.Values) (*oracle
 
 func (f *oracleDaoProposeSettingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeSettingContext, api.OracleDaoProposeSettingData](
-		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/propose-settings.go
+++ b/rocketpool-daemon/api/odao/propose-settings.go
@@ -42,7 +42,7 @@ func (f *oracleDaoProposeSettingContextFactory) Create(args url.Values) (*oracle
 
 func (f *oracleDaoProposeSettingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoProposeSettingContext, api.OracleDaoProposeSettingData](
-		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/settings.go
+++ b/rocketpool-daemon/api/odao/settings.go
@@ -34,7 +34,7 @@ func (f *oracleDaoSettingsContextFactory) Create(args url.Values) (*oracleDaoSet
 
 func (f *oracleDaoSettingsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoSettingsContext, api.OracleDaoSettingsData](
-		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/settings.go
+++ b/rocketpool-daemon/api/odao/settings.go
@@ -34,7 +34,7 @@ func (f *oracleDaoSettingsContextFactory) Create(args url.Values) (*oracleDaoSet
 
 func (f *oracleDaoSettingsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoSettingsContext, api.OracleDaoSettingsData](
-		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/status.go
+++ b/rocketpool-daemon/api/odao/status.go
@@ -37,7 +37,7 @@ func (f *oracleDaoStatusContextFactory) Create(args url.Values) (*oracleDaoStatu
 
 func (f *oracleDaoStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoStatusContext, api.OracleDaoStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/status.go
+++ b/rocketpool-daemon/api/odao/status.go
@@ -37,7 +37,7 @@ func (f *oracleDaoStatusContextFactory) Create(args url.Values) (*oracleDaoStatu
 
 func (f *oracleDaoStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoStatusContext, api.OracleDaoStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/vote.go
+++ b/rocketpool-daemon/api/odao/vote.go
@@ -42,7 +42,7 @@ func (f *oracleDaoVoteContextFactory) Create(args url.Values) (*oracleDaoVoteCon
 
 func (f *oracleDaoVoteContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoVoteContext, api.OracleDaoVoteOnProposalData](
-		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/odao/vote.go
+++ b/rocketpool-daemon/api/odao/vote.go
@@ -42,7 +42,7 @@ func (f *oracleDaoVoteContextFactory) Create(args url.Values) (*oracleDaoVoteCon
 
 func (f *oracleDaoVoteContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*oracleDaoVoteContext, api.OracleDaoVoteOnProposalData](
-		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/claim-bonds.go
+++ b/rocketpool-daemon/api/pdao/claim-bonds.go
@@ -44,7 +44,7 @@ func (f *protocolDaoClaimBondsContextFactory) Create(body api.ProtocolDaoClaimBo
 
 func (f *protocolDaoClaimBondsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStagePost[*protocolDaoClaimBondsContext, api.ProtocolDaoClaimBondsBody, types.DataBatch[api.ProtocolDaoClaimBondsData]](
-		router, "claim-bonds", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "claim-bonds", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/claim-bonds.go
+++ b/rocketpool-daemon/api/pdao/claim-bonds.go
@@ -44,7 +44,7 @@ func (f *protocolDaoClaimBondsContextFactory) Create(body api.ProtocolDaoClaimBo
 
 func (f *protocolDaoClaimBondsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStagePost[*protocolDaoClaimBondsContext, api.ProtocolDaoClaimBondsBody, types.DataBatch[api.ProtocolDaoClaimBondsData]](
-		router, "claim-bonds", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "claim-bonds", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/current-voting-delegate.go
+++ b/rocketpool-daemon/api/pdao/current-voting-delegate.go
@@ -33,7 +33,7 @@ func (f *protocolDaoCurrentVotingDelegateContextFactory) Create(args url.Values)
 
 func (f *protocolDaoCurrentVotingDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoCurrentVotingDelegateContext, api.ProtocolDaoCurrentVotingDelegateData](
-		router, "voting-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "voting-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/current-voting-delegate.go
+++ b/rocketpool-daemon/api/pdao/current-voting-delegate.go
@@ -33,7 +33,7 @@ func (f *protocolDaoCurrentVotingDelegateContextFactory) Create(args url.Values)
 
 func (f *protocolDaoCurrentVotingDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoCurrentVotingDelegateContext, api.ProtocolDaoCurrentVotingDelegateData](
-		router, "voting-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "voting-delegate", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/defeat-proposal.go
+++ b/rocketpool-daemon/api/pdao/defeat-proposal.go
@@ -42,7 +42,7 @@ func (f *protocolDaoDefeatProposalContextFactory) Create(args url.Values) (*prot
 
 func (f *protocolDaoDefeatProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoDefeatProposalContext, api.ProtocolDaoDefeatProposalData](
-		router, "proposal/defeat", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/defeat", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/defeat-proposal.go
+++ b/rocketpool-daemon/api/pdao/defeat-proposal.go
@@ -42,7 +42,7 @@ func (f *protocolDaoDefeatProposalContextFactory) Create(args url.Values) (*prot
 
 func (f *protocolDaoDefeatProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoDefeatProposalContext, api.ProtocolDaoDefeatProposalData](
-		router, "proposal/defeat", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/defeat", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/execute-proposals.go
+++ b/rocketpool-daemon/api/pdao/execute-proposals.go
@@ -44,7 +44,7 @@ func (f *protocolDaoExecuteProposalsContextFactory) Create(args url.Values) (*pr
 
 func (f *protocolDaoExecuteProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoExecuteProposalsContext, types.DataBatch[api.ProtocolDaoExecuteProposalData]](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/execute-proposals.go
+++ b/rocketpool-daemon/api/pdao/execute-proposals.go
@@ -44,7 +44,7 @@ func (f *protocolDaoExecuteProposalsContextFactory) Create(args url.Values) (*pr
 
 func (f *protocolDaoExecuteProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoExecuteProposalsContext, types.DataBatch[api.ProtocolDaoExecuteProposalData]](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/finalize-proposal.go
+++ b/rocketpool-daemon/api/pdao/finalize-proposal.go
@@ -40,7 +40,7 @@ func (f *protocolDaoFinalizeProposalContextFactory) Create(args url.Values) (*pr
 
 func (f *protocolDaoFinalizeProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoFinalizeProposalContext, api.ProtocolDaoFinalizeProposalData](
-		router, "proposal/finalize", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/finalize", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/finalize-proposal.go
+++ b/rocketpool-daemon/api/pdao/finalize-proposal.go
@@ -40,7 +40,7 @@ func (f *protocolDaoFinalizeProposalContextFactory) Create(args url.Values) (*pr
 
 func (f *protocolDaoFinalizeProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoFinalizeProposalContext, api.ProtocolDaoFinalizeProposalData](
-		router, "proposal/finalize", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/finalize", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/get-claimable-bonds.go
+++ b/rocketpool-daemon/api/pdao/get-claimable-bonds.go
@@ -42,7 +42,7 @@ func (f *protocolDaoGetClaimableBondsContextFactory) Create(args url.Values) (*p
 
 func (f *protocolDaoGetClaimableBondsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoGetClaimableBondsContext, api.ProtocolDaoGetClaimableBondsData](
-		router, "get-claimable-bonds", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "get-claimable-bonds", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/get-claimable-bonds.go
+++ b/rocketpool-daemon/api/pdao/get-claimable-bonds.go
@@ -54,7 +54,7 @@ type protocolDaoGetClaimableBondsContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/handler.go
+++ b/rocketpool-daemon/api/pdao/handler.go
@@ -13,11 +13,11 @@ import (
 type ProtocolDaoHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewProtocolDaoHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *ProtocolDaoHandler {
+func NewProtocolDaoHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *ProtocolDaoHandler {
 	h := &ProtocolDaoHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/pdao/initialize-voting.go
+++ b/rocketpool-daemon/api/pdao/initialize-voting.go
@@ -40,7 +40,7 @@ func (f *protocolDaoInitializeVotingContextFactory) Create(args url.Values) (*pr
 
 func (f *protocolDaoInitializeVotingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoInitializeVotingContext, api.ProtocolDaoInitializeVotingData](
-		router, "initialize-voting", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "initialize-voting", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/initialize-voting.go
+++ b/rocketpool-daemon/api/pdao/initialize-voting.go
@@ -40,7 +40,7 @@ func (f *protocolDaoInitializeVotingContextFactory) Create(args url.Values) (*pr
 
 func (f *protocolDaoInitializeVotingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoInitializeVotingContext, api.ProtocolDaoInitializeVotingData](
-		router, "initialize-voting", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "initialize-voting", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/invite-security.go
+++ b/rocketpool-daemon/api/pdao/invite-security.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeInviteToSecurityCouncilContextFactory) Create(args ur
 
 func (f *protocolDaoProposeInviteToSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeInviteToSecurityCouncilContext, api.ProtocolDaoProposeInviteToSecurityCouncilData](
-		router, "security/invite", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "security/invite", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/invite-security.go
+++ b/rocketpool-daemon/api/pdao/invite-security.go
@@ -56,7 +56,7 @@ type protocolDaoProposeInviteToSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/invite-security.go
+++ b/rocketpool-daemon/api/pdao/invite-security.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeInviteToSecurityCouncilContextFactory) Create(args ur
 
 func (f *protocolDaoProposeInviteToSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeInviteToSecurityCouncilContext, api.ProtocolDaoProposeInviteToSecurityCouncilData](
-		router, "security/invite", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "security/invite", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -56,6 +56,7 @@ type protocolDaoProposeInviteToSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -70,6 +71,7 @@ func (c *protocolDaoProposeInviteToSecurityCouncilContext) Initialize() (types.R
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -118,7 +120,7 @@ func (c *protocolDaoProposeInviteToSecurityCouncilContext) PrepareData(data *api
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/kick-multi-security.go
+++ b/rocketpool-daemon/api/pdao/kick-multi-security.go
@@ -47,7 +47,7 @@ func (f *protocolDaoProposeKickMultiFromSecurityCouncilContextFactory) Create(ar
 
 func (f *protocolDaoProposeKickMultiFromSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeKickMultiFromSecurityCouncilContext, api.ProtocolDaoProposeKickMultiFromSecurityCouncilData](
-		router, "security/kick-multi", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "security/kick-multi", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -59,6 +59,7 @@ type protocolDaoProposeKickMultiFromSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -72,6 +73,7 @@ func (c *protocolDaoProposeKickMultiFromSecurityCouncilContext) Initialize() (ty
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 
 	// Requirements
@@ -127,7 +129,7 @@ func (c *protocolDaoProposeKickMultiFromSecurityCouncilContext) PrepareData(data
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/kick-multi-security.go
+++ b/rocketpool-daemon/api/pdao/kick-multi-security.go
@@ -59,7 +59,7 @@ type protocolDaoProposeKickMultiFromSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/kick-multi-security.go
+++ b/rocketpool-daemon/api/pdao/kick-multi-security.go
@@ -47,7 +47,7 @@ func (f *protocolDaoProposeKickMultiFromSecurityCouncilContextFactory) Create(ar
 
 func (f *protocolDaoProposeKickMultiFromSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeKickMultiFromSecurityCouncilContext, api.ProtocolDaoProposeKickMultiFromSecurityCouncilData](
-		router, "security/kick-multi", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "security/kick-multi", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/kick-security.go
+++ b/rocketpool-daemon/api/pdao/kick-security.go
@@ -55,7 +55,7 @@ type protocolDaoProposeKickFromSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/kick-security.go
+++ b/rocketpool-daemon/api/pdao/kick-security.go
@@ -43,7 +43,7 @@ func (f *protocolDaoProposeKickFromSecurityCouncilContextFactory) Create(args ur
 
 func (f *protocolDaoProposeKickFromSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeKickFromSecurityCouncilContext, api.ProtocolDaoProposeKickFromSecurityCouncilData](
-		router, "security/kick", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "security/kick", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/kick-security.go
+++ b/rocketpool-daemon/api/pdao/kick-security.go
@@ -43,7 +43,7 @@ func (f *protocolDaoProposeKickFromSecurityCouncilContextFactory) Create(args ur
 
 func (f *protocolDaoProposeKickFromSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeKickFromSecurityCouncilContext, api.ProtocolDaoProposeKickFromSecurityCouncilData](
-		router, "security/kick", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "security/kick", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -55,6 +55,7 @@ type protocolDaoProposeKickFromSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -68,6 +69,7 @@ func (c *protocolDaoProposeKickFromSecurityCouncilContext) Initialize() (types.R
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -117,7 +119,7 @@ func (c *protocolDaoProposeKickFromSecurityCouncilContext) PrepareData(data *api
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/one-time-spend.go
+++ b/rocketpool-daemon/api/pdao/one-time-spend.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeOneTimeSpendContextFactory) Create(args url.Values) (
 
 func (f *protocolDaoProposeOneTimeSpendContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeOneTimeSpendContext, api.ProtocolDaoGeneralProposeData](
-		router, "one-time-spend", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "one-time-spend", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/one-time-spend.go
+++ b/rocketpool-daemon/api/pdao/one-time-spend.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeOneTimeSpendContextFactory) Create(args url.Values) (
 
 func (f *protocolDaoProposeOneTimeSpendContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeOneTimeSpendContext, api.ProtocolDaoGeneralProposeData](
-		router, "one-time-spend", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "one-time-spend", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -56,6 +56,7 @@ type protocolDaoProposeOneTimeSpendContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -70,6 +71,7 @@ func (c *protocolDaoProposeOneTimeSpendContext) Initialize() (types.ResponseStat
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -112,7 +114,7 @@ func (c *protocolDaoProposeOneTimeSpendContext) PrepareData(data *api.ProtocolDa
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/one-time-spend.go
+++ b/rocketpool-daemon/api/pdao/one-time-spend.go
@@ -56,7 +56,7 @@ type protocolDaoProposeOneTimeSpendContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/override-vote.go
+++ b/rocketpool-daemon/api/pdao/override-vote.go
@@ -45,7 +45,7 @@ func (f *protocolDaoOverrideVoteOnProposalContextFactory) Create(args url.Values
 
 func (f *protocolDaoOverrideVoteOnProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoOverrideVoteOnProposalContext, api.ProtocolDaoVoteOnProposalData](
-		router, "proposal/override-vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/override-vote", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/override-vote.go
+++ b/rocketpool-daemon/api/pdao/override-vote.go
@@ -45,7 +45,7 @@ func (f *protocolDaoOverrideVoteOnProposalContextFactory) Create(args url.Values
 
 func (f *protocolDaoOverrideVoteOnProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoOverrideVoteOnProposalContext, api.ProtocolDaoVoteOnProposalData](
-		router, "proposal/override-vote", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/override-vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/proposals.go
+++ b/rocketpool-daemon/api/pdao/proposals.go
@@ -39,7 +39,7 @@ func (f *protocolDaoProposalsContextFactory) Create(args url.Values) (*protocolD
 
 func (f *protocolDaoProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposalsContext, api.ProtocolDaoProposalsData](
-		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/proposals.go
+++ b/rocketpool-daemon/api/pdao/proposals.go
@@ -39,7 +39,7 @@ func (f *protocolDaoProposalsContextFactory) Create(args url.Values) (*protocolD
 
 func (f *protocolDaoProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposalsContext, api.ProtocolDaoProposalsData](
-		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/propose-rewards-percentages.go
+++ b/rocketpool-daemon/api/pdao/propose-rewards-percentages.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeRewardsPercentagesContextFactory) Create(args url.Val
 
 func (f *protocolDaoProposeRewardsPercentagesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeRewardsPercentagesContext, api.ProtocolDaoGeneralProposeData](
-		router, "rewards-percentages/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rewards-percentages/propose", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -56,6 +56,7 @@ type protocolDaoProposeRewardsPercentagesContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -70,6 +71,7 @@ func (c *protocolDaoProposeRewardsPercentagesContext) Initialize() (types.Respon
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -121,7 +123,7 @@ func (c *protocolDaoProposeRewardsPercentagesContext) PrepareData(data *api.Prot
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/propose-rewards-percentages.go
+++ b/rocketpool-daemon/api/pdao/propose-rewards-percentages.go
@@ -56,7 +56,7 @@ type protocolDaoProposeRewardsPercentagesContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/propose-rewards-percentages.go
+++ b/rocketpool-daemon/api/pdao/propose-rewards-percentages.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeRewardsPercentagesContextFactory) Create(args url.Val
 
 func (f *protocolDaoProposeRewardsPercentagesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeRewardsPercentagesContext, api.ProtocolDaoGeneralProposeData](
-		router, "rewards-percentages/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rewards-percentages/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/propose-settings.go
+++ b/rocketpool-daemon/api/pdao/propose-settings.go
@@ -56,7 +56,7 @@ type protocolDaoProposeSettingContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/propose-settings.go
+++ b/rocketpool-daemon/api/pdao/propose-settings.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeSettingContextFactory) Create(args url.Values) (*prot
 
 func (f *protocolDaoProposeSettingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeSettingContext, api.ProtocolDaoProposeSettingData](
-		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -56,6 +56,7 @@ type protocolDaoProposeSettingContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -70,6 +71,7 @@ func (c *protocolDaoProposeSettingContext) Initialize() (types.ResponseStatus, e
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -146,7 +148,7 @@ func (c *protocolDaoProposeSettingContext) createProposalTx(category protocol.Se
 			if err != nil {
 				return false, nil, fmt.Errorf("error parsing value '%s' as bool: %w", c.valueString, err), nil
 			}
-			blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+			blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 			if err != nil {
 				return false, nil, fmt.Errorf("error creating pollard for proposal creation: %w", err), nil
 			}
@@ -163,7 +165,7 @@ func (c *protocolDaoProposeSettingContext) createProposalTx(category protocol.Se
 			if err != nil {
 				return false, nil, fmt.Errorf("error parsing value '%s' as *big.Int: %w", c.valueString, err), nil
 			}
-			blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+			blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 			if err != nil {
 				return false, nil, fmt.Errorf("error creating pollard for proposal creation: %w", err), nil
 			}

--- a/rocketpool-daemon/api/pdao/propose-settings.go
+++ b/rocketpool-daemon/api/pdao/propose-settings.go
@@ -44,7 +44,7 @@ func (f *protocolDaoProposeSettingContextFactory) Create(args url.Values) (*prot
 
 func (f *protocolDaoProposeSettingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeSettingContext, api.ProtocolDaoProposeSettingData](
-		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/recurring-spend.go
+++ b/rocketpool-daemon/api/pdao/recurring-spend.go
@@ -48,7 +48,7 @@ func (f *protocolDaoProposeRecurringSpendContextFactory) Create(args url.Values)
 
 func (f *protocolDaoProposeRecurringSpendContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeRecurringSpendContext, api.ProtocolDaoGeneralProposeData](
-		router, "recurring-spend", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "recurring-spend", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -60,6 +60,7 @@ type protocolDaoProposeRecurringSpendContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -77,6 +78,7 @@ func (c *protocolDaoProposeRecurringSpendContext) Initialize() (types.ResponseSt
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -119,7 +121,7 @@ func (c *protocolDaoProposeRecurringSpendContext) PrepareData(data *api.Protocol
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/recurring-spend.go
+++ b/rocketpool-daemon/api/pdao/recurring-spend.go
@@ -60,7 +60,7 @@ type protocolDaoProposeRecurringSpendContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/recurring-spend.go
+++ b/rocketpool-daemon/api/pdao/recurring-spend.go
@@ -48,7 +48,7 @@ func (f *protocolDaoProposeRecurringSpendContextFactory) Create(args url.Values)
 
 func (f *protocolDaoProposeRecurringSpendContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeRecurringSpendContext, api.ProtocolDaoGeneralProposeData](
-		router, "recurring-spend", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "recurring-spend", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/replace-security.go
+++ b/rocketpool-daemon/api/pdao/replace-security.go
@@ -45,7 +45,7 @@ func (f *protocolDaoProposeReplaceMemberOfSecurityCouncilContextFactory) Create(
 
 func (f *protocolDaoProposeReplaceMemberOfSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeReplaceMemberOfSecurityCouncilContext, api.ProtocolDaoProposeReplaceMemberOfSecurityCouncilData](
-		router, "security/replace", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "security/replace", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/replace-security.go
+++ b/rocketpool-daemon/api/pdao/replace-security.go
@@ -45,7 +45,7 @@ func (f *protocolDaoProposeReplaceMemberOfSecurityCouncilContextFactory) Create(
 
 func (f *protocolDaoProposeReplaceMemberOfSecurityCouncilContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeReplaceMemberOfSecurityCouncilContext, api.ProtocolDaoProposeReplaceMemberOfSecurityCouncilData](
-		router, "security/replace", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "security/replace", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -57,6 +57,7 @@ type protocolDaoProposeReplaceMemberOfSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -73,6 +74,7 @@ func (c *protocolDaoProposeReplaceMemberOfSecurityCouncilContext) Initialize() (
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -128,7 +130,7 @@ func (c *protocolDaoProposeReplaceMemberOfSecurityCouncilContext) PrepareData(da
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/replace-security.go
+++ b/rocketpool-daemon/api/pdao/replace-security.go
@@ -57,7 +57,7 @@ type protocolDaoProposeReplaceMemberOfSecurityCouncilContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/rewards-percentages.go
+++ b/rocketpool-daemon/api/pdao/rewards-percentages.go
@@ -31,7 +31,7 @@ func (f *protocolDaoRewardsPercentagesContextFactory) Create(args url.Values) (*
 
 func (f *protocolDaoRewardsPercentagesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoRewardsPercentagesContext, api.ProtocolDaoRewardsPercentagesData](
-		router, "rewards-percentages", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rewards-percentages", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/rewards-percentages.go
+++ b/rocketpool-daemon/api/pdao/rewards-percentages.go
@@ -31,7 +31,7 @@ func (f *protocolDaoRewardsPercentagesContextFactory) Create(args url.Values) (*
 
 func (f *protocolDaoRewardsPercentagesContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoRewardsPercentagesContext, api.ProtocolDaoRewardsPercentagesData](
-		router, "rewards-percentages", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rewards-percentages", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/set-voting-delegate.go
+++ b/rocketpool-daemon/api/pdao/set-voting-delegate.go
@@ -35,7 +35,7 @@ func (f *protocolDaoSetVotingDelegateContextFactory) Create(args url.Values) (*p
 
 func (f *protocolDaoSetVotingDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*protocolDaoSetSnapshotDelegateContext, types.TxInfoData](
-		router, "voting-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "voting-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/set-voting-delegate.go
+++ b/rocketpool-daemon/api/pdao/set-voting-delegate.go
@@ -35,7 +35,7 @@ func (f *protocolDaoSetVotingDelegateContextFactory) Create(args url.Values) (*p
 
 func (f *protocolDaoSetVotingDelegateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*protocolDaoSetSnapshotDelegateContext, types.TxInfoData](
-		router, "voting-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "voting-delegate/set", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/settings.go
+++ b/rocketpool-daemon/api/pdao/settings.go
@@ -33,7 +33,7 @@ func (f *protocolDaoSettingsContextFactory) Create(args url.Values) (*protocolDa
 
 func (f *protocolDaoSettingsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoSettingsContext, api.ProtocolDaoSettingsData](
-		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/settings.go
+++ b/rocketpool-daemon/api/pdao/settings.go
@@ -33,7 +33,7 @@ func (f *protocolDaoSettingsContextFactory) Create(args url.Values) (*protocolDa
 
 func (f *protocolDaoSettingsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoSettingsContext, api.ProtocolDaoSettingsData](
-		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "settings", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/status.go
+++ b/rocketpool-daemon/api/pdao/status.go
@@ -36,7 +36,7 @@ func (f *protocolDaoGetStatusContextFactory) Create(args url.Values) (*protocolD
 
 func (f *protocolDaoGetStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*protocolDaoGetStatusContext, api.ProtocolDAOStatusResponse](
-		router, "get-status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "get-status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -47,6 +47,7 @@ func (f *protocolDaoGetStatusContextFactory) RegisterRoute(router *mux.Router) {
 type protocolDaoGetStatusContext struct {
 	handler *ProtocolDaoHandler
 	cfg     *config.SmartNodeConfig
+	res     *config.RocketPoolResources
 	rp      *rocketpool.RocketPool
 	bc      beacon.IBeaconClient
 
@@ -58,6 +59,7 @@ func (c *protocolDaoGetStatusContext) PrepareData(data *api.ProtocolDAOStatusRes
 	rp := sp.GetRocketPool()
 	ec := sp.GetEthClient()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.rp = sp.GetRocketPool()
 	c.bc = sp.GetBeaconClient()
 	ctx := c.handler.ctx
@@ -75,7 +77,7 @@ func (c *protocolDaoGetStatusContext) PrepareData(data *api.ProtocolDAOStatusRes
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error creating node %s binding: %w", nodeAddress.Hex(), err)
 	}
-	c.propMgr, err = proposals.NewProposalManager(ctx, c.handler.logger.Logger, c.cfg, c.rp, c.bc)
+	c.propMgr, err = proposals.NewProposalManager(ctx, c.handler.logger.Logger, c.cfg, c.res, c.rp, c.bc)
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error creating proposal manager: %w", err)
 	}

--- a/rocketpool-daemon/api/pdao/status.go
+++ b/rocketpool-daemon/api/pdao/status.go
@@ -36,7 +36,7 @@ func (f *protocolDaoGetStatusContextFactory) Create(args url.Values) (*protocolD
 
 func (f *protocolDaoGetStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*protocolDaoGetStatusContext, api.ProtocolDAOStatusResponse](
-		router, "get-status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "get-status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/status.go
+++ b/rocketpool-daemon/api/pdao/status.go
@@ -47,7 +47,7 @@ func (f *protocolDaoGetStatusContextFactory) RegisterRoute(router *mux.Router) {
 type protocolDaoGetStatusContext struct {
 	handler *ProtocolDaoHandler
 	cfg     *config.SmartNodeConfig
-	res     *config.RocketPoolResources
+	res     *config.MergedResources
 	rp      *rocketpool.RocketPool
 	bc      beacon.IBeaconClient
 

--- a/rocketpool-daemon/api/pdao/update-recurring-spend.go
+++ b/rocketpool-daemon/api/pdao/update-recurring-spend.go
@@ -59,7 +59,7 @@ type protocolDaoProposeRecurringSpendUpdateContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 

--- a/rocketpool-daemon/api/pdao/update-recurring-spend.go
+++ b/rocketpool-daemon/api/pdao/update-recurring-spend.go
@@ -47,7 +47,7 @@ func (f *protocolDaoProposeRecurringSpendUpdateContextFactory) Create(args url.V
 
 func (f *protocolDaoProposeRecurringSpendUpdateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeRecurringSpendUpdateContext, api.ProtocolDaoProposeRecurringSpendUpdateData](
-		router, "recurring-spend-update", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "recurring-spend-update", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/pdao/update-recurring-spend.go
+++ b/rocketpool-daemon/api/pdao/update-recurring-spend.go
@@ -47,7 +47,7 @@ func (f *protocolDaoProposeRecurringSpendUpdateContextFactory) Create(args url.V
 
 func (f *protocolDaoProposeRecurringSpendUpdateContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoProposeRecurringSpendUpdateContext, api.ProtocolDaoProposeRecurringSpendUpdateData](
-		router, "recurring-spend-update", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "recurring-spend-update", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -59,6 +59,7 @@ type protocolDaoProposeRecurringSpendUpdateContext struct {
 	handler     *ProtocolDaoHandler
 	rp          *rocketpool.RocketPool
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
 
@@ -76,6 +77,7 @@ func (c *protocolDaoProposeRecurringSpendUpdateContext) Initialize() (types.Resp
 	sp := c.handler.serviceProvider
 	c.rp = sp.GetRocketPool()
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.bc = sp.GetBeaconClient()
 	c.nodeAddress, _ = sp.GetWallet().GetAddress()
 
@@ -120,7 +122,7 @@ func (c *protocolDaoProposeRecurringSpendUpdateContext) PrepareData(data *api.Pr
 
 	// Get the tx
 	if data.CanPropose && opts != nil {
-		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.bc)
+		blockNumber, pollard, err := createPollard(ctx, c.handler.logger.Logger, c.rp, c.cfg, c.res, c.bc)
 		if err != nil {
 			return types.ResponseStatus_Error, fmt.Errorf("error creating pollard for proposal creation: %w", err)
 		}

--- a/rocketpool-daemon/api/pdao/utils.go
+++ b/rocketpool-daemon/api/pdao/utils.go
@@ -12,9 +12,9 @@ import (
 )
 
 // Constructs a pollard for the latest finalized block and saves it to disk
-func createPollard(context context.Context, logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient) (uint32, []types.VotingTreeNode, error) {
+func createPollard(context context.Context, logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (uint32, []types.VotingTreeNode, error) {
 	// Create a proposal manager
-	propMgr, err := proposals.NewProposalManager(context, logger, cfg, rp, bc)
+	propMgr, err := proposals.NewProposalManager(context, logger, cfg, res, rp, bc)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/rocketpool-daemon/api/pdao/utils.go
+++ b/rocketpool-daemon/api/pdao/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Constructs a pollard for the latest finalized block and saves it to disk
-func createPollard(context context.Context, logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (uint32, []types.VotingTreeNode, error) {
+func createPollard(context context.Context, logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (uint32, []types.VotingTreeNode, error) {
 	// Create a proposal manager
 	propMgr, err := proposals.NewProposalManager(context, logger, cfg, res, rp, bc)
 	if err != nil {

--- a/rocketpool-daemon/api/pdao/vote-proposal.go
+++ b/rocketpool-daemon/api/pdao/vote-proposal.go
@@ -57,7 +57,7 @@ func (f *protocolDaoVoteOnProposalContextFactory) RegisterRoute(router *mux.Rout
 type protocolDaoVoteOnProposalContext struct {
 	handler     *ProtocolDaoHandler
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	rp          *rocketpool.RocketPool
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address

--- a/rocketpool-daemon/api/pdao/vote-proposal.go
+++ b/rocketpool-daemon/api/pdao/vote-proposal.go
@@ -46,7 +46,7 @@ func (f *protocolDaoVoteOnProposalContextFactory) Create(args url.Values) (*prot
 
 func (f *protocolDaoVoteOnProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoVoteOnProposalContext, api.ProtocolDaoVoteOnProposalData](
-		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -57,6 +57,7 @@ func (f *protocolDaoVoteOnProposalContextFactory) RegisterRoute(router *mux.Rout
 type protocolDaoVoteOnProposalContext struct {
 	handler     *ProtocolDaoHandler
 	cfg         *config.SmartNodeConfig
+	res         *config.RocketPoolResources
 	rp          *rocketpool.RocketPool
 	bc          beacon.IBeaconClient
 	nodeAddress common.Address
@@ -73,6 +74,7 @@ type protocolDaoVoteOnProposalContext struct {
 func (c *protocolDaoVoteOnProposalContext) Initialize() (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
 	c.cfg = sp.GetConfig()
+	c.res = sp.GetResources()
 	c.rp = sp.GetRocketPool()
 	c.bc = sp.GetBeaconClient()
 	ctx := c.handler.ctx
@@ -97,7 +99,7 @@ func (c *protocolDaoVoteOnProposalContext) Initialize() (types.ResponseStatus, e
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error creating proposal binding: %w", err)
 	}
-	c.propMgr, err = proposals.NewProposalManager(ctx, c.handler.logger.Logger, c.cfg, c.rp, c.bc)
+	c.propMgr, err = proposals.NewProposalManager(ctx, c.handler.logger.Logger, c.cfg, c.res, c.rp, c.bc)
 	if err != nil {
 		return types.ResponseStatus_Error, fmt.Errorf("error creating proposal manager: %w", err)
 	}

--- a/rocketpool-daemon/api/pdao/vote-proposal.go
+++ b/rocketpool-daemon/api/pdao/vote-proposal.go
@@ -46,7 +46,7 @@ func (f *protocolDaoVoteOnProposalContextFactory) Create(args url.Values) (*prot
 
 func (f *protocolDaoVoteOnProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*protocolDaoVoteOnProposalContext, api.ProtocolDaoVoteOnProposalData](
-		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/queue/handler.go
+++ b/rocketpool-daemon/api/queue/handler.go
@@ -13,11 +13,11 @@ import (
 type QueueHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewQueueHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *QueueHandler {
+func NewQueueHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *QueueHandler {
 	h := &QueueHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/queue/process.go
+++ b/rocketpool-daemon/api/queue/process.go
@@ -34,7 +34,7 @@ func (f *queueProcessContextFactory) Create(args url.Values) (*queueProcessConte
 
 func (f *queueProcessContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*queueProcessContext, api.QueueProcessData](
-		router, "process", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "process", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/queue/process.go
+++ b/rocketpool-daemon/api/queue/process.go
@@ -34,7 +34,7 @@ func (f *queueProcessContextFactory) Create(args url.Values) (*queueProcessConte
 
 func (f *queueProcessContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*queueProcessContext, api.QueueProcessData](
-		router, "process", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "process", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/queue/status.go
+++ b/rocketpool-daemon/api/queue/status.go
@@ -34,7 +34,7 @@ func (f *queueStatusContextFactory) Create(args url.Values) (*queueStatusContext
 
 func (f *queueStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*queueStatusContext, api.QueueStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/queue/status.go
+++ b/rocketpool-daemon/api/queue/status.go
@@ -34,7 +34,7 @@ func (f *queueStatusContextFactory) Create(args url.Values) (*queueStatusContext
 
 func (f *queueStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*queueStatusContext, api.QueueStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/cancel-proposal.go
+++ b/rocketpool-daemon/api/security/cancel-proposal.go
@@ -41,7 +41,7 @@ func (f *securityCancelProposalContextFactory) Create(args url.Values) (*securit
 
 func (f *securityCancelProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityCancelProposalContext, api.SecurityCancelProposalData](
-		router, "proposal/cancel", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/cancel", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/cancel-proposal.go
+++ b/rocketpool-daemon/api/security/cancel-proposal.go
@@ -41,7 +41,7 @@ func (f *securityCancelProposalContextFactory) Create(args url.Values) (*securit
 
 func (f *securityCancelProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityCancelProposalContext, api.SecurityCancelProposalData](
-		router, "proposal/cancel", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/cancel", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/execute-proposals.go
+++ b/rocketpool-daemon/api/security/execute-proposals.go
@@ -44,7 +44,7 @@ func (f *securityExecuteProposalsContextFactory) Create(args url.Values) (*secur
 
 func (f *securityExecuteProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityExecuteProposalsContext, types.DataBatch[api.SecurityExecuteProposalData]](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/execute-proposals.go
+++ b/rocketpool-daemon/api/security/execute-proposals.go
@@ -44,7 +44,7 @@ func (f *securityExecuteProposalsContextFactory) Create(args url.Values) (*secur
 
 func (f *securityExecuteProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityExecuteProposalsContext, types.DataBatch[api.SecurityExecuteProposalData]](
-		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/execute", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/handler.go
+++ b/rocketpool-daemon/api/security/handler.go
@@ -13,11 +13,11 @@ import (
 type SecurityCouncilHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewSecurityCouncilHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *SecurityCouncilHandler {
+func NewSecurityCouncilHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *SecurityCouncilHandler {
 	h := &SecurityCouncilHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/security/join.go
+++ b/rocketpool-daemon/api/security/join.go
@@ -36,7 +36,7 @@ func (f *securityJoinContextFactory) Create(args url.Values) (*securityJoinConte
 
 func (f *securityJoinContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityJoinContext, api.SecurityJoinData](
-		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/join.go
+++ b/rocketpool-daemon/api/security/join.go
@@ -36,7 +36,7 @@ func (f *securityJoinContextFactory) Create(args url.Values) (*securityJoinConte
 
 func (f *securityJoinContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityJoinContext, api.SecurityJoinData](
-		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "join", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/leave.go
+++ b/rocketpool-daemon/api/security/leave.go
@@ -37,7 +37,7 @@ func (f *securityLeaveContextFactory) Create(args url.Values) (*securityLeaveCon
 
 func (f *securityLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityLeaveContext, api.SecurityLeaveData](
-		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/leave.go
+++ b/rocketpool-daemon/api/security/leave.go
@@ -37,7 +37,7 @@ func (f *securityLeaveContextFactory) Create(args url.Values) (*securityLeaveCon
 
 func (f *securityLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityLeaveContext, api.SecurityLeaveData](
-		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "leave", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/members.go
+++ b/rocketpool-daemon/api/security/members.go
@@ -35,7 +35,7 @@ func (f *securityMembersContextFactory) Create(args url.Values) (*securityMember
 
 func (f *securityMembersContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityMembersContext, api.SecurityMembersData](
-		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/members.go
+++ b/rocketpool-daemon/api/security/members.go
@@ -35,7 +35,7 @@ func (f *securityMembersContextFactory) Create(args url.Values) (*securityMember
 
 func (f *securityMembersContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityMembersContext, api.SecurityMembersData](
-		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "members", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/proposals.go
+++ b/rocketpool-daemon/api/security/proposals.go
@@ -39,7 +39,7 @@ func (f *securityProposalsContextFactory) Create(args url.Values) (*securityProp
 
 func (f *securityProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityProposalsContext, api.SecurityProposalsData](
-		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/proposals.go
+++ b/rocketpool-daemon/api/security/proposals.go
@@ -39,7 +39,7 @@ func (f *securityProposalsContextFactory) Create(args url.Values) (*securityProp
 
 func (f *securityProposalsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityProposalsContext, api.SecurityProposalsData](
-		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposals", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/propose-leave.go
+++ b/rocketpool-daemon/api/security/propose-leave.go
@@ -30,7 +30,7 @@ func (f *securityProposeLeaveContextFactory) Create(args url.Values) (*securityP
 
 func (f *securityProposeLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*securityProposeLeaveContext, types.TxInfoData](
-		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/propose-leave.go
+++ b/rocketpool-daemon/api/security/propose-leave.go
@@ -30,7 +30,7 @@ func (f *securityProposeLeaveContextFactory) Create(args url.Values) (*securityP
 
 func (f *securityProposeLeaveContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*securityProposeLeaveContext, types.TxInfoData](
-		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "propose-leave", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/propose-settings.go
+++ b/rocketpool-daemon/api/security/propose-settings.go
@@ -39,7 +39,7 @@ func (f *securityProposeSettingContextFactory) Create(args url.Values) (*securit
 
 func (f *securityProposeSettingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*securityProposeSettingContext, api.SecurityProposeSettingData](
-		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/propose-settings.go
+++ b/rocketpool-daemon/api/security/propose-settings.go
@@ -39,7 +39,7 @@ func (f *securityProposeSettingContextFactory) Create(args url.Values) (*securit
 
 func (f *securityProposeSettingContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*securityProposeSettingContext, api.SecurityProposeSettingData](
-		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "setting/propose", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/status.go
+++ b/rocketpool-daemon/api/security/status.go
@@ -44,7 +44,7 @@ func (f *securityStatusContextFactory) Create(args url.Values) (*securityStatusC
 
 func (f *securityStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityStatusContext, api.SecurityStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/status.go
+++ b/rocketpool-daemon/api/security/status.go
@@ -44,7 +44,7 @@ func (f *securityStatusContextFactory) Create(args url.Values) (*securityStatusC
 
 func (f *securityStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityStatusContext, api.SecurityStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/vote-proposal.go
+++ b/rocketpool-daemon/api/security/vote-proposal.go
@@ -42,7 +42,7 @@ func (f *securityVoteOnProposalContextFactory) Create(args url.Values) (*securit
 
 func (f *securityVoteOnProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityVoteOnProposalContext, api.SecurityVoteOnProposalData](
-		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/security/vote-proposal.go
+++ b/rocketpool-daemon/api/security/vote-proposal.go
@@ -42,7 +42,7 @@ func (f *securityVoteOnProposalContextFactory) Create(args url.Values) (*securit
 
 func (f *securityVoteOnProposalContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterSingleStageRoute[*securityVoteOnProposalContext, api.SecurityVoteOnProposalData](
-		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "proposal/vote", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/server-manager.go
+++ b/rocketpool-daemon/api/server-manager.go
@@ -27,7 +27,7 @@ type ServerManager struct {
 }
 
 // Creates a new server manager
-func NewServerManager(sp *services.ServiceProvider, ip string, port uint16, stopWg *sync.WaitGroup) (*ServerManager, error) {
+func NewServerManager(sp services.ISmartNodeServiceProvider, ip string, port uint16, stopWg *sync.WaitGroup) (*ServerManager, error) {
 	// Start the API server
 	apiServer, err := createServer(sp, ip, port)
 	if err != nil {
@@ -55,7 +55,7 @@ func (m *ServerManager) Stop() {
 }
 
 // Creates a new Smart Node API server
-func createServer(sp *services.ServiceProvider, ip string, port uint16) (*server.NetworkSocketApiServer, error) {
+func createServer(sp services.ISmartNodeServiceProvider, ip string, port uint16) (*server.NetworkSocketApiServer, error) {
 	apiLogger := sp.GetApiLogger()
 	ctx := apiLogger.CreateContextWithLogger(sp.GetBaseContext())
 

--- a/rocketpool-daemon/api/service/client-status.go
+++ b/rocketpool-daemon/api/service/client-status.go
@@ -28,7 +28,7 @@ func (f *serviceClientStatusContextFactory) Create(args url.Values) (*serviceCli
 
 func (f *serviceClientStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceClientStatusContext, api.ServiceClientStatusData](
-		router, "client-status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "client-status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/client-status.go
+++ b/rocketpool-daemon/api/service/client-status.go
@@ -28,7 +28,7 @@ func (f *serviceClientStatusContextFactory) Create(args url.Values) (*serviceCli
 
 func (f *serviceClientStatusContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceClientStatusContext, api.ServiceClientStatusData](
-		router, "client-status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "client-status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/get-config.go
+++ b/rocketpool-daemon/api/service/get-config.go
@@ -27,7 +27,7 @@ func (f *serviceGetConfigContextFactory) Create(args url.Values) (*serviceGetCon
 
 func (f *serviceGetConfigContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceGetConfigContext, api.ServiceGetConfigData](
-		router, "get-config", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "get-config", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/get-config.go
+++ b/rocketpool-daemon/api/service/get-config.go
@@ -27,7 +27,7 @@ func (f *serviceGetConfigContextFactory) Create(args url.Values) (*serviceGetCon
 
 func (f *serviceGetConfigContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceGetConfigContext, api.ServiceGetConfigData](
-		router, "get-config", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "get-config", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/handler.go
+++ b/rocketpool-daemon/api/service/handler.go
@@ -12,11 +12,11 @@ import (
 type ServiceHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewServiceHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *ServiceHandler {
+func NewServiceHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *ServiceHandler {
 	h := &ServiceHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/service/restart-vc.go
+++ b/rocketpool-daemon/api/service/restart-vc.go
@@ -29,7 +29,7 @@ func (f *serviceRestartVcContextFactory) Create(args url.Values) (*serviceRestar
 
 func (f *serviceRestartVcContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceRestartVcContext, types.SuccessData](
-		router, "restart-vc", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "restart-vc", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/restart-vc.go
+++ b/rocketpool-daemon/api/service/restart-vc.go
@@ -29,7 +29,7 @@ func (f *serviceRestartVcContextFactory) Create(args url.Values) (*serviceRestar
 
 func (f *serviceRestartVcContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceRestartVcContext, types.SuccessData](
-		router, "restart-vc", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "restart-vc", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/terminate-data-folder.go
+++ b/rocketpool-daemon/api/service/terminate-data-folder.go
@@ -36,7 +36,7 @@ func (f *serviceTerminateDataFolderContextFactory) Create(args url.Values) (*ser
 
 func (f *serviceTerminateDataFolderContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceTerminateDataFolderContext, api.ServiceTerminateDataFolderData](
-		router, "terminate-data-folder", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "terminate-data-folder", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/terminate-data-folder.go
+++ b/rocketpool-daemon/api/service/terminate-data-folder.go
@@ -36,7 +36,7 @@ func (f *serviceTerminateDataFolderContextFactory) Create(args url.Values) (*ser
 
 func (f *serviceTerminateDataFolderContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceTerminateDataFolderContext, api.ServiceTerminateDataFolderData](
-		router, "terminate-data-folder", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "terminate-data-folder", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/version.go
+++ b/rocketpool-daemon/api/service/version.go
@@ -28,7 +28,7 @@ func (f *serviceVersionContextFactory) Create(args url.Values) (*serviceVersionC
 
 func (f *serviceVersionContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceVersionContext, api.ServiceVersionData](
-		router, "version", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "version", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/service/version.go
+++ b/rocketpool-daemon/api/service/version.go
@@ -28,7 +28,7 @@ func (f *serviceVersionContextFactory) Create(args url.Values) (*serviceVersionC
 
 func (f *serviceVersionContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*serviceVersionContext, api.ServiceVersionData](
-		router, "version", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "version", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/batch-sign-txs.go
+++ b/rocketpool-daemon/api/tx/batch-sign-txs.go
@@ -48,7 +48,7 @@ func (f *txBatchSignTxsContextFactory) Create(body api.BatchSubmitTxsBody) (*txB
 
 func (f *txBatchSignTxsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txBatchSignTxsContext, api.BatchSubmitTxsBody, api.TxBatchSignTxData](
-		router, "batch-sign-txs", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "batch-sign-txs", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/batch-sign-txs.go
+++ b/rocketpool-daemon/api/tx/batch-sign-txs.go
@@ -48,7 +48,7 @@ func (f *txBatchSignTxsContextFactory) Create(body api.BatchSubmitTxsBody) (*txB
 
 func (f *txBatchSignTxsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txBatchSignTxsContext, api.BatchSubmitTxsBody, api.TxBatchSignTxData](
-		router, "batch-sign-txs", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "batch-sign-txs", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/batch-submit-txs.go
+++ b/rocketpool-daemon/api/tx/batch-submit-txs.go
@@ -47,7 +47,7 @@ func (f *txBatchSubmitTxsContextFactory) Create(body api.BatchSubmitTxsBody) (*t
 
 func (f *txBatchSubmitTxsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txBatchSubmitTxsContext, api.BatchSubmitTxsBody, api.BatchTxData](
-		router, "batch-submit-txs", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "batch-submit-txs", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/batch-submit-txs.go
+++ b/rocketpool-daemon/api/tx/batch-submit-txs.go
@@ -47,7 +47,7 @@ func (f *txBatchSubmitTxsContextFactory) Create(body api.BatchSubmitTxsBody) (*t
 
 func (f *txBatchSubmitTxsContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txBatchSubmitTxsContext, api.BatchSubmitTxsBody, api.BatchTxData](
-		router, "batch-submit-txs", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "batch-submit-txs", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/handler.go
+++ b/rocketpool-daemon/api/tx/handler.go
@@ -13,11 +13,11 @@ import (
 type TxHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewTxHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *TxHandler {
+func NewTxHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *TxHandler {
 	h := &TxHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/tx/sign-tx.go
+++ b/rocketpool-daemon/api/tx/sign-tx.go
@@ -44,7 +44,7 @@ func (f *txSignTxContextFactory) Create(body api.SubmitTxBody) (*txSignTxContext
 
 func (f *txSignTxContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txSignTxContext, api.SubmitTxBody, api.TxSignTxData](
-		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/sign-tx.go
+++ b/rocketpool-daemon/api/tx/sign-tx.go
@@ -44,7 +44,7 @@ func (f *txSignTxContextFactory) Create(body api.SubmitTxBody) (*txSignTxContext
 
 func (f *txSignTxContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txSignTxContext, api.SubmitTxBody, api.TxSignTxData](
-		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/submit-tx.go
+++ b/rocketpool-daemon/api/tx/submit-tx.go
@@ -43,7 +43,7 @@ func (f *txSubmitTxContextFactory) Create(body api.SubmitTxBody) (*txSubmitTxCon
 
 func (f *txSubmitTxContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txSubmitTxContext, api.SubmitTxBody, api.TxData](
-		router, "submit-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "submit-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/submit-tx.go
+++ b/rocketpool-daemon/api/tx/submit-tx.go
@@ -43,7 +43,7 @@ func (f *txSubmitTxContextFactory) Create(body api.SubmitTxBody) (*txSubmitTxCon
 
 func (f *txSubmitTxContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessPost[*txSubmitTxContext, api.SubmitTxBody, api.TxData](
-		router, "submit-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "submit-tx", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/wait.go
+++ b/rocketpool-daemon/api/tx/wait.go
@@ -35,7 +35,7 @@ func (f *txWaitContextFactory) Create(args url.Values) (*txWaitContext, error) {
 
 func (f *txWaitContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*txWaitContext, types.SuccessData](
-		router, "wait", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "wait", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/tx/wait.go
+++ b/rocketpool-daemon/api/tx/wait.go
@@ -35,7 +35,7 @@ func (f *txWaitContextFactory) Create(args url.Values) (*txWaitContext, error) {
 
 func (f *txWaitContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*txWaitContext, types.SuccessData](
-		router, "wait", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "wait", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/create-validator-key.go
+++ b/rocketpool-daemon/api/wallet/create-validator-key.go
@@ -35,7 +35,7 @@ func (f *walletCreateValidatorKeyContextFactory) Create(args url.Values) (*walle
 
 func (f *walletCreateValidatorKeyContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletCreateValidatorKeyContext, types.SuccessData](
-		router, "create-validator-key", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "create-validator-key", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/create-validator-key.go
+++ b/rocketpool-daemon/api/wallet/create-validator-key.go
@@ -35,7 +35,7 @@ func (f *walletCreateValidatorKeyContextFactory) Create(args url.Values) (*walle
 
 func (f *walletCreateValidatorKeyContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletCreateValidatorKeyContext, types.SuccessData](
-		router, "create-validator-key", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "create-validator-key", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/delete-password.go
+++ b/rocketpool-daemon/api/wallet/delete-password.go
@@ -28,7 +28,7 @@ func (f *walletDeletePasswordContextFactory) Create(args url.Values) (*walletDel
 
 func (f *walletDeletePasswordContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletDeletePasswordContext, types.SuccessData](
-		router, "delete-password", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "delete-password", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/delete-password.go
+++ b/rocketpool-daemon/api/wallet/delete-password.go
@@ -28,7 +28,7 @@ func (f *walletDeletePasswordContextFactory) Create(args url.Values) (*walletDel
 
 func (f *walletDeletePasswordContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletDeletePasswordContext, types.SuccessData](
-		router, "delete-password", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "delete-password", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/export-eth-key.go
+++ b/rocketpool-daemon/api/wallet/export-eth-key.go
@@ -30,7 +30,7 @@ func (f *walletExportEthKeyContextFactory) Create(args url.Values) (*walletExpor
 
 func (f *walletExportEthKeyContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletExportEthKeyContext, api.WalletExportEthKeyData](
-		router, "export-eth-key", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "export-eth-key", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/export-eth-key.go
+++ b/rocketpool-daemon/api/wallet/export-eth-key.go
@@ -30,7 +30,7 @@ func (f *walletExportEthKeyContextFactory) Create(args url.Values) (*walletExpor
 
 func (f *walletExportEthKeyContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletExportEthKeyContext, api.WalletExportEthKeyData](
-		router, "export-eth-key", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "export-eth-key", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/export.go
+++ b/rocketpool-daemon/api/wallet/export.go
@@ -29,7 +29,7 @@ func (f *walletExportContextFactory) Create(args url.Values) (*walletExportConte
 
 func (f *walletExportContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletExportContext, api.WalletExportData](
-		router, "export", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "export", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/export.go
+++ b/rocketpool-daemon/api/wallet/export.go
@@ -29,7 +29,7 @@ func (f *walletExportContextFactory) Create(args url.Values) (*walletExportConte
 
 func (f *walletExportContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletExportContext, api.WalletExportData](
-		router, "export", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "export", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/handler.go
+++ b/rocketpool-daemon/api/wallet/handler.go
@@ -13,11 +13,11 @@ import (
 type WalletHandler struct {
 	logger          *log.Logger
 	ctx             context.Context
-	serviceProvider *services.ServiceProvider
+	serviceProvider services.ISmartNodeServiceProvider
 	factories       []server.IContextFactory
 }
 
-func NewWalletHandler(logger *log.Logger, ctx context.Context, serviceProvider *services.ServiceProvider) *WalletHandler {
+func NewWalletHandler(logger *log.Logger, ctx context.Context, serviceProvider services.ISmartNodeServiceProvider) *WalletHandler {
 	h := &WalletHandler{
 		logger:          logger,
 		ctx:             ctx,

--- a/rocketpool-daemon/api/wallet/initialize.go
+++ b/rocketpool-daemon/api/wallet/initialize.go
@@ -40,7 +40,7 @@ func (f *walletInitializeContextFactory) Create(args url.Values) (*walletInitial
 
 func (f *walletInitializeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletInitializeContext, api.WalletInitializeData](
-		router, "initialize", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "initialize", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/initialize.go
+++ b/rocketpool-daemon/api/wallet/initialize.go
@@ -40,7 +40,7 @@ func (f *walletInitializeContextFactory) Create(args url.Values) (*walletInitial
 
 func (f *walletInitializeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletInitializeContext, api.WalletInitializeData](
-		router, "initialize", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "initialize", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/masquerade.go
+++ b/rocketpool-daemon/api/wallet/masquerade.go
@@ -33,7 +33,7 @@ func (f *walletMasqueradeContextFactory) Create(args url.Values) (*walletMasquer
 
 func (f *walletMasqueradeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletMasqueradeContext, types.SuccessData](
-		router, "masquerade", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "masquerade", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/masquerade.go
+++ b/rocketpool-daemon/api/wallet/masquerade.go
@@ -33,7 +33,7 @@ func (f *walletMasqueradeContextFactory) Create(args url.Values) (*walletMasquer
 
 func (f *walletMasqueradeContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletMasqueradeContext, types.SuccessData](
-		router, "masquerade", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "masquerade", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/rebuild.go
+++ b/rocketpool-daemon/api/wallet/rebuild.go
@@ -29,7 +29,7 @@ func (f *walletRebuildContextFactory) Create(args url.Values) (*walletRebuildCon
 
 func (f *walletRebuildContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletRebuildContext, api.WalletRebuildData](
-		router, "rebuild", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "rebuild", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/rebuild.go
+++ b/rocketpool-daemon/api/wallet/rebuild.go
@@ -29,7 +29,7 @@ func (f *walletRebuildContextFactory) Create(args url.Values) (*walletRebuildCon
 
 func (f *walletRebuildContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletRebuildContext, api.WalletRebuildData](
-		router, "rebuild", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "rebuild", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/recover.go
+++ b/rocketpool-daemon/api/wallet/recover.go
@@ -40,7 +40,7 @@ func (f *walletRecoverContextFactory) Create(args url.Values) (*walletRecoverCon
 
 func (f *walletRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletRecoverContext, api.WalletRecoverData](
-		router, "recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "recover", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/recover.go
+++ b/rocketpool-daemon/api/wallet/recover.go
@@ -40,7 +40,7 @@ func (f *walletRecoverContextFactory) Create(args url.Values) (*walletRecoverCon
 
 func (f *walletRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletRecoverContext, api.WalletRecoverData](
-		router, "recover", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/restore-address.go
+++ b/rocketpool-daemon/api/wallet/restore-address.go
@@ -27,7 +27,7 @@ func (f *walletRestoreAddressContextFactory) Create(args url.Values) (*walletRes
 
 func (f *walletRestoreAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletRestoreAddressContext, types.SuccessData](
-		router, "restore-address", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "restore-address", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/restore-address.go
+++ b/rocketpool-daemon/api/wallet/restore-address.go
@@ -27,7 +27,7 @@ func (f *walletRestoreAddressContextFactory) Create(args url.Values) (*walletRes
 
 func (f *walletRestoreAddressContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletRestoreAddressContext, types.SuccessData](
-		router, "restore-address", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "restore-address", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/search-and-recover.go
+++ b/rocketpool-daemon/api/wallet/search-and-recover.go
@@ -44,7 +44,7 @@ func (f *walletSearchAndRecoverContextFactory) Create(args url.Values) (*walletS
 
 func (f *walletSearchAndRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSearchAndRecoverContext, api.WalletSearchAndRecoverData](
-		router, "search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/search-and-recover.go
+++ b/rocketpool-daemon/api/wallet/search-and-recover.go
@@ -44,7 +44,7 @@ func (f *walletSearchAndRecoverContextFactory) Create(args url.Values) (*walletS
 
 func (f *walletSearchAndRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSearchAndRecoverContext, api.WalletSearchAndRecoverData](
-		router, "search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -64,7 +64,7 @@ type walletSearchAndRecoverContext struct {
 func (c *walletSearchAndRecoverContext) PrepareData(data *api.WalletSearchAndRecoverData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
 	w := sp.GetWallet()
-	rs := sp.GetNetworkResources()
+	rs := sp.GetResources()
 	vMgr := sp.GetValidatorManager()
 
 	// Requirements

--- a/rocketpool-daemon/api/wallet/send-message.go
+++ b/rocketpool-daemon/api/wallet/send-message.go
@@ -35,7 +35,7 @@ func (f *walletSendMessageContextFactory) Create(args url.Values) (*walletSendMe
 
 func (f *walletSendMessageContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSendMessageContext, types.TxInfoData](
-		router, "send-message", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "send-message", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/send-message.go
+++ b/rocketpool-daemon/api/wallet/send-message.go
@@ -35,7 +35,7 @@ func (f *walletSendMessageContextFactory) Create(args url.Values) (*walletSendMe
 
 func (f *walletSendMessageContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSendMessageContext, types.TxInfoData](
-		router, "send-message", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "send-message", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/set-ens-name.go
+++ b/rocketpool-daemon/api/wallet/set-ens-name.go
@@ -33,7 +33,7 @@ func (f *walletSetEnsNameContextFactory) Create(args url.Values) (*walletSetEnsN
 
 func (f *walletSetEnsNameContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSetEnsNameContext, api.WalletSetEnsNameData](
-		router, "set-ens-name", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "set-ens-name", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/set-ens-name.go
+++ b/rocketpool-daemon/api/wallet/set-ens-name.go
@@ -33,7 +33,7 @@ func (f *walletSetEnsNameContextFactory) Create(args url.Values) (*walletSetEnsN
 
 func (f *walletSetEnsNameContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSetEnsNameContext, api.WalletSetEnsNameData](
-		router, "set-ens-name", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "set-ens-name", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/set-password.go
+++ b/rocketpool-daemon/api/wallet/set-password.go
@@ -33,7 +33,7 @@ func (f *walletSetPasswordContextFactory) Create(args url.Values) (*walletSetPas
 
 func (f *walletSetPasswordContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSetPasswordContext, types.SuccessData](
-		router, "set-password", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "set-password", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/set-password.go
+++ b/rocketpool-daemon/api/wallet/set-password.go
@@ -33,7 +33,7 @@ func (f *walletSetPasswordContextFactory) Create(args url.Values) (*walletSetPas
 
 func (f *walletSetPasswordContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSetPasswordContext, types.SuccessData](
-		router, "set-password", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "set-password", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/sign-message.go
+++ b/rocketpool-daemon/api/wallet/sign-message.go
@@ -35,7 +35,7 @@ func (f *walletSignMessageContextFactory) Create(args url.Values) (*walletSignMe
 
 func (f *walletSignMessageContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSignMessageContext, api.WalletSignMessageData](
-		router, "sign-message", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "sign-message", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/sign-message.go
+++ b/rocketpool-daemon/api/wallet/sign-message.go
@@ -35,7 +35,7 @@ func (f *walletSignMessageContextFactory) Create(args url.Values) (*walletSignMe
 
 func (f *walletSignMessageContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSignMessageContext, api.WalletSignMessageData](
-		router, "sign-message", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "sign-message", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/sign-tx.go
+++ b/rocketpool-daemon/api/wallet/sign-tx.go
@@ -34,7 +34,7 @@ func (f *walletSignTxContextFactory) Create(args url.Values) (*walletSignTxConte
 
 func (f *walletSignTxContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSignTxContext, api.WalletSignTxData](
-		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/sign-tx.go
+++ b/rocketpool-daemon/api/wallet/sign-tx.go
@@ -34,7 +34,7 @@ func (f *walletSignTxContextFactory) Create(args url.Values) (*walletSignTxConte
 
 func (f *walletSignTxContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletSignTxContext, api.WalletSignTxData](
-		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "sign-tx", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/status.go
+++ b/rocketpool-daemon/api/wallet/status.go
@@ -28,7 +28,7 @@ func (f *walletStatusFactory) Create(args url.Values) (*walletStatusContext, err
 
 func (f *walletStatusFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletStatusContext, api.WalletStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/status.go
+++ b/rocketpool-daemon/api/wallet/status.go
@@ -28,7 +28,7 @@ func (f *walletStatusFactory) Create(args url.Values) (*walletStatusContext, err
 
 func (f *walletStatusFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletStatusContext, api.WalletStatusData](
-		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "status", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/test-recover.go
+++ b/rocketpool-daemon/api/wallet/test-recover.go
@@ -39,7 +39,7 @@ func (f *walletTestRecoverContextFactory) Create(args url.Values) (*walletTestRe
 
 func (f *walletTestRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletTestRecoverContext, api.WalletRecoverData](
-		router, "test-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "test-recover", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -57,7 +57,7 @@ type walletTestRecoverContext struct {
 
 func (c *walletTestRecoverContext) PrepareData(data *api.WalletRecoverData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
-	rs := sp.GetNetworkResources()
+	rs := sp.GetResources()
 	vMgr := sp.GetValidatorManager()
 
 	if !c.skipValidatorKeyRecovery {

--- a/rocketpool-daemon/api/wallet/test-recover.go
+++ b/rocketpool-daemon/api/wallet/test-recover.go
@@ -39,7 +39,7 @@ func (f *walletTestRecoverContextFactory) Create(args url.Values) (*walletTestRe
 
 func (f *walletTestRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletTestRecoverContext, api.WalletRecoverData](
-		router, "test-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "test-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/api/wallet/test-search-and-recover.go
+++ b/rocketpool-daemon/api/wallet/test-search-and-recover.go
@@ -38,7 +38,7 @@ func (f *walletTestSearchAndRecoverContextFactory) Create(args url.Values) (*wal
 
 func (f *walletTestSearchAndRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletTestSearchAndRecoverContext, api.WalletSearchAndRecoverData](
-		router, "test-search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
+		router, "test-search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider,
 	)
 }
 
@@ -55,7 +55,7 @@ type walletTestSearchAndRecoverContext struct {
 
 func (c *walletTestSearchAndRecoverContext) PrepareData(data *api.WalletSearchAndRecoverData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	sp := c.handler.serviceProvider
-	rs := sp.GetNetworkResources()
+	rs := sp.GetResources()
 	vMgr := sp.GetValidatorManager()
 
 	if !c.skipValidatorKeyRecovery {

--- a/rocketpool-daemon/api/wallet/test-search-and-recover.go
+++ b/rocketpool-daemon/api/wallet/test-search-and-recover.go
@@ -38,7 +38,7 @@ func (f *walletTestSearchAndRecoverContextFactory) Create(args url.Values) (*wal
 
 func (f *walletTestSearchAndRecoverContextFactory) RegisterRoute(router *mux.Router) {
 	server.RegisterQuerylessGet[*walletTestSearchAndRecoverContext, api.WalletSearchAndRecoverData](
-		router, "test-search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+		router, "test-search-and-recover", f, f.handler.logger.Logger, f.handler.serviceProvider.IServiceProvider,
 	)
 }
 

--- a/rocketpool-daemon/common/eth1/eth1.go
+++ b/rocketpool-daemon/common/eth1/eth1.go
@@ -17,9 +17,8 @@ import (
 )
 
 // Determines if the primary EC can be used for historical queries, or if the Archive EC is required
-func GetBestApiClient(primary *rocketpool.RocketPool, cfg *config.SmartNodeConfig, logger *slog.Logger, blockNumber *big.Int) (*rocketpool.RocketPool, error) {
+func GetBestApiClient(primary *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.RocketPoolResources, logger *slog.Logger, blockNumber *big.Int) (*rocketpool.RocketPool, error) {
 	client := primary
-	resources := cfg.GetRocketPoolResources()
 
 	// Try getting the rETH address as a canary to see if the block is available
 	opts := &bind.CallOpts{

--- a/rocketpool-daemon/common/eth1/eth1.go
+++ b/rocketpool-daemon/common/eth1/eth1.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Determines if the primary EC can be used for historical queries, or if the Archive EC is required
-func GetBestApiClient(primary *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.RocketPoolResources, logger *slog.Logger, blockNumber *big.Int) (*rocketpool.RocketPool, error) {
+func GetBestApiClient(primary *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.MergedResources, logger *slog.Logger, blockNumber *big.Int) (*rocketpool.RocketPool, error) {
 	client := primary
 
 	// Try getting the rETH address as a canary to see if the block is available

--- a/rocketpool-daemon/common/proposals/proposal-manager.go
+++ b/rocketpool-daemon/common/proposals/proposal-manager.go
@@ -28,7 +28,7 @@ type ProposalManager struct {
 	bc     beacon.IBeaconClient
 }
 
-func NewProposalManager(context context.Context, logger *slog.Logger, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, bc beacon.IBeaconClient) (*ProposalManager, error) {
+func NewProposalManager(context context.Context, logger *slog.Logger, cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, bc beacon.IBeaconClient) (*ProposalManager, error) {
 	viSnapshotMgr, err := NewVotingInfoSnapshotManager(logger, cfg, rp)
 	if err != nil {
 		return nil, fmt.Errorf("error creating voting info manager: %w", err)

--- a/rocketpool-daemon/common/proposals/proposal-manager.go
+++ b/rocketpool-daemon/common/proposals/proposal-manager.go
@@ -28,7 +28,7 @@ type ProposalManager struct {
 	bc     beacon.IBeaconClient
 }
 
-func NewProposalManager(context context.Context, logger *slog.Logger, cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, bc beacon.IBeaconClient) (*ProposalManager, error) {
+func NewProposalManager(context context.Context, logger *slog.Logger, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, bc beacon.IBeaconClient) (*ProposalManager, error) {
 	viSnapshotMgr, err := NewVotingInfoSnapshotManager(logger, cfg, rp)
 	if err != nil {
 		return nil, fmt.Errorf("error creating voting info manager: %w", err)
@@ -44,7 +44,7 @@ func NewProposalManager(context context.Context, logger *slog.Logger, cfg *confi
 		return nil, fmt.Errorf("error creating node tree manager: %w", err)
 	}
 
-	stateMgr, err := state.NewNetworkStateManager(context, rp, cfg, rp.Client, bc, logger)
+	stateMgr, err := state.NewNetworkStateManager(context, rp, cfg, res, rp.Client, bc, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating network state manager: %w", err)
 	}

--- a/rocketpool-daemon/common/rewards/generator-impl-v8-rolling.go
+++ b/rocketpool-daemon/common/rewards/generator-impl-v8-rolling.go
@@ -33,7 +33,7 @@ type treeGeneratorImpl_v8_rolling struct {
 	logger               *slog.Logger
 	rp                   *rocketpool.RocketPool
 	cfg                  *config.SmartNodeConfig
-	res                  *config.RocketPoolResources
+	res                  *config.MergedResources
 	bc                   beacon.IBeaconClient
 	opts                 *bind.CallOpts
 	smoothingPoolBalance *big.Int
@@ -97,7 +97,7 @@ func (r *treeGeneratorImpl_v8_rolling) getRulesetVersion() uint64 {
 	return r.rewardsFile.RulesetVersion
 }
 
-func (r *treeGeneratorImpl_v8_rolling) generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error) {
+func (r *treeGeneratorImpl_v8_rolling) generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error) {
 	r.logger.Info("Started rewards tree generation.", slog.Uint64(keys.RulesetKey, r.rewardsFile.RulesetVersion))
 
 	// Provision some struct params
@@ -168,7 +168,7 @@ func (r *treeGeneratorImpl_v8_rolling) generateTree(context context.Context, rp 
 
 // Quickly calculates an approximate of the staker's share of the smoothing pool balance without processing Beacon performance
 // Used for approximate returns in the rETH ratio update
-func (r *treeGeneratorImpl_v8_rolling) approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*big.Int, error) {
+func (r *treeGeneratorImpl_v8_rolling) approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (*big.Int, error) {
 	r.logger.Info("Approximating rewards tree.", slog.Uint64(keys.RulesetKey, r.rewardsFile.RulesetVersion))
 
 	r.rp = rp

--- a/rocketpool-daemon/common/rewards/generator-impl-v8-rolling.go
+++ b/rocketpool-daemon/common/rewards/generator-impl-v8-rolling.go
@@ -33,6 +33,7 @@ type treeGeneratorImpl_v8_rolling struct {
 	logger               *slog.Logger
 	rp                   *rocketpool.RocketPool
 	cfg                  *config.SmartNodeConfig
+	res                  *config.RocketPoolResources
 	bc                   beacon.IBeaconClient
 	opts                 *bind.CallOpts
 	smoothingPoolBalance *big.Int
@@ -96,12 +97,13 @@ func (r *treeGeneratorImpl_v8_rolling) getRulesetVersion() uint64 {
 	return r.rewardsFile.RulesetVersion
 }
 
-func (r *treeGeneratorImpl_v8_rolling) generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error) {
+func (r *treeGeneratorImpl_v8_rolling) generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error) {
 	r.logger.Info("Started rewards tree generation.", slog.Uint64(keys.RulesetKey, r.rewardsFile.RulesetVersion))
 
 	// Provision some struct params
 	r.rp = rp
 	r.cfg = cfg
+	r.res = res
 	r.bc = bc
 	r.validNetworkCache = map[uint64]bool{
 		0: true,
@@ -166,11 +168,12 @@ func (r *treeGeneratorImpl_v8_rolling) generateTree(context context.Context, rp 
 
 // Quickly calculates an approximate of the staker's share of the smoothing pool balance without processing Beacon performance
 // Used for approximate returns in the rETH ratio update
-func (r *treeGeneratorImpl_v8_rolling) approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient) (*big.Int, error) {
+func (r *treeGeneratorImpl_v8_rolling) approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*big.Int, error) {
 	r.logger.Info("Approximating rewards tree.", slog.Uint64(keys.RulesetKey, r.rewardsFile.RulesetVersion))
 
 	r.rp = rp
 	r.cfg = cfg
+	r.res = res
 	r.bc = bc
 	r.validNetworkCache = map[uint64]bool{
 		0: true,

--- a/rocketpool-daemon/common/rewards/generator-impl-v8.go
+++ b/rocketpool-daemon/common/rewards/generator-impl-v8.go
@@ -36,7 +36,7 @@ type treeGeneratorImpl_v8 struct {
 	logger                 *slog.Logger
 	rp                     *rocketpool.RocketPool
 	cfg                    *config.SmartNodeConfig
-	res                    *config.RocketPoolResources
+	res                    *config.MergedResources
 	bc                     beacon.IBeaconClient
 	opts                   *bind.CallOpts
 	nodeDetails            []*NodeSmoothingDetails
@@ -104,7 +104,7 @@ func (r *treeGeneratorImpl_v8) getRulesetVersion() uint64 {
 	return r.rewardsFile.RulesetVersion
 }
 
-func (r *treeGeneratorImpl_v8) generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error) {
+func (r *treeGeneratorImpl_v8) generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error) {
 	r.logger.Info("Started rewards tree generation.", slog.Uint64(keys.RulesetKey, r.rewardsFile.RulesetVersion))
 
 	// Provision some struct params
@@ -176,7 +176,7 @@ func (r *treeGeneratorImpl_v8) generateTree(context context.Context, rp *rocketp
 
 // Quickly calculates an approximate of the staker's share of the smoothing pool balance without processing Beacon performance
 // Used for approximate returns in the rETH ratio update
-func (r *treeGeneratorImpl_v8) approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*big.Int, error) {
+func (r *treeGeneratorImpl_v8) approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (*big.Int, error) {
 	r.logger.Info("Approximating rewards tree.", slog.Uint64(keys.RulesetKey, r.rewardsFile.RulesetVersion))
 
 	r.rp = rp

--- a/rocketpool-daemon/common/rewards/generator.go
+++ b/rocketpool-daemon/common/rewards/generator.go
@@ -53,7 +53,7 @@ type TreeGenerator struct {
 	logger               *slog.Logger
 	rp                   *rocketpool.RocketPool
 	cfg                  *config.SmartNodeConfig
-	res                  *config.RocketPoolResources
+	res                  *config.MergedResources
 	bc                   beacon.IBeaconClient
 	index                uint64
 	startTime            time.Time
@@ -66,12 +66,12 @@ type TreeGenerator struct {
 }
 
 type treeGeneratorImpl interface {
-	generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error)
-	approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*big.Int, error)
+	generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error)
+	approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (*big.Int, error)
 	getRulesetVersion() uint64
 }
 
-func NewTreeGenerator(logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient, index uint64, startTime time.Time, endTime time.Time, consensusBlock uint64, elSnapshotHeader *types.Header, intervalsPassed uint64, state *state.NetworkState, rollingRecord *RollingRecord) (*TreeGenerator, error) {
+func NewTreeGenerator(logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient, index uint64, startTime time.Time, endTime time.Time, consensusBlock uint64, elSnapshotHeader *types.Header, intervalsPassed uint64, state *state.NetworkState, rollingRecord *RollingRecord) (*TreeGenerator, error) {
 	t := &TreeGenerator{
 		logger:           logger,
 		rp:               rp,

--- a/rocketpool-daemon/common/rewards/generator.go
+++ b/rocketpool-daemon/common/rewards/generator.go
@@ -53,6 +53,7 @@ type TreeGenerator struct {
 	logger               *slog.Logger
 	rp                   *rocketpool.RocketPool
 	cfg                  *config.SmartNodeConfig
+	res                  *config.RocketPoolResources
 	bc                   beacon.IBeaconClient
 	index                uint64
 	startTime            time.Time
@@ -65,16 +66,17 @@ type TreeGenerator struct {
 }
 
 type treeGeneratorImpl interface {
-	generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error)
-	approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient) (*big.Int, error)
+	generateTree(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (sharedtypes.IRewardsFile, error)
+	approximateStakerShareOfSmoothingPool(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*big.Int, error)
 	getRulesetVersion() uint64
 }
 
-func NewTreeGenerator(logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient, index uint64, startTime time.Time, endTime time.Time, consensusBlock uint64, elSnapshotHeader *types.Header, intervalsPassed uint64, state *state.NetworkState, rollingRecord *RollingRecord) (*TreeGenerator, error) {
+func NewTreeGenerator(logger *slog.Logger, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient, index uint64, startTime time.Time, endTime time.Time, consensusBlock uint64, elSnapshotHeader *types.Header, intervalsPassed uint64, state *state.NetworkState, rollingRecord *RollingRecord) (*TreeGenerator, error) {
 	t := &TreeGenerator{
 		logger:           logger,
 		rp:               rp,
 		cfg:              cfg,
+		res:              res,
 		bc:               bc,
 		index:            index,
 		startTime:        startTime,
@@ -196,11 +198,11 @@ func NewTreeGenerator(logger *slog.Logger, rp *rocketpool.RocketPool, cfg *confi
 }
 
 func (t *TreeGenerator) GenerateTree(context context.Context) (sharedtypes.IRewardsFile, error) {
-	return t.generatorImpl.generateTree(context, t.rp, t.cfg, t.bc)
+	return t.generatorImpl.generateTree(context, t.rp, t.cfg, t.res, t.bc)
 }
 
 func (t *TreeGenerator) ApproximateStakerShareOfSmoothingPool(context context.Context) (*big.Int, error) {
-	return t.approximatorImpl.approximateStakerShareOfSmoothingPool(context, t.rp, t.cfg, t.bc)
+	return t.approximatorImpl.approximateStakerShareOfSmoothingPool(context, t.rp, t.cfg, t.res, t.bc)
 }
 
 func (t *TreeGenerator) GetGeneratorRulesetVersion() uint64 {
@@ -220,7 +222,7 @@ func (t *TreeGenerator) GenerateTreeWithRuleset(context context.Context, ruleset
 	if info.generator == nil {
 		return nil, fmt.Errorf("ruleset v%d is obsolete and no longer supported by this Smart Node", ruleset)
 	}
-	return info.generator.generateTree(context, t.rp, t.cfg, t.bc)
+	return info.generator.generateTree(context, t.rp, t.cfg, t.res, t.bc)
 }
 
 func (t *TreeGenerator) ApproximateStakerShareOfSmoothingPoolWithRuleset(context context.Context, ruleset uint64) (*big.Int, error) {
@@ -232,7 +234,7 @@ func (t *TreeGenerator) ApproximateStakerShareOfSmoothingPoolWithRuleset(context
 	if info.generator == nil {
 		return nil, fmt.Errorf("ruleset v%d is obsolete and no longer supported by this Smart Node", ruleset)
 	}
-	return info.generator.approximateStakerShareOfSmoothingPool(context, t.rp, t.cfg, t.bc)
+	return info.generator.approximateStakerShareOfSmoothingPool(context, t.rp, t.cfg, t.res, t.bc)
 }
 
 // Gets the ruleset to use for rewards calculation and rewards approximation respectively for a given interval

--- a/rocketpool-daemon/common/rewards/rolling-manager.go
+++ b/rocketpool-daemon/common/rewards/rolling-manager.go
@@ -41,6 +41,7 @@ type RollingRecordManager struct {
 
 	logger          *slog.Logger
 	cfg             *config.SmartNodeConfig
+	res             *config.RocketPoolResources
 	rp              *rocketpool.RocketPool
 	bc              beacon.IBeaconClient
 	mgr             *state.NetworkStateManager
@@ -55,7 +56,7 @@ type RollingRecordManager struct {
 }
 
 // Creates a new manager for rolling records.
-func NewRollingRecordManager(logger *slog.Logger, cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, bc beacon.IBeaconClient, mgr *state.NetworkStateManager, startSlot uint64, beaconCfg beacon.Eth2Config, rewardsInterval uint64) (*RollingRecordManager, error) {
+func NewRollingRecordManager(logger *slog.Logger, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, bc beacon.IBeaconClient, mgr *state.NetworkStateManager, startSlot uint64, beaconCfg beacon.Eth2Config, rewardsInterval uint64) (*RollingRecordManager, error) {
 	// Get the Beacon genesis time
 	genesisTime := time.Unix(int64(beaconCfg.GenesisTime), 0)
 
@@ -94,6 +95,7 @@ func NewRollingRecordManager(logger *slog.Logger, cfg *config.SmartNodeConfig, r
 
 		logger:               sublogger,
 		cfg:                  cfg,
+		res:                  res,
 		rp:                   rp,
 		bc:                   bc,
 		mgr:                  mgr,
@@ -619,8 +621,7 @@ func (r *RollingRecordManager) createNewRecord(context context.Context, state *s
 	currentIndex := rewardsPool.RewardIndex.Formatted()
 
 	// Get the last rewards event and starting epoch
-	resources := r.cfg.GetRocketPoolResources()
-	found, event, err := rewardsPool.GetRewardsEvent(r.rp, currentIndex-1, resources.PreviousRewardsPoolAddresses, nil)
+	found, event, err := rewardsPool.GetRewardsEvent(r.rp, currentIndex-1, r.res.PreviousRewardsPoolAddresses, nil)
 	if err != nil {
 		return fmt.Errorf("error getting event for rewards interval %d: %w", currentIndex-1, err)
 	}

--- a/rocketpool-daemon/common/rewards/rolling-manager.go
+++ b/rocketpool-daemon/common/rewards/rolling-manager.go
@@ -41,7 +41,7 @@ type RollingRecordManager struct {
 
 	logger          *slog.Logger
 	cfg             *config.SmartNodeConfig
-	res             *config.RocketPoolResources
+	res             *config.MergedResources
 	rp              *rocketpool.RocketPool
 	bc              beacon.IBeaconClient
 	mgr             *state.NetworkStateManager
@@ -56,7 +56,7 @@ type RollingRecordManager struct {
 }
 
 // Creates a new manager for rolling records.
-func NewRollingRecordManager(logger *slog.Logger, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, bc beacon.IBeaconClient, mgr *state.NetworkStateManager, startSlot uint64, beaconCfg beacon.Eth2Config, rewardsInterval uint64) (*RollingRecordManager, error) {
+func NewRollingRecordManager(logger *slog.Logger, cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, bc beacon.IBeaconClient, mgr *state.NetworkStateManager, startSlot uint64, beaconCfg beacon.Eth2Config, rewardsInterval uint64) (*RollingRecordManager, error) {
 	// Get the Beacon genesis time
 	genesisTime := time.Unix(int64(beaconCfg.GenesisTime), 0)
 

--- a/rocketpool-daemon/common/rewards/utils.go
+++ b/rocketpool-daemon/common/rewards/utils.go
@@ -95,7 +95,7 @@ func GetClaimStatus(rp *rocketpool.RocketPool, nodeAddress common.Address, curre
 }
 
 // Gets the information for an interval including the file status, the validity, and the node's rewards
-func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.RocketPoolResources, nodeAddress common.Address, interval uint64, opts *bind.CallOpts) (info sharedtypes.IntervalInfo, err error) {
+func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.MergedResources, nodeAddress common.Address, interval uint64, opts *bind.CallOpts) (info sharedtypes.IntervalInfo, err error) {
 	info.Index = interval
 	var event rewards.RewardsEvent
 
@@ -161,7 +161,7 @@ func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res
 }
 
 // Get the event for a rewards snapshot
-func GetRewardSnapshotEvent(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.RocketPoolResources, interval uint64, opts *bind.CallOpts) (rewards.RewardsEvent, error) {
+func GetRewardSnapshotEvent(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.MergedResources, interval uint64, opts *bind.CallOpts) (rewards.RewardsEvent, error) {
 	rewardsPool, err := rewards.NewRewardsPool(rp)
 	if err != nil {
 		return rewards.RewardsEvent{}, fmt.Errorf("error getting rewards pool binding: %w", err)

--- a/rocketpool-daemon/common/rewards/utils.go
+++ b/rocketpool-daemon/common/rewards/utils.go
@@ -95,12 +95,12 @@ func GetClaimStatus(rp *rocketpool.RocketPool, nodeAddress common.Address, curre
 }
 
 // Gets the information for an interval including the file status, the validity, and the node's rewards
-func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, nodeAddress common.Address, interval uint64, opts *bind.CallOpts) (info sharedtypes.IntervalInfo, err error) {
+func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.RocketPoolResources, nodeAddress common.Address, interval uint64, opts *bind.CallOpts) (info sharedtypes.IntervalInfo, err error) {
 	info.Index = interval
 	var event rewards.RewardsEvent
 
 	// Get the event details for this interval
-	event, err = GetRewardSnapshotEvent(rp, cfg, interval, opts)
+	event, err = GetRewardSnapshotEvent(rp, cfg, resources, interval, opts)
 	if err != nil {
 		return
 	}
@@ -161,8 +161,7 @@ func GetIntervalInfo(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, nod
 }
 
 // Get the event for a rewards snapshot
-func GetRewardSnapshotEvent(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, interval uint64, opts *bind.CallOpts) (rewards.RewardsEvent, error) {
-	resources := cfg.GetRocketPoolResources()
+func GetRewardSnapshotEvent(rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, resources *config.RocketPoolResources, interval uint64, opts *bind.CallOpts) (rewards.RewardsEvent, error) {
 	rewardsPool, err := rewards.NewRewardsPool(rp)
 	if err != nil {
 		return rewards.RewardsEvent{}, fmt.Errorf("error getting rewards pool binding: %w", err)

--- a/rocketpool-daemon/common/services/requirements.go
+++ b/rocketpool-daemon/common/services/requirements.go
@@ -50,7 +50,7 @@ var (
 // === Requirements ===
 // ====================
 
-func (p *ServiceProvider) RequireRocketPoolContracts(ctx context.Context) (types.ResponseStatus, error) {
+func (p *SmartNodeServiceProvider) RequireRocketPoolContracts(ctx context.Context) (types.ResponseStatus, error) {
 	err := p.RequireEthClientSynced(ctx)
 	if err != nil {
 		return types.ResponseStatus_ClientsNotSynced, err
@@ -62,7 +62,7 @@ func (p *ServiceProvider) RequireRocketPoolContracts(ctx context.Context) (types
 	return types.ResponseStatus_Success, nil
 }
 
-func (p *ServiceProvider) RequireEthClientSynced(ctx context.Context) error {
+func (p *SmartNodeServiceProvider) RequireEthClientSynced(ctx context.Context) error {
 	synced, _, err := p.checkExecutionClientStatus(ctx)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func (p *ServiceProvider) RequireEthClientSynced(ctx context.Context) error {
 	return errors.New("The Execution client is currently syncing. Please try again later.")
 }
 
-func (p *ServiceProvider) RequireBeaconClientSynced(ctx context.Context) error {
+func (p *SmartNodeServiceProvider) RequireBeaconClientSynced(ctx context.Context) error {
 	synced, err := p.checkBeaconClientStatus(ctx)
 	if err != nil {
 		return err
@@ -85,18 +85,18 @@ func (p *ServiceProvider) RequireBeaconClientSynced(ctx context.Context) error {
 }
 
 // Wait for the Executon client to sync; timeout of 0 indicates no timeout
-func (p *ServiceProvider) WaitEthClientSynced(ctx context.Context, verbose bool) error {
+func (p *SmartNodeServiceProvider) WaitEthClientSynced(ctx context.Context, verbose bool) error {
 	_, err := p.waitEthClientSynced(ctx, verbose)
 	return err
 }
 
 // Wait for the Beacon client to sync; timeout of 0 indicates no timeout
-func (p *ServiceProvider) WaitBeaconClientSynced(ctx context.Context, verbose bool) error {
+func (p *SmartNodeServiceProvider) WaitBeaconClientSynced(ctx context.Context, verbose bool) error {
 	_, err := p.waitBeaconClientSynced(ctx, verbose)
 	return err
 }
 
-func (p *ServiceProvider) RequireNodeAddress() error {
+func (p *SmartNodeServiceProvider) RequireNodeAddress() error {
 	status, err := p.GetWallet().GetStatus()
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (p *ServiceProvider) RequireNodeAddress() error {
 	return nil
 }
 
-func (p *ServiceProvider) RequireWalletReady() error {
+func (p *SmartNodeServiceProvider) RequireWalletReady() error {
 	status, err := p.GetWallet().GetStatus()
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func (p *ServiceProvider) RequireWalletReady() error {
 	return utils.CheckIfWalletReady(status)
 }
 
-func (p *ServiceProvider) RequireNodeRegistered(ctx context.Context) (types.ResponseStatus, error) {
+func (p *SmartNodeServiceProvider) RequireNodeRegistered(ctx context.Context) (types.ResponseStatus, error) {
 	if err := p.RequireNodeAddress(); err != nil {
 		return types.ResponseStatus_AddressNotPresent, err
 	}
@@ -132,7 +132,7 @@ func (p *ServiceProvider) RequireNodeRegistered(ctx context.Context) (types.Resp
 	return types.ResponseStatus_Success, nil
 }
 
-func (p *ServiceProvider) RequireSnapshot() error {
+func (p *SmartNodeServiceProvider) RequireSnapshot() error {
 	if p.snapshotDelegation == nil {
 		network := string(p.cfg.Network.Value)
 		return fmt.Errorf("Snapshot voting is not available on the %s network.", network)
@@ -140,7 +140,7 @@ func (p *ServiceProvider) RequireSnapshot() error {
 	return nil
 }
 
-func (p *ServiceProvider) RequireOnOracleDao(ctx context.Context) (types.ResponseStatus, error) {
+func (p *SmartNodeServiceProvider) RequireOnOracleDao(ctx context.Context) (types.ResponseStatus, error) {
 	if err := p.RequireNodeAddress(); err != nil {
 		return types.ResponseStatus_AddressNotPresent, err
 	}
@@ -157,7 +157,7 @@ func (p *ServiceProvider) RequireOnOracleDao(ctx context.Context) (types.Respons
 	return types.ResponseStatus_Success, nil
 }
 
-func (p *ServiceProvider) RequireOnSecurityCouncil(ctx context.Context) (types.ResponseStatus, error) {
+func (p *SmartNodeServiceProvider) RequireOnSecurityCouncil(ctx context.Context) (types.ResponseStatus, error) {
 	if err := p.RequireNodeAddress(); err != nil {
 		return types.ResponseStatus_AddressNotPresent, err
 	}
@@ -178,7 +178,7 @@ func (p *ServiceProvider) RequireOnSecurityCouncil(ctx context.Context) (types.R
 // === Service Synchronization ===
 // ===============================
 
-func (p *ServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) error {
+func (p *SmartNodeServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) error {
 	// Get the logger
 	logger, exists := log.FromContext(ctx)
 	if !exists {
@@ -207,7 +207,7 @@ func (p *ServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) err
 	}
 }
 
-func (p *ServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) error {
+func (p *SmartNodeServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) error {
 	// Get the logger
 	logger, exists := log.FromContext(ctx)
 	if !exists {
@@ -249,7 +249,7 @@ func (p *ServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) err
 }
 
 // Wait until the node has been registered with the Rocket Pool network
-func (p *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool) error {
+func (p *SmartNodeServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool) error {
 	// Get the logger
 	logger, exists := log.FromContext(ctx)
 	if !exists {
@@ -287,7 +287,7 @@ func (p *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool) 
 // ===============
 
 // Check if the node is registered
-func (p *ServiceProvider) getNodeRegistered() (bool, error) {
+func (p *SmartNodeServiceProvider) getNodeRegistered() (bool, error) {
 	rp := p.rocketPool
 	address, _ := p.GetWallet().GetAddress()
 
@@ -306,7 +306,7 @@ func (p *ServiceProvider) getNodeRegistered() (bool, error) {
 }
 
 // Check if the node is a member of the oracle DAO
-func (p *ServiceProvider) isMemberOfOracleDao() (bool, error) {
+func (p *SmartNodeServiceProvider) isMemberOfOracleDao() (bool, error) {
 	rp := p.rocketPool
 	address, _ := p.GetWallet().GetAddress()
 
@@ -329,7 +329,7 @@ func (p *ServiceProvider) isMemberOfOracleDao() (bool, error) {
 }
 
 // Check if the node is a member of the security council
-func (p *ServiceProvider) isMemberOfSecurityCouncil() (bool, error) {
+func (p *SmartNodeServiceProvider) isMemberOfSecurityCouncil() (bool, error) {
 	rp := p.rocketPool
 	address, _ := p.GetWallet().GetAddress()
 
@@ -353,7 +353,7 @@ func (p *ServiceProvider) isMemberOfSecurityCouncil() (bool, error) {
 
 // Check if the primary and fallback Execution clients are synced
 // TODO: Move this into ec-manager and stop exposing the primary and fallback directly...
-func (p *ServiceProvider) checkExecutionClientStatus(ctx context.Context) (bool, eth.IExecutionClient, error) {
+func (p *SmartNodeServiceProvider) checkExecutionClientStatus(ctx context.Context) (bool, eth.IExecutionClient, error) {
 	// Check the EC status
 	ecMgr := p.GetEthClient()
 	mgrStatus := ecMgr.CheckStatus(ctx, true)
@@ -400,7 +400,7 @@ func (p *ServiceProvider) checkExecutionClientStatus(ctx context.Context) (bool,
 }
 
 // Check if the primary and fallback Beacon clients are synced
-func (p *ServiceProvider) checkBeaconClientStatus(ctx context.Context) (bool, error) {
+func (p *SmartNodeServiceProvider) checkBeaconClientStatus(ctx context.Context) (bool, error) {
 	// Check the BC status
 	bcMgr := p.GetBeaconClient()
 	mgrStatus := bcMgr.CheckStatus(ctx, true)
@@ -447,7 +447,7 @@ func (p *ServiceProvider) checkBeaconClientStatus(ctx context.Context) (bool, er
 }
 
 // Wait for the primary or fallback Execution client to be synced
-func (p *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool) (bool, error) {
+func (p *SmartNodeServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool) (bool, error) {
 	// Prevent multiple waiting goroutines from requesting sync progress
 	ethClientSyncLock.Lock()
 	defer ethClientSyncLock.Unlock()
@@ -529,7 +529,7 @@ func (p *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool)
 }
 
 // Wait for the primary or fallback Beacon client to be synced
-func (p *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose bool) (bool, error) {
+func (p *SmartNodeServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose bool) (bool, error) {
 	// Prevent multiple waiting goroutines from requesting sync progress
 	beaconClientSyncLock.Lock()
 	defer beaconClientSyncLock.Unlock()

--- a/rocketpool-daemon/common/services/requirements.go
+++ b/rocketpool-daemon/common/services/requirements.go
@@ -50,20 +50,20 @@ var (
 // === Requirements ===
 // ====================
 
-func (sp *ServiceProvider) RequireRocketPoolContracts(ctx context.Context) (types.ResponseStatus, error) {
-	err := sp.RequireEthClientSynced(ctx)
+func (p *ServiceProvider) RequireRocketPoolContracts(ctx context.Context) (types.ResponseStatus, error) {
+	err := p.RequireEthClientSynced(ctx)
 	if err != nil {
 		return types.ResponseStatus_ClientsNotSynced, err
 	}
-	err = sp.RefreshRocketPoolContracts()
+	err = p.RefreshRocketPoolContracts()
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}
 	return types.ResponseStatus_Success, nil
 }
 
-func (sp *ServiceProvider) RequireEthClientSynced(ctx context.Context) error {
-	synced, _, err := sp.checkExecutionClientStatus(ctx)
+func (p *ServiceProvider) RequireEthClientSynced(ctx context.Context) error {
+	synced, _, err := p.checkExecutionClientStatus(ctx)
 	if err != nil {
 		return err
 	}
@@ -73,8 +73,8 @@ func (sp *ServiceProvider) RequireEthClientSynced(ctx context.Context) error {
 	return errors.New("The Execution client is currently syncing. Please try again later.")
 }
 
-func (sp *ServiceProvider) RequireBeaconClientSynced(ctx context.Context) error {
-	synced, err := sp.checkBeaconClientStatus(ctx)
+func (p *ServiceProvider) RequireBeaconClientSynced(ctx context.Context) error {
+	synced, err := p.checkBeaconClientStatus(ctx)
 	if err != nil {
 		return err
 	}
@@ -85,19 +85,19 @@ func (sp *ServiceProvider) RequireBeaconClientSynced(ctx context.Context) error 
 }
 
 // Wait for the Executon client to sync; timeout of 0 indicates no timeout
-func (sp *ServiceProvider) WaitEthClientSynced(ctx context.Context, verbose bool) error {
-	_, err := sp.waitEthClientSynced(ctx, verbose)
+func (p *ServiceProvider) WaitEthClientSynced(ctx context.Context, verbose bool) error {
+	_, err := p.waitEthClientSynced(ctx, verbose)
 	return err
 }
 
 // Wait for the Beacon client to sync; timeout of 0 indicates no timeout
-func (sp *ServiceProvider) WaitBeaconClientSynced(ctx context.Context, verbose bool) error {
-	_, err := sp.waitBeaconClientSynced(ctx, verbose)
+func (p *ServiceProvider) WaitBeaconClientSynced(ctx context.Context, verbose bool) error {
+	_, err := p.waitBeaconClientSynced(ctx, verbose)
 	return err
 }
 
-func (sp *ServiceProvider) RequireNodeAddress() error {
-	status, err := sp.GetWallet().GetStatus()
+func (p *ServiceProvider) RequireNodeAddress() error {
+	status, err := p.GetWallet().GetStatus()
 	if err != nil {
 		return err
 	}
@@ -107,22 +107,22 @@ func (sp *ServiceProvider) RequireNodeAddress() error {
 	return nil
 }
 
-func (sp *ServiceProvider) RequireWalletReady() error {
-	status, err := sp.GetWallet().GetStatus()
+func (p *ServiceProvider) RequireWalletReady() error {
+	status, err := p.GetWallet().GetStatus()
 	if err != nil {
 		return err
 	}
 	return utils.CheckIfWalletReady(status)
 }
 
-func (sp *ServiceProvider) RequireNodeRegistered(ctx context.Context) (types.ResponseStatus, error) {
-	if err := sp.RequireNodeAddress(); err != nil {
+func (p *ServiceProvider) RequireNodeRegistered(ctx context.Context) (types.ResponseStatus, error) {
+	if err := p.RequireNodeAddress(); err != nil {
 		return types.ResponseStatus_AddressNotPresent, err
 	}
-	if status, err := sp.RequireRocketPoolContracts(ctx); err != nil {
+	if status, err := p.RequireRocketPoolContracts(ctx); err != nil {
 		return status, err
 	}
-	nodeRegistered, err := sp.getNodeRegistered()
+	nodeRegistered, err := p.getNodeRegistered()
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}
@@ -132,22 +132,22 @@ func (sp *ServiceProvider) RequireNodeRegistered(ctx context.Context) (types.Res
 	return types.ResponseStatus_Success, nil
 }
 
-func (sp *ServiceProvider) RequireSnapshot() error {
-	if sp.snapshotDelegation == nil {
-		network := string(sp.cfg.Network.Value)
+func (p *ServiceProvider) RequireSnapshot() error {
+	if p.snapshotDelegation == nil {
+		network := string(p.cfg.Network.Value)
 		return fmt.Errorf("Snapshot voting is not available on the %s network.", network)
 	}
 	return nil
 }
 
-func (sp *ServiceProvider) RequireOnOracleDao(ctx context.Context) (types.ResponseStatus, error) {
-	if err := sp.RequireNodeAddress(); err != nil {
+func (p *ServiceProvider) RequireOnOracleDao(ctx context.Context) (types.ResponseStatus, error) {
+	if err := p.RequireNodeAddress(); err != nil {
 		return types.ResponseStatus_AddressNotPresent, err
 	}
-	if status, err := sp.RequireRocketPoolContracts(ctx); err != nil {
+	if status, err := p.RequireRocketPoolContracts(ctx); err != nil {
 		return status, err
 	}
-	nodeTrusted, err := sp.isMemberOfOracleDao()
+	nodeTrusted, err := p.isMemberOfOracleDao()
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}
@@ -157,14 +157,14 @@ func (sp *ServiceProvider) RequireOnOracleDao(ctx context.Context) (types.Respon
 	return types.ResponseStatus_Success, nil
 }
 
-func (sp *ServiceProvider) RequireOnSecurityCouncil(ctx context.Context) (types.ResponseStatus, error) {
-	if err := sp.RequireNodeAddress(); err != nil {
+func (p *ServiceProvider) RequireOnSecurityCouncil(ctx context.Context) (types.ResponseStatus, error) {
+	if err := p.RequireNodeAddress(); err != nil {
 		return types.ResponseStatus_AddressNotPresent, err
 	}
-	if status, err := sp.RequireRocketPoolContracts(ctx); err != nil {
+	if status, err := p.RequireRocketPoolContracts(ctx); err != nil {
 		return status, err
 	}
-	nodeTrusted, err := sp.isMemberOfSecurityCouncil()
+	nodeTrusted, err := p.isMemberOfSecurityCouncil()
 	if err != nil {
 		return types.ResponseStatus_Error, err
 	}
@@ -178,7 +178,7 @@ func (sp *ServiceProvider) RequireOnSecurityCouncil(ctx context.Context) (types.
 // === Service Synchronization ===
 // ===============================
 
-func (sp *ServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) error {
+func (p *ServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) error {
 	// Get the logger
 	logger, exists := log.FromContext(ctx)
 	if !exists {
@@ -186,7 +186,7 @@ func (sp *ServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) er
 	}
 
 	for {
-		status, err := sp.GetWallet().GetStatus()
+		status, err := p.GetWallet().GetStatus()
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func (sp *ServiceProvider) WaitNodeAddress(ctx context.Context, verbose bool) er
 	}
 }
 
-func (sp *ServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) error {
+func (p *ServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) error {
 	// Get the logger
 	logger, exists := log.FromContext(ctx)
 	if !exists {
@@ -215,7 +215,7 @@ func (sp *ServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) er
 	}
 
 	for {
-		status, err := sp.GetWallet().GetStatus()
+		status, err := p.GetWallet().GetStatus()
 		if err != nil {
 			return err
 		}
@@ -249,7 +249,7 @@ func (sp *ServiceProvider) WaitWalletReady(ctx context.Context, verbose bool) er
 }
 
 // Wait until the node has been registered with the Rocket Pool network
-func (sp *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool) error {
+func (p *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool) error {
 	// Get the logger
 	logger, exists := log.FromContext(ctx)
 	if !exists {
@@ -258,7 +258,7 @@ func (sp *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool)
 
 	contractRefreshTime := time.Now()
 	for {
-		nodeRegistered, err := sp.getNodeRegistered()
+		nodeRegistered, err := p.getNodeRegistered()
 		if err != nil {
 			return err
 		}
@@ -274,7 +274,7 @@ func (sp *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool)
 
 		// Refresh the contracts if needed to make sure we're polling the latest ones
 		if time.Since(contractRefreshTime) > contractRefreshInterval {
-			if err := sp.RefreshRocketPoolContracts(); err != nil {
+			if err := p.RefreshRocketPoolContracts(); err != nil {
 				return fmt.Errorf("error refreshing contract bindings: %w", err)
 			}
 			contractRefreshTime = time.Now()
@@ -287,9 +287,9 @@ func (sp *ServiceProvider) WaitNodeRegistered(ctx context.Context, verbose bool)
 // ===============
 
 // Check if the node is registered
-func (sp *ServiceProvider) getNodeRegistered() (bool, error) {
-	rp := sp.rocketPool
-	address, _ := sp.GetWallet().GetAddress()
+func (p *ServiceProvider) getNodeRegistered() (bool, error) {
+	rp := p.rocketPool
+	address, _ := p.GetWallet().GetAddress()
 
 	// Create a node binding
 	node, err := node.NewNode(rp, address)
@@ -306,9 +306,9 @@ func (sp *ServiceProvider) getNodeRegistered() (bool, error) {
 }
 
 // Check if the node is a member of the oracle DAO
-func (sp *ServiceProvider) isMemberOfOracleDao() (bool, error) {
-	rp := sp.rocketPool
-	address, _ := sp.GetWallet().GetAddress()
+func (p *ServiceProvider) isMemberOfOracleDao() (bool, error) {
+	rp := p.rocketPool
+	address, _ := p.GetWallet().GetAddress()
 
 	// Create the bindings
 	node, err := node.NewNode(rp, address)
@@ -329,9 +329,9 @@ func (sp *ServiceProvider) isMemberOfOracleDao() (bool, error) {
 }
 
 // Check if the node is a member of the security council
-func (sp *ServiceProvider) isMemberOfSecurityCouncil() (bool, error) {
-	rp := sp.rocketPool
-	address, _ := sp.GetWallet().GetAddress()
+func (p *ServiceProvider) isMemberOfSecurityCouncil() (bool, error) {
+	rp := p.rocketPool
+	address, _ := p.GetWallet().GetAddress()
 
 	// Create the bindings
 	node, err := node.NewNode(rp, address)
@@ -353,9 +353,9 @@ func (sp *ServiceProvider) isMemberOfSecurityCouncil() (bool, error) {
 
 // Check if the primary and fallback Execution clients are synced
 // TODO: Move this into ec-manager and stop exposing the primary and fallback directly...
-func (sp *ServiceProvider) checkExecutionClientStatus(ctx context.Context) (bool, eth.IExecutionClient, error) {
+func (p *ServiceProvider) checkExecutionClientStatus(ctx context.Context) (bool, eth.IExecutionClient, error) {
 	// Check the EC status
-	ecMgr := sp.GetEthClient()
+	ecMgr := p.GetEthClient()
 	mgrStatus := ecMgr.CheckStatus(ctx, true)
 	if ecMgr.IsPrimaryReady() {
 		return true, nil, nil
@@ -400,9 +400,9 @@ func (sp *ServiceProvider) checkExecutionClientStatus(ctx context.Context) (bool
 }
 
 // Check if the primary and fallback Beacon clients are synced
-func (sp *ServiceProvider) checkBeaconClientStatus(ctx context.Context) (bool, error) {
+func (p *ServiceProvider) checkBeaconClientStatus(ctx context.Context) (bool, error) {
 	// Check the BC status
-	bcMgr := sp.GetBeaconClient()
+	bcMgr := p.GetBeaconClient()
 	mgrStatus := bcMgr.CheckStatus(ctx, true)
 	if bcMgr.IsPrimaryReady() {
 		return true, nil
@@ -447,12 +447,12 @@ func (sp *ServiceProvider) checkBeaconClientStatus(ctx context.Context) (bool, e
 }
 
 // Wait for the primary or fallback Execution client to be synced
-func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool) (bool, error) {
+func (p *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool) (bool, error) {
 	// Prevent multiple waiting goroutines from requesting sync progress
 	ethClientSyncLock.Lock()
 	defer ethClientSyncLock.Unlock()
 
-	synced, clientToCheck, err := sp.checkExecutionClientStatus(ctx)
+	synced, clientToCheck, err := p.checkExecutionClientStatus(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -473,7 +473,7 @@ func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool
 	}
 
 	// Make an alerter
-	alerter := alerting.NewAlerter(sp.GetConfig(), logger)
+	alerter := alerting.NewAlerter(p.GetConfig(), logger)
 
 	// Wait for sync
 	for {
@@ -481,7 +481,7 @@ func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool
 		if time.Since(ecRefreshTime) > ethClientStatusRefreshInterval {
 			logger.Info("Refreshing primary / fallback execution client status...")
 			ecRefreshTime = time.Now()
-			synced, clientToCheck, err = sp.checkExecutionClientStatus(ctx)
+			synced, clientToCheck, err = p.checkExecutionClientStatus(ctx)
 			if err != nil {
 				return false, err
 			}
@@ -529,12 +529,12 @@ func (sp *ServiceProvider) waitEthClientSynced(ctx context.Context, verbose bool
 }
 
 // Wait for the primary or fallback Beacon client to be synced
-func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose bool) (bool, error) {
+func (p *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose bool) (bool, error) {
 	// Prevent multiple waiting goroutines from requesting sync progress
 	beaconClientSyncLock.Lock()
 	defer beaconClientSyncLock.Unlock()
 
-	synced, err := sp.checkBeaconClientStatus(ctx)
+	synced, err := p.checkBeaconClientStatus(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -555,7 +555,7 @@ func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose b
 	}
 
 	// Make an alerter
-	alerter := alerting.NewAlerter(sp.GetConfig(), logger)
+	alerter := alerting.NewAlerter(p.GetConfig(), logger)
 
 	// Wait for sync
 	for {
@@ -563,7 +563,7 @@ func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose b
 		if time.Since(bcRefreshTime) > ethClientStatusRefreshInterval {
 			logger.Info("Refreshing primary / fallback Beacon Node status...")
 			bcRefreshTime = time.Now()
-			synced, err = sp.checkBeaconClientStatus(ctx)
+			synced, err = p.checkBeaconClientStatus(ctx)
 			if err != nil {
 				return false, err
 			}
@@ -574,7 +574,7 @@ func (sp *ServiceProvider) waitBeaconClientSynced(ctx context.Context, verbose b
 		}
 
 		// Get sync status
-		syncStatus, err := sp.GetBeaconClient().GetSyncStatus(ctx)
+		syncStatus, err := p.GetBeaconClient().GetSyncStatus(ctx)
 		if err != nil {
 			return false, err
 		}

--- a/rocketpool-daemon/common/services/service-provider.go
+++ b/rocketpool-daemon/common/services/service-provider.go
@@ -19,7 +19,7 @@ import (
 
 // A container for all of the various services used by the Smartnode
 type ServiceProvider struct {
-	*services.ServiceProvider
+	services.IServiceProvider
 
 	// Services
 	cfg                *config.SmartNodeConfig
@@ -74,7 +74,7 @@ func NewServiceProvider(userDir string) (*ServiceProvider, error) {
 }
 
 // Creates a ServiceProvider instance from a core service provider and Smart Node config
-func CreateServiceProviderFromComponents(cfg *config.SmartNodeConfig, sp *services.ServiceProvider) (*ServiceProvider, error) {
+func CreateServiceProviderFromComponents(cfg *config.SmartNodeConfig, sp services.IServiceProvider) (*ServiceProvider, error) {
 	// Make the watchtower log
 	loggerOpts := cfg.GetLoggerOptions()
 	watchtowerLogger, err := log.NewLogger(cfg.GetWatchtowerLogFilePath(), loggerOpts)
@@ -114,7 +114,7 @@ func CreateServiceProviderFromComponents(cfg *config.SmartNodeConfig, sp *servic
 	defaultVersion, _ := version.NewSemver("0.0.0")
 	provider := &ServiceProvider{
 		userDir:               cfg.RocketPoolDirectory(),
-		ServiceProvider:       sp,
+		IServiceProvider:      sp,
 		cfg:                   cfg,
 		rocketPool:            rp,
 		validatorManager:      vMgr,
@@ -130,8 +130,8 @@ func CreateServiceProviderFromComponents(cfg *config.SmartNodeConfig, sp *servic
 // === Getters ===
 // ===============
 
-func (p *ServiceProvider) GetServiceProvider() *services.ServiceProvider {
-	return p.ServiceProvider
+func (p *ServiceProvider) GetServiceProvider() services.IServiceProvider {
+	return p.IServiceProvider
 }
 
 func (p *ServiceProvider) GetUserDir() string {
@@ -158,9 +158,9 @@ func (p *ServiceProvider) GetWatchtowerLogger() *log.Logger {
 	return p.watchtowerLog
 }
 
-func (p *ServiceProvider) Close() {
+func (p *ServiceProvider) Close() error {
 	p.watchtowerLog.Close()
-	p.ServiceProvider.Close()
+	return p.IServiceProvider.Close()
 }
 
 // =============

--- a/rocketpool-daemon/common/state/manager.go
+++ b/rocketpool-daemon/common/state/manager.go
@@ -18,7 +18,7 @@ import (
 
 type NetworkStateManager struct {
 	cfg          *config.SmartNodeConfig
-	res          *config.RocketPoolResources
+	res          *config.MergedResources
 	rp           *rocketpool.RocketPool
 	ec           eth.IExecutionClient
 	bc           beacon.IBeaconClient
@@ -30,7 +30,7 @@ type NetworkStateManager struct {
 }
 
 // Create a new manager for the network state
-func NewNetworkStateManager(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger) (*NetworkStateManager, error) {
+func NewNetworkStateManager(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger) (*NetworkStateManager, error) {
 	// Create the manager
 	m := &NetworkStateManager{
 		cfg:     cfg,

--- a/rocketpool-daemon/common/state/manager.go
+++ b/rocketpool-daemon/common/state/manager.go
@@ -18,6 +18,7 @@ import (
 
 type NetworkStateManager struct {
 	cfg          *config.SmartNodeConfig
+	res          *config.RocketPoolResources
 	rp           *rocketpool.RocketPool
 	ec           eth.IExecutionClient
 	bc           beacon.IBeaconClient
@@ -29,19 +30,17 @@ type NetworkStateManager struct {
 }
 
 // Create a new manager for the network state
-func NewNetworkStateManager(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger) (*NetworkStateManager, error) {
-	// Make a resource list
-	resources := cfg.GetNetworkResources()
-
+func NewNetworkStateManager(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger) (*NetworkStateManager, error) {
 	// Create the manager
 	m := &NetworkStateManager{
 		cfg:     cfg,
+		res:     res,
 		rp:      rp,
 		ec:      ec,
 		bc:      bc,
 		logger:  logger,
 		Network: cfg.Network.Value,
-		ChainID: resources.ChainID,
+		ChainID: res.ChainID,
 	}
 
 	// Get the Beacon config info
@@ -139,7 +138,7 @@ func (m *NetworkStateManager) GetLatestProposedBeaconBlock(context context.Conte
 
 // Get the state of the network at the provided Beacon slot
 func (m *NetworkStateManager) getState(context context.Context, slotNumber uint64) (*NetworkState, error) {
-	state, err := CreateNetworkState(m.cfg, m.rp, m.ec, m.bc, m.logger, slotNumber, m.BeaconConfig, context)
+	state, err := CreateNetworkState(m.cfg, m.res, m.rp, m.ec, m.bc, m.logger, slotNumber, m.BeaconConfig, context)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +147,7 @@ func (m *NetworkStateManager) getState(context context.Context, slotNumber uint6
 
 // Get the state of the network for a specific node only at the provided Beacon slot
 func (m *NetworkStateManager) getStateForNode(context context.Context, nodeAddress common.Address, slotNumber uint64, calculateTotalEffectiveStake bool) (*NetworkState, *big.Int, error) {
-	state, totalEffectiveStake, err := CreateNetworkStateForNode(m.cfg, m.rp, m.ec, m.bc, m.logger, slotNumber, m.BeaconConfig, nodeAddress, calculateTotalEffectiveStake, context)
+	state, totalEffectiveStake, err := CreateNetworkStateForNode(m.cfg, m.res, m.rp, m.ec, m.bc, m.logger, slotNumber, m.BeaconConfig, nodeAddress, calculateTotalEffectiveStake, context)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rocketpool-daemon/common/state/network-state.go
+++ b/rocketpool-daemon/common/state/network-state.go
@@ -65,7 +65,7 @@ type NetworkState struct {
 }
 
 // Creates a snapshot of the entire Rocket Pool network state, on both the Execution and Consensus layers
-func CreateNetworkState(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, context context.Context) (*NetworkState, error) {
+func CreateNetworkState(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, context context.Context) (*NetworkState, error) {
 	// Get the relevant network contracts
 	multicallerAddress := res.MulticallAddress
 	balanceBatcherAddress := res.BalanceBatcherAddress
@@ -193,7 +193,7 @@ func CreateNetworkState(cfg *config.SmartNodeConfig, res *config.RocketPoolResou
 
 // Creates a snapshot of the Rocket Pool network, but only for a single node
 // Also gets the total effective RPL stake of the network for convenience since this is required by several node routines
-func CreateNetworkStateForNode(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, nodeAddress common.Address, calculateTotalEffectiveStake bool, context context.Context) (*NetworkState, *big.Int, error) {
+func CreateNetworkStateForNode(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, nodeAddress common.Address, calculateTotalEffectiveStake bool, context context.Context) (*NetworkState, *big.Int, error) {
 	steps := 6
 	if calculateTotalEffectiveStake {
 		steps++

--- a/rocketpool-daemon/common/state/network-state.go
+++ b/rocketpool-daemon/common/state/network-state.go
@@ -65,11 +65,10 @@ type NetworkState struct {
 }
 
 // Creates a snapshot of the entire Rocket Pool network state, on both the Execution and Consensus layers
-func CreateNetworkState(cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, context context.Context) (*NetworkState, error) {
+func CreateNetworkState(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, context context.Context) (*NetworkState, error) {
 	// Get the relevant network contracts
-	resources := cfg.GetNetworkResources()
-	multicallerAddress := resources.MulticallAddress
-	balanceBatcherAddress := resources.BalanceBatcherAddress
+	multicallerAddress := res.MulticallAddress
+	balanceBatcherAddress := res.BalanceBatcherAddress
 
 	// Get the execution block for the given slot
 	beaconBlock, exists, err := bc.GetBeaconBlock(context, fmt.Sprintf("%d", slotNumber))
@@ -194,16 +193,15 @@ func CreateNetworkState(cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, 
 
 // Creates a snapshot of the Rocket Pool network, but only for a single node
 // Also gets the total effective RPL stake of the network for convenience since this is required by several node routines
-func CreateNetworkStateForNode(cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, nodeAddress common.Address, calculateTotalEffectiveStake bool, context context.Context) (*NetworkState, *big.Int, error) {
+func CreateNetworkStateForNode(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, bc beacon.IBeaconClient, logger *slog.Logger, slotNumber uint64, beaconConfig beacon.Eth2Config, nodeAddress common.Address, calculateTotalEffectiveStake bool, context context.Context) (*NetworkState, *big.Int, error) {
 	steps := 6
 	if calculateTotalEffectiveStake {
 		steps++
 	}
 
 	// Get the relevant network contracts
-	resources := cfg.GetNetworkResources()
-	multicallerAddress := resources.MulticallAddress
-	balanceBatcherAddress := resources.BalanceBatcherAddress
+	multicallerAddress := res.MulticallAddress
+	balanceBatcherAddress := res.BalanceBatcherAddress
 
 	// Get the execution block for the given slot
 	beaconBlock, exists, err := bc.GetBeaconBlock(context, fmt.Sprintf("%d", slotNumber))

--- a/rocketpool-daemon/common/tx/utils.go
+++ b/rocketpool-daemon/common/tx/utils.go
@@ -19,14 +19,13 @@ import (
 const TimeoutSafetyFactor time.Duration = 2
 
 // Prints a TX's details to the logger and waits for it to validated.
-func PrintAndWaitForTransaction(cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, logger *slog.Logger, txInfo *eth.TransactionInfo, opts *bind.TransactOpts) error {
+func PrintAndWaitForTransaction(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, logger *slog.Logger, txInfo *eth.TransactionInfo, opts *bind.TransactOpts) error {
 	tx, err := rp.ExecuteTransaction(txInfo, opts)
 	if err != nil {
 		return fmt.Errorf("error submitting transaction: %w", err)
 	}
 
-	resources := cfg.GetRocketPoolResources()
-	txWatchUrl := resources.TxWatchUrl
+	txWatchUrl := res.TxWatchUrl
 	hashString := tx.Hash().String()
 	logger.Info("Transaction has been submitted.", slog.String(keys.HashKey, hashString))
 	if txWatchUrl != "" {
@@ -45,7 +44,7 @@ func PrintAndWaitForTransaction(cfg *config.SmartNodeConfig, rp *rocketpool.Rock
 }
 
 // Prints a TX's details to the logger and waits for it to validated.
-func PrintAndWaitForTransactionBatch(cfg *config.SmartNodeConfig, rp *rocketpool.RocketPool, logger *slog.Logger, submissions []*eth.TransactionSubmission, callbacks []func(err error), opts *bind.TransactOpts) error {
+func PrintAndWaitForTransactionBatch(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, logger *slog.Logger, submissions []*eth.TransactionSubmission, callbacks []func(err error), opts *bind.TransactOpts) error {
 	txs, err := rp.BatchExecuteTransactions(submissions, opts)
 	if err != nil {
 		return fmt.Errorf("error submitting transactions: %w", err)
@@ -59,8 +58,7 @@ func PrintAndWaitForTransactionBatch(cfg *config.SmartNodeConfig, rp *rocketpool
 		}
 	}
 
-	resources := cfg.GetRocketPoolResources()
-	txWatchUrl := resources.TxWatchUrl
+	txWatchUrl := res.TxWatchUrl
 	if txWatchUrl != "" {
 		logger.Info("Transactions have been submitted. You may follow them progress by visiting:")
 		for _, tx := range txs {

--- a/rocketpool-daemon/common/tx/utils.go
+++ b/rocketpool-daemon/common/tx/utils.go
@@ -19,7 +19,7 @@ import (
 const TimeoutSafetyFactor time.Duration = 2
 
 // Prints a TX's details to the logger and waits for it to validated.
-func PrintAndWaitForTransaction(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, logger *slog.Logger, txInfo *eth.TransactionInfo, opts *bind.TransactOpts) error {
+func PrintAndWaitForTransaction(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, logger *slog.Logger, txInfo *eth.TransactionInfo, opts *bind.TransactOpts) error {
 	tx, err := rp.ExecuteTransaction(txInfo, opts)
 	if err != nil {
 		return fmt.Errorf("error submitting transaction: %w", err)
@@ -44,7 +44,7 @@ func PrintAndWaitForTransaction(cfg *config.SmartNodeConfig, res *config.RocketP
 }
 
 // Prints a TX's details to the logger and waits for it to validated.
-func PrintAndWaitForTransactionBatch(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, logger *slog.Logger, submissions []*eth.TransactionSubmission, callbacks []func(err error), opts *bind.TransactOpts) error {
+func PrintAndWaitForTransactionBatch(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, logger *slog.Logger, submissions []*eth.TransactionSubmission, callbacks []func(err error), opts *bind.TransactOpts) error {
 	txs, err := rp.BatchExecuteTransactions(submissions, opts)
 	if err != nil {
 		return fmt.Errorf("error submitting transactions: %w", err)

--- a/rocketpool-daemon/common/utils/deposit-contract.go
+++ b/rocketpool-daemon/common/utils/deposit-contract.go
@@ -17,7 +17,7 @@ type DepositContractInfo struct {
 	BeaconDepositContract common.Address
 }
 
-func GetDepositContractInfo(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*DepositContractInfo, error) {
+func GetDepositContractInfo(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.MergedResources, bc beacon.IBeaconClient) (*DepositContractInfo, error) {
 	info := &DepositContractInfo{}
 	info.RPNetwork = uint64(res.ChainID)
 

--- a/rocketpool-daemon/common/utils/deposit-contract.go
+++ b/rocketpool-daemon/common/utils/deposit-contract.go
@@ -17,10 +17,9 @@ type DepositContractInfo struct {
 	BeaconDepositContract common.Address
 }
 
-func GetDepositContractInfo(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, bc beacon.IBeaconClient) (*DepositContractInfo, error) {
+func GetDepositContractInfo(context context.Context, rp *rocketpool.RocketPool, cfg *config.SmartNodeConfig, res *config.RocketPoolResources, bc beacon.IBeaconClient) (*DepositContractInfo, error) {
 	info := &DepositContractInfo{}
-	resources := cfg.GetRocketPoolResources()
-	info.RPNetwork = uint64(resources.ChainID)
+	info.RPNetwork = uint64(res.ChainID)
 
 	// Get the deposit contract address Rocket Pool will deposit to
 	rpDepositContract, err := rp.GetContract(rocketpool.ContractName_CasperDeposit)

--- a/rocketpool-daemon/common/voting/utils.go
+++ b/rocketpool-daemon/common/voting/utils.go
@@ -113,10 +113,9 @@ type snapshotProposalsResponse struct {
 // === Utils ===
 // =============
 
-func GetSnapshotVotingPower(cfg *config.SmartNodeConfig, address common.Address) (float64, error) {
+func GetSnapshotVotingPower(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, address common.Address) (float64, error) {
 	client := getHttpClientWithTimeout()
-	resources := cfg.GetRocketPoolResources()
-	apiDomain := resources.SnapshotApiDomain
+	apiDomain := res.SnapshotApiDomain
 	id := config.SnapshotID
 	if apiDomain == "" {
 		return 0, nil
@@ -149,10 +148,9 @@ func GetSnapshotVotingPower(cfg *config.SmartNodeConfig, address common.Address)
 	return vp, nil
 }
 
-func GetSnapshotProposals(cfg *config.SmartNodeConfig, address common.Address, delegate common.Address, activeOnly bool) ([]*sharedtypes.SnapshotProposal, error) {
+func GetSnapshotProposals(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, address common.Address, delegate common.Address, activeOnly bool) ([]*sharedtypes.SnapshotProposal, error) {
 	client := getHttpClientWithTimeout()
-	resources := cfg.GetRocketPoolResources()
-	apiDomain := resources.SnapshotApiDomain
+	apiDomain := res.SnapshotApiDomain
 	id := config.SnapshotID
 	if apiDomain == "" {
 		return nil, nil

--- a/rocketpool-daemon/common/voting/utils.go
+++ b/rocketpool-daemon/common/voting/utils.go
@@ -113,7 +113,7 @@ type snapshotProposalsResponse struct {
 // === Utils ===
 // =============
 
-func GetSnapshotVotingPower(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, address common.Address) (float64, error) {
+func GetSnapshotVotingPower(cfg *config.SmartNodeConfig, res *config.MergedResources, address common.Address) (float64, error) {
 	client := getHttpClientWithTimeout()
 	apiDomain := res.SnapshotApiDomain
 	id := config.SnapshotID
@@ -148,7 +148,7 @@ func GetSnapshotVotingPower(cfg *config.SmartNodeConfig, res *config.RocketPoolR
 	return vp, nil
 }
 
-func GetSnapshotProposals(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, address common.Address, delegate common.Address, activeOnly bool) ([]*sharedtypes.SnapshotProposal, error) {
+func GetSnapshotProposals(cfg *config.SmartNodeConfig, res *config.MergedResources, address common.Address, delegate common.Address, activeOnly bool) ([]*sharedtypes.SnapshotProposal, error) {
 	client := getHttpClientWithTimeout()
 	apiDomain := res.SnapshotApiDomain
 	id := config.SnapshotID

--- a/rocketpool-daemon/node/collectors/beacon-collector.go
+++ b/rocketpool-daemon/node/collectors/beacon-collector.go
@@ -32,7 +32,7 @@ type BeaconCollector struct {
 	ctx context.Context
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -42,7 +42,7 @@ type BeaconCollector struct {
 }
 
 // Create a new BeaconCollector instance
-func NewBeaconCollector(logger *log.Logger, ctx context.Context, sp *services.ServiceProvider, stateLocker *StateLocker) *BeaconCollector {
+func NewBeaconCollector(logger *log.Logger, ctx context.Context, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *BeaconCollector {
 	subsystem := "beacon"
 	sublogger := logger.With(slog.String(keys.TaskKey, "Beacon Collector"))
 	return &BeaconCollector{

--- a/rocketpool-daemon/node/collectors/demand-collector.go
+++ b/rocketpool-daemon/node/collectors/demand-collector.go
@@ -30,7 +30,7 @@ type DemandCollector struct {
 	queueLength *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -40,7 +40,7 @@ type DemandCollector struct {
 }
 
 // Create a new DemandCollector instance
-func NewDemandCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *DemandCollector {
+func NewDemandCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *DemandCollector {
 	subsystem := "demand"
 	sublogger := logger.With(slog.String(keys.TaskKey, "Demand Collector"))
 	return &DemandCollector{

--- a/rocketpool-daemon/node/collectors/odao-collector.go
+++ b/rocketpool-daemon/node/collectors/odao-collector.go
@@ -24,7 +24,7 @@ type OdaoCollector struct {
 	latestReportableBlock *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -34,7 +34,7 @@ type OdaoCollector struct {
 }
 
 // Create a new OdaoCollector instance
-func NewOdaoCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *OdaoCollector {
+func NewOdaoCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *OdaoCollector {
 	subsystem := "odao"
 	sublogger := logger.With(slog.String(keys.TaskKey, "ODAO Collector"))
 	return &OdaoCollector{

--- a/rocketpool-daemon/node/collectors/performance-collector.go
+++ b/rocketpool-daemon/node/collectors/performance-collector.go
@@ -31,7 +31,7 @@ type PerformanceCollector struct {
 	rethContractBalance *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -41,7 +41,7 @@ type PerformanceCollector struct {
 }
 
 // Create a new PerformanceCollector instance
-func NewPerformanceCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *PerformanceCollector {
+func NewPerformanceCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *PerformanceCollector {
 	subsystem := "performance"
 	sublogger := logger.With(slog.String(keys.TaskKey, "Performance Collector"))
 	return &PerformanceCollector{

--- a/rocketpool-daemon/node/collectors/rpl-collector.go
+++ b/rocketpool-daemon/node/collectors/rpl-collector.go
@@ -25,7 +25,7 @@ type RplCollector struct {
 	checkpointTime *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -35,7 +35,7 @@ type RplCollector struct {
 }
 
 // Create a new RplCollector instance
-func NewRplCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *RplCollector {
+func NewRplCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *RplCollector {
 	subsystem := "rpl"
 	sublogger := logger.With(slog.String(keys.TaskKey, "RPL Collector"))
 	return &RplCollector{

--- a/rocketpool-daemon/node/collectors/smoothing-pool-collector.go
+++ b/rocketpool-daemon/node/collectors/smoothing-pool-collector.go
@@ -16,7 +16,7 @@ type SmoothingPoolCollector struct {
 	ethBalanceOnSmoothingPool *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -26,7 +26,7 @@ type SmoothingPoolCollector struct {
 }
 
 // Create a new SmoothingPoolCollector instance
-func NewSmoothingPoolCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *SmoothingPoolCollector {
+func NewSmoothingPoolCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *SmoothingPoolCollector {
 	subsystem := "smoothing_pool"
 	sublogger := logger.With(slog.String(keys.TaskKey, "SP Collector"))
 	return &SmoothingPoolCollector{

--- a/rocketpool-daemon/node/collectors/supply-collector.go
+++ b/rocketpool-daemon/node/collectors/supply-collector.go
@@ -28,7 +28,7 @@ type SupplyCollector struct {
 	activeMinipools *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -38,7 +38,7 @@ type SupplyCollector struct {
 }
 
 // Create a new PerformanceCollector instance
-func NewSupplyCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *SupplyCollector {
+func NewSupplyCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *SupplyCollector {
 	subsystem := "supply"
 	sublogger := logger.With(slog.String(keys.TaskKey, "Supply Collector"))
 	return &SupplyCollector{

--- a/rocketpool-daemon/node/collectors/trusted-node-collector.go
+++ b/rocketpool-daemon/node/collectors/trusted-node-collector.go
@@ -36,7 +36,7 @@ type TrustedNodeCollector struct {
 	pricesParticipation *prometheus.Desc
 
 	// The Smartnode service provider
-	sp *services.ServiceProvider
+	sp services.ISmartNodeServiceProvider
 
 	// The logger
 	logger *slog.Logger
@@ -48,7 +48,7 @@ type TrustedNodeCollector struct {
 }
 
 // Create a new TrustedNodeCollector instance
-func NewTrustedNodeCollector(logger *log.Logger, sp *services.ServiceProvider, stateLocker *StateLocker) *TrustedNodeCollector {
+func NewTrustedNodeCollector(logger *log.Logger, sp services.ISmartNodeServiceProvider, stateLocker *StateLocker) *TrustedNodeCollector {
 	subsystem := "trusted_node"
 	sublogger := logger.With(slog.String(keys.TaskKey, "ODAO Stats Collector"))
 	return &TrustedNodeCollector{

--- a/rocketpool-daemon/node/defend-pdao-props.go
+++ b/rocketpool-daemon/node/defend-pdao-props.go
@@ -35,11 +35,10 @@ type DefendPdaoProps struct {
 	sp               services.ISmartNodeServiceProvider
 	logger           *slog.Logger
 	cfg              *config.SmartNodeConfig
-	res              *config.RocketPoolResources
+	res              *config.MergedResources
 	w                *wallet.Wallet
 	rp               *rocketpool.RocketPool
 	bc               beacon.IBeaconClient
-	rs               *config.RocketPoolResources
 	gasThreshold     float64
 	maxFee           *big.Int
 	maxPriorityFee   *big.Int
@@ -67,7 +66,6 @@ func NewDefendPdaoProps(ctx context.Context, sp services.ISmartNodeServiceProvid
 		w:                sp.GetWallet(),
 		rp:               sp.GetRocketPool(),
 		bc:               sp.GetBeaconClient(),
-		rs:               sp.GetResources(),
 		gasThreshold:     cfg.AutoTxGasThreshold.Value,
 		maxFee:           maxFee,
 		maxPriorityFee:   maxPriorityFee,
@@ -169,7 +167,7 @@ func (t *DefendPdaoProps) getDefendableProposals(state *state.NetworkState, opts
 	}
 
 	// Get any challenges issued for the proposals
-	challengeEvents, err := t.pdaoMgr.GetChallengeSubmittedEvents(ids, t.intervalSize, startBlock, endBlock, t.rs.PreviousProtocolDaoVerifierAddresses, opts)
+	challengeEvents, err := t.pdaoMgr.GetChallengeSubmittedEvents(ids, t.intervalSize, startBlock, endBlock, t.res.PreviousProtocolDaoVerifierAddresses, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error scanning for ChallengeSubmitted events: %w", err)
 	}

--- a/rocketpool-daemon/node/distribute-minipools.go
+++ b/rocketpool-daemon/node/distribute-minipools.go
@@ -31,7 +31,7 @@ type DistributeMinipools struct {
 	logger              *slog.Logger
 	alerter             *alerting.Alerter
 	cfg                 *config.SmartNodeConfig
-	res                 *config.RocketPoolResources
+	res                 *config.MergedResources
 	w                   *wallet.Wallet
 	rp                  *rocketpool.RocketPool
 	bc                  beacon.IBeaconClient

--- a/rocketpool-daemon/node/download-reward-trees.go
+++ b/rocketpool-daemon/node/download-reward-trees.go
@@ -19,7 +19,7 @@ type DownloadRewardsTrees struct {
 	sp     services.ISmartNodeServiceProvider
 	logger *slog.Logger
 	cfg    *config.SmartNodeConfig
-	res    *config.RocketPoolResources
+	res    *config.MergedResources
 	rp     *rocketpool.RocketPool
 }
 

--- a/rocketpool-daemon/node/download-reward-trees.go
+++ b/rocketpool-daemon/node/download-reward-trees.go
@@ -16,18 +16,20 @@ import (
 
 // Manage download rewards trees task
 type DownloadRewardsTrees struct {
-	sp     *services.ServiceProvider
+	sp     services.ISmartNodeServiceProvider
 	logger *slog.Logger
 	cfg    *config.SmartNodeConfig
+	res    *config.RocketPoolResources
 	rp     *rocketpool.RocketPool
 }
 
 // Create manage fee recipient task
-func NewDownloadRewardsTrees(sp *services.ServiceProvider, logger *log.Logger) *DownloadRewardsTrees {
+func NewDownloadRewardsTrees(sp services.ISmartNodeServiceProvider, logger *log.Logger) *DownloadRewardsTrees {
 	return &DownloadRewardsTrees{
 		sp:     sp,
 		logger: logger.With(slog.String(keys.TaskKey, "Rewards Tree Download")),
 		cfg:    sp.GetConfig(),
+		res:    sp.GetResources(),
 		rp:     sp.GetRocketPool(),
 	}
 }
@@ -67,7 +69,7 @@ func (t *DownloadRewardsTrees) Run(state *state.NetworkState) error {
 	// Download missing intervals
 	for _, missingInterval := range missingIntervals {
 		t.logger.Info("Downloading file... ", slog.Uint64(keys.IntervalKey, missingInterval))
-		intervalInfo, err := rprewards.GetIntervalInfo(t.rp, t.cfg, nodeAddress, missingInterval, nil)
+		intervalInfo, err := rprewards.GetIntervalInfo(t.rp, t.cfg, t.res, nodeAddress, missingInterval, nil)
 		if err != nil {
 			return fmt.Errorf("error getting interval %d info: %w", missingInterval, err)
 		}

--- a/rocketpool-daemon/node/manage-fee-recipient.go
+++ b/rocketpool-daemon/node/manage-fee-recipient.go
@@ -30,7 +30,7 @@ const (
 // Manage fee recipient task
 type ManageFeeRecipient struct {
 	ctx     context.Context
-	sp      *services.ServiceProvider
+	sp      services.ISmartNodeServiceProvider
 	cfg     *config.SmartNodeConfig
 	logger  *slog.Logger
 	alerter *alerting.Alerter
@@ -39,7 +39,7 @@ type ManageFeeRecipient struct {
 }
 
 // Create manage fee recipient task
-func NewManageFeeRecipient(ctx context.Context, sp *services.ServiceProvider, logger *log.Logger) *ManageFeeRecipient {
+func NewManageFeeRecipient(ctx context.Context, sp services.ISmartNodeServiceProvider, logger *log.Logger) *ManageFeeRecipient {
 	return &ManageFeeRecipient{
 		ctx:     ctx,
 		sp:      sp,

--- a/rocketpool-daemon/node/metrics-exporter.go
+++ b/rocketpool-daemon/node/metrics-exporter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/rocket-pool/smartnode/v2/shared/keys"
 )
 
-func runMetricsServer(ctx context.Context, sp *services.ServiceProvider, logger *log.Logger, stateLocker *collectors.StateLocker, wg *sync.WaitGroup,
+func runMetricsServer(ctx context.Context, sp services.ISmartNodeServiceProvider, logger *log.Logger, stateLocker *collectors.StateLocker, wg *sync.WaitGroup,
 	scrubCollector *wc.ScrubCollector, bondReductionCollector *wc.BondReductionCollector, soloMigrationCollector *wc.SoloMigrationCollector) *http.Server {
 	// Get services
 	cfg := sp.GetConfig()

--- a/rocketpool-daemon/node/node.go
+++ b/rocketpool-daemon/node/node.go
@@ -58,8 +58,7 @@ type TaskLoop struct {
 	sp                services.ISmartNodeServiceProvider
 	wg                *sync.WaitGroup
 	cfg               *config.SmartNodeConfig
-	res               *config.RocketPoolResources
-	rs                *config.RocketPoolResources
+	res               *config.MergedResources
 	rp                *rocketpool.RocketPool
 	ec                eth.IExecutionClient
 	bc                beacon.IBeaconClient
@@ -101,7 +100,6 @@ func NewTaskLoop(sp services.ISmartNodeServiceProvider, wg *sync.WaitGroup) *Tas
 		wg:                          wg,
 		cfg:                         sp.GetConfig(),
 		res:                         sp.GetResources(),
-		rs:                          sp.GetResources(),
 		rp:                          sp.GetRocketPool(),
 		ec:                          sp.GetEthClient(),
 		bc:                          sp.GetBeaconClient(),
@@ -144,7 +142,7 @@ func (t *TaskLoop) Run() error {
 	}
 
 	// Handle the initial fee recipient file deployment
-	err := deployDefaultFeeRecipientFile(t.cfg, t.rs)
+	err := deployDefaultFeeRecipientFile(t.cfg, t.res)
 	if err != nil {
 		return err
 	}
@@ -409,7 +407,7 @@ func (t *TaskLoop) runTasks() bool {
 }
 
 // Copy the default fee recipient file into the proper location
-func deployDefaultFeeRecipientFile(cfg *config.SmartNodeConfig, rs *config.RocketPoolResources) error {
+func deployDefaultFeeRecipientFile(cfg *config.SmartNodeConfig, rs *config.MergedResources) error {
 	feeRecipientPath := cfg.GetFeeRecipientFilePath()
 	_, err := os.Stat(feeRecipientPath)
 	if os.IsNotExist(err) {

--- a/rocketpool-daemon/node/promote-minipools.go
+++ b/rocketpool-daemon/node/promote-minipools.go
@@ -31,7 +31,7 @@ type PromoteMinipools struct {
 	logger         *slog.Logger
 	alerter        *alerting.Alerter
 	cfg            *config.SmartNodeConfig
-	res            *config.RocketPoolResources
+	res            *config.MergedResources
 	w              *wallet.Wallet
 	rp             *rocketpool.RocketPool
 	mpMgr          *minipool.MinipoolManager

--- a/rocketpool-daemon/node/promote-minipools.go
+++ b/rocketpool-daemon/node/promote-minipools.go
@@ -27,10 +27,11 @@ import (
 
 // Promote minipools task
 type PromoteMinipools struct {
-	sp             *services.ServiceProvider
+	sp             services.ISmartNodeServiceProvider
 	logger         *slog.Logger
 	alerter        *alerting.Alerter
 	cfg            *config.SmartNodeConfig
+	res            *config.RocketPoolResources
 	w              *wallet.Wallet
 	rp             *rocketpool.RocketPool
 	mpMgr          *minipool.MinipoolManager
@@ -40,7 +41,7 @@ type PromoteMinipools struct {
 }
 
 // Create promote minipools task
-func NewPromoteMinipools(sp *services.ServiceProvider, logger *log.Logger) *PromoteMinipools {
+func NewPromoteMinipools(sp services.ISmartNodeServiceProvider, logger *log.Logger) *PromoteMinipools {
 	cfg := sp.GetConfig()
 	log := logger.With(slog.String(keys.TaskKey, "Promote Minipools"))
 	maxFee, maxPriorityFee := getAutoTxInfo(cfg, log)
@@ -49,6 +50,7 @@ func NewPromoteMinipools(sp *services.ServiceProvider, logger *log.Logger) *Prom
 		logger:         log,
 		alerter:        alerting.NewAlerter(cfg, logger),
 		cfg:            cfg,
+		res:            sp.GetResources(),
 		w:              sp.GetWallet(),
 		rp:             sp.GetRocketPool(),
 		gasThreshold:   cfg.AutoTxGasThreshold.Value,
@@ -219,7 +221,7 @@ func (t *PromoteMinipools) promoteMinipools(submissions []*eth.TransactionSubmis
 	}
 
 	// Print TX info and wait for them to be included in a block
-	err = tx.PrintAndWaitForTransactionBatch(t.cfg, t.rp, t.logger, submissions, callbacks, opts)
+	err = tx.PrintAndWaitForTransactionBatch(t.cfg, t.res, t.rp, t.logger, submissions, callbacks, opts)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-daemon/node/reduce-bonds.go
+++ b/rocketpool-daemon/node/reduce-bonds.go
@@ -39,7 +39,7 @@ type ReduceBonds struct {
 	logger         *slog.Logger
 	alerter        *alerting.Alerter
 	cfg            *config.SmartNodeConfig
-	res            *config.RocketPoolResources
+	res            *config.MergedResources
 	w              *wallet.Wallet
 	rp             *rocketpool.RocketPool
 	mpMgr          *minipool.MinipoolManager

--- a/rocketpool-daemon/node/stake-prelaunch-minipools.go
+++ b/rocketpool-daemon/node/stake-prelaunch-minipools.go
@@ -35,7 +35,7 @@ type StakePrelaunchMinipools struct {
 	logger         *slog.Logger
 	alerter        *alerting.Alerter
 	cfg            *config.SmartNodeConfig
-	res            *config.RocketPoolResources
+	res            *config.MergedResources
 	w              *wallet.Wallet
 	vMgr           *validator.ValidatorManager
 	rp             *rocketpool.RocketPool

--- a/rocketpool-daemon/node/verify-pdao-props.go
+++ b/rocketpool-daemon/node/verify-pdao-props.go
@@ -43,7 +43,7 @@ type VerifyPdaoProps struct {
 	sp                  services.ISmartNodeServiceProvider
 	logger              *slog.Logger
 	cfg                 *config.SmartNodeConfig
-	res                 *config.RocketPoolResources
+	res                 *config.MergedResources
 	w                   *wallet.Wallet
 	rp                  *rocketpool.RocketPool
 	bc                  beacon.IBeaconClient

--- a/rocketpool-daemon/watchtower/cancel-bond-reductions.go
+++ b/rocketpool-daemon/watchtower/cancel-bond-reductions.go
@@ -36,7 +36,7 @@ type CancelBondReductions struct {
 	sp        services.ISmartNodeServiceProvider
 	logger    *slog.Logger
 	cfg       *config.SmartNodeConfig
-	res       *config.RocketPoolResources
+	res       *config.MergedResources
 	w         *wallet.Wallet
 	rp        *rocketpool.RocketPool
 	ec        eth.IExecutionClient

--- a/rocketpool-daemon/watchtower/check-solo-migrations.go
+++ b/rocketpool-daemon/watchtower/check-solo-migrations.go
@@ -39,7 +39,7 @@ type CheckSoloMigrations struct {
 	sp        services.ISmartNodeServiceProvider
 	logger    *slog.Logger
 	cfg       *config.SmartNodeConfig
-	res       *config.RocketPoolResources
+	res       *config.MergedResources
 	w         *wallet.Wallet
 	rp        *rocketpool.RocketPool
 	ec        eth.IExecutionClient

--- a/rocketpool-daemon/watchtower/dissolve-timed-out-minipools.go
+++ b/rocketpool-daemon/watchtower/dissolve-timed-out-minipools.go
@@ -26,9 +26,10 @@ const MinipoolStatusBatchSize = 20
 
 // Dissolve timed out minipools task
 type DissolveTimedOutMinipools struct {
-	sp     *services.ServiceProvider
+	sp     services.ISmartNodeServiceProvider
 	logger *slog.Logger
 	cfg    *config.SmartNodeConfig
+	res    *config.RocketPoolResources
 	w      *wallet.Wallet
 	rp     *rocketpool.RocketPool
 	ec     eth.IExecutionClient
@@ -36,10 +37,11 @@ type DissolveTimedOutMinipools struct {
 }
 
 // Create dissolve timed out minipools task
-func NewDissolveTimedOutMinipools(sp *services.ServiceProvider, logger *log.Logger) *DissolveTimedOutMinipools {
+func NewDissolveTimedOutMinipools(sp services.ISmartNodeServiceProvider, logger *log.Logger) *DissolveTimedOutMinipools {
 	return &DissolveTimedOutMinipools{
 		sp:     sp,
 		cfg:    sp.GetConfig(),
+		res:    sp.GetResources(),
 		w:      sp.GetWallet(),
 		rp:     sp.GetRocketPool(),
 		ec:     sp.GetEthClient(),
@@ -141,7 +143,7 @@ func (t *DissolveTimedOutMinipools) dissolveMinipool(mp minipool.IMinipool) erro
 	opts.GasLimit = txInfo.SimulationResult.SafeGasLimit
 
 	// Print TX info and wait for it to be included in a block
-	err = tx.PrintAndWaitForTransaction(t.cfg, t.rp, mpLogger, txInfo, opts)
+	err = tx.PrintAndWaitForTransaction(t.cfg, t.res, t.rp, mpLogger, txInfo, opts)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-daemon/watchtower/dissolve-timed-out-minipools.go
+++ b/rocketpool-daemon/watchtower/dissolve-timed-out-minipools.go
@@ -29,7 +29,7 @@ type DissolveTimedOutMinipools struct {
 	sp     services.ISmartNodeServiceProvider
 	logger *slog.Logger
 	cfg    *config.SmartNodeConfig
-	res    *config.RocketPoolResources
+	res    *config.MergedResources
 	w      *wallet.Wallet
 	rp     *rocketpool.RocketPool
 	ec     eth.IExecutionClient

--- a/rocketpool-daemon/watchtower/finalize-pdao-proposals.go
+++ b/rocketpool-daemon/watchtower/finalize-pdao-proposals.go
@@ -22,19 +22,21 @@ import (
 
 // Finalize PDAO proposals task
 type FinalizePdaoProposals struct {
-	sp     *services.ServiceProvider
+	sp     services.ISmartNodeServiceProvider
 	logger *slog.Logger
 	cfg    *config.SmartNodeConfig
+	res    *config.RocketPoolResources
 	w      *wallet.Wallet
 	ec     eth.IExecutionClient
 	rp     *rocketpool.RocketPool
 }
 
 // Create finalize PDAO proposals task task
-func NewFinalizePdaoProposals(sp *services.ServiceProvider, logger *log.Logger) *FinalizePdaoProposals {
+func NewFinalizePdaoProposals(sp services.ISmartNodeServiceProvider, logger *log.Logger) *FinalizePdaoProposals {
 	return &FinalizePdaoProposals{
 		sp:     sp,
 		cfg:    sp.GetConfig(),
+		res:    sp.GetResources(),
 		w:      sp.GetWallet(),
 		ec:     sp.GetEthClient(),
 		rp:     sp.GetRocketPool(),
@@ -117,7 +119,7 @@ func (t *FinalizePdaoProposals) finalizeProposal(propID uint64) error {
 	opts.GasLimit = txInfo.SimulationResult.SafeGasLimit
 
 	// Print TX info and wait for it to be included in a block
-	err = tx.PrintAndWaitForTransaction(t.cfg, t.rp, propLogger, txInfo, opts)
+	err = tx.PrintAndWaitForTransaction(t.cfg, t.res, t.rp, propLogger, txInfo, opts)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-daemon/watchtower/finalize-pdao-proposals.go
+++ b/rocketpool-daemon/watchtower/finalize-pdao-proposals.go
@@ -25,7 +25,7 @@ type FinalizePdaoProposals struct {
 	sp     services.ISmartNodeServiceProvider
 	logger *slog.Logger
 	cfg    *config.SmartNodeConfig
-	res    *config.RocketPoolResources
+	res    *config.MergedResources
 	w      *wallet.Wallet
 	ec     eth.IExecutionClient
 	rp     *rocketpool.RocketPool

--- a/rocketpool-daemon/watchtower/generate-rewards-tree.go
+++ b/rocketpool-daemon/watchtower/generate-rewards-tree.go
@@ -35,7 +35,7 @@ type GenerateRewardsTree struct {
 	sp        services.ISmartNodeServiceProvider
 	logger    *slog.Logger
 	cfg       *config.SmartNodeConfig
-	res       *config.RocketPoolResources
+	res       *config.MergedResources
 	rp        *rocketpool.RocketPool
 	ec        eth.IExecutionClient
 	bc        beacon.IBeaconClient

--- a/rocketpool-daemon/watchtower/respond-challenges.go
+++ b/rocketpool-daemon/watchtower/respond-challenges.go
@@ -23,7 +23,7 @@ import (
 type RespondChallenges struct {
 	sp     services.ISmartNodeServiceProvider
 	cfg    *config.SmartNodeConfig
-	res    *config.RocketPoolResources
+	res    *config.MergedResources
 	w      *wallet.Wallet
 	rp     *rocketpool.RocketPool
 	logger *slog.Logger

--- a/rocketpool-daemon/watchtower/respond-challenges.go
+++ b/rocketpool-daemon/watchtower/respond-challenges.go
@@ -21,18 +21,20 @@ import (
 
 // Respond to challenges task
 type RespondChallenges struct {
-	sp     *services.ServiceProvider
+	sp     services.ISmartNodeServiceProvider
 	cfg    *config.SmartNodeConfig
+	res    *config.RocketPoolResources
 	w      *wallet.Wallet
 	rp     *rocketpool.RocketPool
 	logger *slog.Logger
 }
 
 // Create respond to challenges task
-func NewRespondChallenges(sp *services.ServiceProvider, logger *log.Logger, m *state.NetworkStateManager) *RespondChallenges {
+func NewRespondChallenges(sp services.ISmartNodeServiceProvider, logger *log.Logger, m *state.NetworkStateManager) *RespondChallenges {
 	return &RespondChallenges{
 		sp:     sp,
 		cfg:    sp.GetConfig(),
+		res:    sp.GetResources(),
 		w:      sp.GetWallet(),
 		rp:     sp.GetRocketPool(),
 		logger: logger.With(slog.String(keys.TaskKey, "Respond to Challenges")),
@@ -95,7 +97,7 @@ func (t *RespondChallenges) Run() error {
 	opts.GasLimit = txInfo.SimulationResult.SafeGasLimit
 
 	// Print TX info and wait for it to be included in a block
-	err = tx.PrintAndWaitForTransaction(t.cfg, t.rp, t.logger, txInfo, opts)
+	err = tx.PrintAndWaitForTransaction(t.cfg, t.res, t.rp, t.logger, txInfo, opts)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-daemon/watchtower/submit-network-balances.go
+++ b/rocketpool-daemon/watchtower/submit-network-balances.go
@@ -44,7 +44,7 @@ type SubmitNetworkBalances struct {
 	sp               services.ISmartNodeServiceProvider
 	logger           *slog.Logger
 	cfg              *config.SmartNodeConfig
-	res              *config.RocketPoolResources
+	res              *config.MergedResources
 	w                *wallet.Wallet
 	ec               eth.IExecutionClient
 	rp               *rocketpool.RocketPool

--- a/rocketpool-daemon/watchtower/submit-rewards-tree-rolling.go
+++ b/rocketpool-daemon/watchtower/submit-rewards-tree-rolling.go
@@ -42,7 +42,7 @@ type SubmitRewardsTree_Rolling struct {
 	sp          services.ISmartNodeServiceProvider
 	logger      *slog.Logger
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	w           *wallet.Wallet
 	ec          eth.IExecutionClient
 	rp          *rocketpool.RocketPool

--- a/rocketpool-daemon/watchtower/submit-rewards-tree-stateless.go
+++ b/rocketpool-daemon/watchtower/submit-rewards-tree-stateless.go
@@ -43,7 +43,7 @@ type SubmitRewardsTree_Stateless struct {
 	sp          services.ISmartNodeServiceProvider
 	logger      *slog.Logger
 	cfg         *config.SmartNodeConfig
-	res         *config.RocketPoolResources
+	res         *config.MergedResources
 	w           *wallet.Wallet
 	rp          *rocketpool.RocketPool
 	ec          eth.IExecutionClient

--- a/rocketpool-daemon/watchtower/submit-rpl-price.go
+++ b/rocketpool-daemon/watchtower/submit-rpl-price.go
@@ -45,7 +45,7 @@ type SubmitRplPrice struct {
 	sp               services.ISmartNodeServiceProvider
 	logger           *slog.Logger
 	cfg              *config.SmartNodeConfig
-	res              *config.RocketPoolResources
+	res              *config.MergedResources
 	ec               eth.IExecutionClient
 	w                *wallet.Wallet
 	rp               *rocketpool.RocketPool
@@ -487,7 +487,7 @@ func (t *SubmitRplPrice) updateL2Prices(state *state.NetworkState) error {
 }
 
 // Submit a price update to Optimism
-func (t *SubmitRplPrice) updateOptimism(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, optimismMessenger *contracts.OptimismMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
+func (t *SubmitRplPrice) updateOptimism(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, optimismMessenger *contracts.OptimismMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
 	t.logger.Info("Submitting rate to Optimism...")
 	txInfo, err := optimismMessenger.SubmitRate(opts)
 	if err != nil {
@@ -520,7 +520,7 @@ func (t *SubmitRplPrice) updateOptimism(cfg *config.SmartNodeConfig, res *config
 }
 
 // Submit a price update to Polygon
-func (t *SubmitRplPrice) updatePolygon(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, polygonmMessenger *contracts.PolygonMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
+func (t *SubmitRplPrice) updatePolygon(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, polygonmMessenger *contracts.PolygonMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
 	t.logger.Info("Submitting rate to Polygon...")
 	txInfo, err := polygonmMessenger.SubmitRate(opts)
 	if err != nil {
@@ -553,7 +553,7 @@ func (t *SubmitRplPrice) updatePolygon(cfg *config.SmartNodeConfig, res *config.
 }
 
 // Submit a price update to Arbitrum
-func (t *SubmitRplPrice) updateArbitrum(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, arbitrumMessenger *contracts.ArbitrumMessenger, version string, blockNumber uint64, opts *bind.TransactOpts) error {
+func (t *SubmitRplPrice) updateArbitrum(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, arbitrumMessenger *contracts.ArbitrumMessenger, version string, blockNumber uint64, opts *bind.TransactOpts) error {
 	t.logger.Info("Submitting rate to Arbitrum...")
 
 	// Get the current network recommended max fee
@@ -613,7 +613,7 @@ func (t *SubmitRplPrice) updateArbitrum(cfg *config.SmartNodeConfig, res *config
 }
 
 // Submit a price update to zkSync Era
-func (t *SubmitRplPrice) updateZkSyncEra(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, zkSyncEraMessenger *contracts.ZkSyncEraMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
+func (t *SubmitRplPrice) updateZkSyncEra(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, zkSyncEraMessenger *contracts.ZkSyncEraMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
 	t.logger.Info("Submitting rate to zkSync Era...")
 	// Constants for zkSync Era
 	l1GasPerPubdataByte := big.NewInt(17)
@@ -665,7 +665,7 @@ func (t *SubmitRplPrice) updateZkSyncEra(cfg *config.SmartNodeConfig, res *confi
 }
 
 // Submit a price update to Base
-func (t *SubmitRplPrice) updateBase(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, baseMessenger *contracts.OptimismMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
+func (t *SubmitRplPrice) updateBase(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, baseMessenger *contracts.OptimismMessenger, blockNumber uint64, opts *bind.TransactOpts) error {
 	t.logger.Info("Submitting rate to Base...")
 	txInfo, err := baseMessenger.SubmitRate(opts)
 	if err != nil {
@@ -698,7 +698,7 @@ func (t *SubmitRplPrice) updateBase(cfg *config.SmartNodeConfig, res *config.Roc
 }
 
 // Submit a price update to Scroll
-func (t *SubmitRplPrice) updateScroll(cfg *config.SmartNodeConfig, res *config.RocketPoolResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, scrollMessenger *contracts.ScrollMessenger, scrollEstimator *contracts.ScrollFeeEstimator, blockNumber uint64, opts *bind.TransactOpts) error {
+func (t *SubmitRplPrice) updateScroll(cfg *config.SmartNodeConfig, res *config.MergedResources, rp *rocketpool.RocketPool, ec eth.IExecutionClient, scrollMessenger *contracts.ScrollMessenger, scrollEstimator *contracts.ScrollFeeEstimator, blockNumber uint64, opts *bind.TransactOpts) error {
 	t.logger.Info("Submitting rate to Scroll...")
 	maxFee := eth.GweiToWei(utils.GetWatchtowerMaxFee(cfg))
 

--- a/rocketpool-daemon/watchtower/submit-scrub-minipools.go
+++ b/rocketpool-daemon/watchtower/submit-scrub-minipools.go
@@ -45,7 +45,7 @@ type SubmitScrubMinipools struct {
 	sp        services.ISmartNodeServiceProvider
 	logger    *slog.Logger
 	cfg       *config.SmartNodeConfig
-	res       *config.RocketPoolResources
+	res       *config.MergedResources
 	w         *wallet.Wallet
 	rp        *rocketpool.RocketPool
 	ec        eth.IExecutionClient

--- a/rocketpool-daemon/watchtower/submit-scrub-minipools.go
+++ b/rocketpool-daemon/watchtower/submit-scrub-minipools.go
@@ -42,9 +42,10 @@ const MinScrubSafetyTime = time.Duration(0) * time.Hour
 
 // Submit scrub minipools task
 type SubmitScrubMinipools struct {
-	sp        *services.ServiceProvider
+	sp        services.ISmartNodeServiceProvider
 	logger    *slog.Logger
 	cfg       *config.SmartNodeConfig
+	res       *config.RocketPoolResources
 	w         *wallet.Wallet
 	rp        *rocketpool.RocketPool
 	ec        eth.IExecutionClient
@@ -85,12 +86,13 @@ type minipoolDetails struct {
 }
 
 // Create submit scrub minipools task
-func NewSubmitScrubMinipools(sp *services.ServiceProvider, logger *log.Logger, coll *collectors.ScrubCollector) *SubmitScrubMinipools {
+func NewSubmitScrubMinipools(sp services.ISmartNodeServiceProvider, logger *log.Logger, coll *collectors.ScrubCollector) *SubmitScrubMinipools {
 	lock := &sync.Mutex{}
 	return &SubmitScrubMinipools{
 		sp:        sp,
 		logger:    logger.With(slog.String(keys.TaskKey, "Minipool Scrub")),
 		cfg:       sp.GetConfig(),
+		res:       sp.GetResources(),
 		w:         sp.GetWallet(),
 		rp:        sp.GetRocketPool(),
 		ec:        sp.GetEthClient(),
@@ -520,7 +522,7 @@ func (t *SubmitScrubMinipools) submitVoteScrubMinipool(mp minipool.IMinipool) er
 	opts.GasLimit = txInfo.SimulationResult.SafeGasLimit
 
 	// Print TX info and wait for it to be included in a block
-	err = tx.PrintAndWaitForTransaction(t.cfg, t.rp, t.logger, txInfo, opts)
+	err = tx.PrintAndWaitForTransaction(t.cfg, t.res, t.rp, t.logger, txInfo, opts)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-daemon/watchtower/watchtower.go
+++ b/rocketpool-daemon/watchtower/watchtower.go
@@ -27,7 +27,7 @@ type TaskManager struct {
 	// Services
 	logger *log.Logger
 	ctx    context.Context
-	sp     *services.ServiceProvider
+	sp     services.ISmartNodeServiceProvider
 	cfg    *config.SmartNodeConfig
 	rp     *rocketpool.RocketPool
 	bc     beacon.IBeaconClient
@@ -56,7 +56,7 @@ type TaskManager struct {
 }
 
 func NewTaskManager(
-	sp *services.ServiceProvider,
+	sp services.ISmartNodeServiceProvider,
 	stateMgr *state.NetworkStateManager,
 	scrubCollector *collectors.ScrubCollector,
 	bondReductionCollector *collectors.BondReductionCollector,

--- a/shared/config/ids/ids.go
+++ b/shared/config/ids/ids.go
@@ -2,9 +2,10 @@ package ids
 
 const (
 	// Root IDs
-	VersionID   string = "version"
-	IsNativeKey string = "isNative"
-	SmartNodeID string = "smartNode"
+	VersionID        string = "version"
+	IsNativeKey      string = "isNative"
+	SmartNodeID      string = "smartNode"
+	EthNetworkNameID string = "ethNetworkName"
 
 	// Smart Node parameter IDs
 	NetworkID                                  string = "network"

--- a/shared/config/resources.go
+++ b/shared/config/resources.go
@@ -127,88 +127,88 @@ type SmartNodeSettings struct {
 // A collection of network-specific resources and getters for them
 type SmartNodeResources struct {
 	// The URL to use for staking rETH
-	StakeUrl string
+	StakeUrl string `yaml:"stakeUrl" json:"stakeUrl"`
 
 	// The contract address of RocketStorage
-	StorageAddress common.Address
+	StorageAddress common.Address `yaml:"storageAddress" json:"storageAddress"`
 
 	// The contract address of rETH
-	RethAddress common.Address
+	RethAddress common.Address `yaml:"rethAddress" json:"rethAddress"`
 
 	// The contract address of the RPL token
-	RplTokenAddress common.Address
+	RplTokenAddress common.Address `yaml:"rplTokenAddress" json:"rplTokenAddress"`
 
 	// The contract address of rocketRewardsPool from v1.0.0
-	V1_0_0_RewardsPoolAddress *common.Address
+	V1_0_0_RewardsPoolAddress *common.Address `yaml:"v1_0_0_RewardsPoolAddress" json:"v1_0_0_RewardsPoolAddress"`
 
 	// The contract address of rocketClaimNode from v1.0.0
-	V1_0_0_ClaimNodeAddress *common.Address
+	V1_0_0_ClaimNodeAddress *common.Address `yaml:"v1_0_0_ClaimNodeAddress" json:"v1_0_0_ClaimNodeAddress"`
 
 	// The contract address of rocketClaimTrustedNode from v1.0.0
-	V1_0_0_ClaimTrustedNodeAddress *common.Address
+	V1_0_0_ClaimTrustedNodeAddress *common.Address `yaml:"v1_0_0_ClaimTrustedNodeAddress" json:"v1_0_0_ClaimTrustedNodeAddress"`
 
 	// The contract address of rocketMinipoolManager from v1.0.0
-	V1_0_0_MinipoolManagerAddress *common.Address
+	V1_0_0_MinipoolManagerAddress *common.Address `yaml:"v1_0_0_MinipoolManagerAddress" json:"v1_0_0_MinipoolManagerAddress"`
 
 	// The contract address of rocketNetworkPrices from v1.1.0
-	V1_1_0_NetworkPricesAddress *common.Address
+	V1_1_0_NetworkPricesAddress *common.Address `yaml:"v1_1_0_NetworkPricesAddress" json:"v1_1_0_NetworkPricesAddress"`
 
 	// The contract address of rocketNodeStaking from v1.1.0
-	V1_1_0_NodeStakingAddress *common.Address
+	V1_1_0_NodeStakingAddress *common.Address `yaml:"v1_1_0_NodeStakingAddress" json:"v1_1_0_NodeStakingAddress"`
 
 	// The contract address of rocketNodeDeposit from v1.1.0
-	V1_1_0_NodeDepositAddress *common.Address
+	V1_1_0_NodeDepositAddress *common.Address `yaml:"v1_1_0_NodeDepositAddress" json:"v1_1_0_NodeDepositAddress"`
 
 	// The contract address of rocketMinipoolQueue from v1.1.0
-	V1_1_0_MinipoolQueueAddress *common.Address
+	V1_1_0_MinipoolQueueAddress *common.Address `yaml:"v1_1_0_MinipoolQueueAddress" json:"v1_1_0_MinipoolQueueAddress"`
 
 	// The contract address of rocketMinipoolFactory from v1.1.0
-	V1_1_0_MinipoolFactoryAddress *common.Address
+	V1_1_0_MinipoolFactoryAddress *common.Address `yaml:"v1_1_0_MinipoolFactoryAddress" json:"v1_1_0_MinipoolFactoryAddress"`
 
 	// The contract address of rocketNetworkPrices from v1.2.0
-	V1_2_0_NetworkPricesAddress *common.Address
+	V1_2_0_NetworkPricesAddress *common.Address `yaml:"v1_2_0_NetworkPricesAddress" json:"v1_2_0_NetworkPricesAddress"`
 
 	// The contract address of rocketNetworkBalances from v1.2.0
-	V1_2_0_NetworkBalancesAddress *common.Address
+	V1_2_0_NetworkBalancesAddress *common.Address `yaml:"v1_2_0_NetworkBalancesAddress" json:"v1_2_0_NetworkBalancesAddress"`
 
 	// The contract address for Snapshot delegation
-	SnapshotDelegationAddress *common.Address
+	SnapshotDelegationAddress *common.Address `yaml:"snapshotDelegationAddress" json:"snapshotDelegationAddress"`
 
 	// The Snapshot API domain
-	SnapshotApiDomain string
+	SnapshotApiDomain string `yaml:"snapshotApiDomain" json:"snapshotApiDomain"`
 
 	// Addresses for RocketRewardsPool that have been upgraded during development
-	PreviousRewardsPoolAddresses []common.Address
+	PreviousRewardsPoolAddresses []common.Address `yaml:"previousRewardsPoolAddresses" json:"previousRewardsPoolAddresses"`
 
 	// Addresses for RocketDAOProtocolVerifier that have been upgraded during development
-	PreviousProtocolDaoVerifierAddresses []common.Address
+	PreviousProtocolDaoVerifierAddresses []common.Address `yaml:"previousProtocolDaoVerifierAddresses" json:"previousProtocolDaoVerifierAddresses"`
 
 	// The RocketOvmPriceMessenger Optimism address for each network
-	OptimismPriceMessengerAddress *common.Address
+	OptimismPriceMessengerAddress *common.Address `yaml:"optimismPriceMessengerAddress" json:"optimismPriceMessengerAddress"`
 
 	// The RocketPolygonPriceMessenger Polygon address for each network
-	PolygonPriceMessengerAddress *common.Address
+	PolygonPriceMessengerAddress *common.Address `yaml:"polygonPriceMessengerAddress" json:"polygonPriceMessengerAddress"`
 
 	// The RocketArbitumPriceMessenger Arbitrum address for each network
-	ArbitrumPriceMessengerAddress *common.Address
+	ArbitrumPriceMessengerAddress *common.Address `yaml:"arbitrumPriceMessengerAddress" json:"arbitrumPriceMessengerAddress"`
 
 	// The RocketArbitumPriceMessengerV2 Arbitrum address for each network
-	ArbitrumPriceMessengerAddressV2 *common.Address
+	ArbitrumPriceMessengerAddressV2 *common.Address `yaml:"arbitrumPriceMessengerAddressV2" json:"arbitrumPriceMessengerAddressV2"`
 
 	// The RocketZkSyncPriceMessenger zkSyncEra address for each network
-	ZkSyncEraPriceMessengerAddress *common.Address
+	ZkSyncEraPriceMessengerAddress *common.Address `yaml:"zkSyncEraPriceMessengerAddress" json:"zkSyncEraPriceMessengerAddress"`
 
 	// The RocketBasePriceMessenger Base address for each network
-	BasePriceMessengerAddress *common.Address
+	BasePriceMessengerAddress *common.Address `yaml:"basePriceMessengerAddress" json:"basePriceMessengerAddress"`
 
 	// The RocketScrollPriceMessenger Scroll address for each network
-	ScrollPriceMessengerAddress *common.Address
+	ScrollPriceMessengerAddress *common.Address `yaml:"scrollPriceMessengerAddress" json:"scrollPriceMessengerAddress"`
 
 	// The Scroll L2 message fee estimator address for each network
-	ScrollFeeEstimatorAddress *common.Address
+	ScrollFeeEstimatorAddress *common.Address `yaml:"scrollFeeEstimatorAddress" json:"scrollFeeEstimatorAddress"`
 
 	// The UniswapV3 pool address for each network (used for RPL price TWAP info)
-	RplTwapPoolAddress *common.Address
+	RplTwapPoolAddress *common.Address `yaml:"rplTwapPoolAddress" json:"rplTwapPoolAddress"`
 }
 
 // An aggregated collection of resources for the selected network, including Rocket Pool resources

--- a/shared/config/resources.go
+++ b/shared/config/resources.go
@@ -1,16 +1,131 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rocket-pool/node-manager-core/config"
+	"gopkg.in/yaml.v3"
 )
 
-// A collection of network-specific resources and getters for them
-type RocketPoolResources struct {
-	*config.NetworkResources
+var (
+	// Mainnet resources for reference in testing
+	MainnetResourcesReference *SmartNodeResources = &SmartNodeResources{
+		StakeUrl:                       "https://stake.rocketpool.net",
+		StorageAddress:                 common.HexToAddress("0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46"),
+		RethAddress:                    common.HexToAddress("0xae78736Cd615f374D3085123A210448E74Fc6393"),
+		RplTokenAddress:                common.HexToAddress("0xD33526068D116cE69F19A9ee46F0bd304F21A51f"),
+		V1_0_0_RewardsPoolAddress:      config.HexToAddressPtr("0xA3a18348e6E2d3897B6f2671bb8c120e36554802"),
+		V1_0_0_ClaimNodeAddress:        config.HexToAddressPtr("0x899336A2a86053705E65dB61f52C686dcFaeF548"),
+		V1_0_0_ClaimTrustedNodeAddress: config.HexToAddressPtr("0x6af730deB0463b432433318dC8002C0A4e9315e8"),
+		V1_0_0_MinipoolManagerAddress:  config.HexToAddressPtr("0x6293B8abC1F36aFB22406Be5f96D893072A8cF3a"),
+		V1_1_0_NetworkPricesAddress:    config.HexToAddressPtr("0xd3f500F550F46e504A4D2153127B47e007e11166"),
+		V1_1_0_NodeStakingAddress:      config.HexToAddressPtr("0xA73ec45Fe405B5BFCdC0bF4cbc9014Bb32a01cd2"),
+		V1_1_0_NodeDepositAddress:      config.HexToAddressPtr("0x1Cc9cF5586522c6F483E84A19c3C2B0B6d027bF0"),
+		V1_1_0_MinipoolQueueAddress:    config.HexToAddressPtr("0x5870dA524635D1310Dc0e6F256Ce331012C9C19E"),
+		V1_1_0_MinipoolFactoryAddress:  config.HexToAddressPtr("0x54705f80D7C51Fcffd9C659ce3f3C9a7dCCf5788"),
+		V1_2_0_NetworkPricesAddress:    config.HexToAddressPtr("0x751826b107672360b764327631cC5764515fFC37"),
+		V1_2_0_NetworkBalancesAddress:  config.HexToAddressPtr("0x07FCaBCbe4ff0d80c2b1eb42855C0131b6cba2F4"),
+		SnapshotDelegationAddress:      config.HexToAddressPtr("0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446"),
+		SnapshotApiDomain:              "hub.snapshot.org",
+		PreviousRewardsPoolAddresses: []common.Address{
+			common.HexToAddress("0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1"),
+		},
+		PreviousProtocolDaoVerifierAddresses: []common.Address{},
+		OptimismPriceMessengerAddress:        config.HexToAddressPtr("0xdddcf2c25d50ec22e67218e873d46938650d03a7"),
+		PolygonPriceMessengerAddress:         config.HexToAddressPtr("0xb1029Ac2Be4e08516697093e2AFeC435057f3511"),
+		ArbitrumPriceMessengerAddress:        config.HexToAddressPtr("0x05330300f829AD3fC8f33838BC88CFC4093baD53"),
+		ArbitrumPriceMessengerAddressV2:      config.HexToAddressPtr("0x312FcFB03eC9B1Ea38CB7BFCd26ee7bC3b505aB1"),
+		ZkSyncEraPriceMessengerAddress:       config.HexToAddressPtr("0x6cf6CB29754aEBf88AF12089224429bD68b0b8c8"),
+		BasePriceMessengerAddress:            config.HexToAddressPtr("0x64A5856869C06B0188C84A5F83d712bbAc03517d"),
+		ScrollPriceMessengerAddress:          config.HexToAddressPtr("0x0f22dc9b9c03757d4676539203d7549c8f22c15c"),
+		ScrollFeeEstimatorAddress:            config.HexToAddressPtr("0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B"),
+		RplTwapPoolAddress:                   config.HexToAddressPtr("0xe42318ea3b998e8355a3da364eb9d48ec725eb45"),
+	}
 
+	// Holesky resources for reference in testing
+	HoleskyResourcesReference *SmartNodeResources = &SmartNodeResources{
+		StakeUrl:                       "https://testnet.rocketpool.net",
+		StorageAddress:                 common.HexToAddress("0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1"),
+		RethAddress:                    common.HexToAddress("0x7322c24752f79c05FFD1E2a6FCB97020C1C264F1"),
+		RplTokenAddress:                common.HexToAddress("0x1Cc9cF5586522c6F483E84A19c3C2B0B6d027bF0"),
+		V1_0_0_RewardsPoolAddress:      nil,
+		V1_0_0_ClaimNodeAddress:        nil,
+		V1_0_0_ClaimTrustedNodeAddress: nil,
+		V1_0_0_MinipoolManagerAddress:  nil,
+		V1_1_0_NetworkPricesAddress:    nil,
+		V1_1_0_NodeStakingAddress:      nil,
+		V1_1_0_NodeDepositAddress:      nil,
+		V1_1_0_MinipoolQueueAddress:    nil,
+		V1_1_0_MinipoolFactoryAddress:  nil,
+		V1_2_0_NetworkPricesAddress:    config.HexToAddressPtr("0x029d946F28F93399a5b0D09c879FC8c94E596AEb"),
+		V1_2_0_NetworkBalancesAddress:  config.HexToAddressPtr("0x9294Fc6F03c64Cc217f5BE8697EA3Ed2De77e2F8"),
+		SnapshotDelegationAddress:      nil,
+		SnapshotApiDomain:              "",
+		PreviousRewardsPoolAddresses: []common.Address{
+			common.HexToAddress("0x4a625C617a44E60F74E3fe3bf6d6333b63766e91"),
+		},
+		PreviousProtocolDaoVerifierAddresses: nil,
+		OptimismPriceMessengerAddress:        nil,
+		PolygonPriceMessengerAddress:         nil,
+		ArbitrumPriceMessengerAddress:        nil,
+		ArbitrumPriceMessengerAddressV2:      nil,
+		ZkSyncEraPriceMessengerAddress:       nil,
+		BasePriceMessengerAddress:            nil,
+		ScrollPriceMessengerAddress:          nil,
+		ScrollFeeEstimatorAddress:            nil,
+		RplTwapPoolAddress:                   config.HexToAddressPtr("0x7bb10d2a3105ed5cc150c099a06cafe43d8aa15d"),
+	}
+
+	// Devnet resources for reference in testing
+	HoleskyDevResourcesReference *SmartNodeResources = &SmartNodeResources{
+		StakeUrl:                       "TBD",
+		StorageAddress:                 common.HexToAddress("0xf04de123993761Bb9F08c9C39112b0E0b0eccE50"),
+		RethAddress:                    common.HexToAddress("0x4be7161080b5d890500194cee2c40B1428002Bd3"),
+		RplTokenAddress:                common.HexToAddress("0x59A1a7AebCbF103B3C4f85261fbaC166117E1979"),
+		V1_0_0_RewardsPoolAddress:      nil,
+		V1_0_0_ClaimNodeAddress:        nil,
+		V1_0_0_ClaimTrustedNodeAddress: nil,
+		V1_0_0_MinipoolManagerAddress:  nil,
+		V1_1_0_NetworkPricesAddress:    nil,
+		V1_1_0_NodeStakingAddress:      nil,
+		V1_1_0_NodeDepositAddress:      nil,
+		V1_1_0_MinipoolQueueAddress:    nil,
+		V1_1_0_MinipoolFactoryAddress:  nil,
+		V1_2_0_NetworkPricesAddress:    config.HexToAddressPtr("0xBba3FBCD4Bdbfc79118B1B31218602E5A71B426c"),
+		V1_2_0_NetworkBalancesAddress:  config.HexToAddressPtr("0xBe8Dc8CA5f339c196Aef634DfcDFbA61E30DC743"),
+		SnapshotDelegationAddress:      nil,
+		SnapshotApiDomain:              "",
+		PreviousRewardsPoolAddresses: []common.Address{
+			common.HexToAddress("0x4d581a552490fb6fce5F978e66560C8b7E481818"),
+		},
+		PreviousProtocolDaoVerifierAddresses: nil,
+		OptimismPriceMessengerAddress:        nil,
+		PolygonPriceMessengerAddress:         nil,
+		ArbitrumPriceMessengerAddress:        nil,
+		ArbitrumPriceMessengerAddressV2:      nil,
+		ZkSyncEraPriceMessengerAddress:       nil,
+		BasePriceMessengerAddress:            nil,
+		ScrollPriceMessengerAddress:          nil,
+		ScrollFeeEstimatorAddress:            nil,
+		RplTwapPoolAddress:                   config.HexToAddressPtr("0x7bb10d2a3105ed5cc150c099a06cafe43d8aa15d"),
+	}
+)
+
+// Network settings with a field for Rocket Pool-specific settings
+type SmartNodeSettings struct {
+	*config.NetworkSettings `yaml:",inline"`
+
+	// Rocket Pool resources for the network
+	SmartNodeResources *SmartNodeResources `yaml:"smartNodeResources" json:"smartNodeResources"`
+}
+
+// A collection of network-specific resources and getters for them
+type SmartNodeResources struct {
 	// The URL to use for staking rETH
 	StakeUrl string
 
@@ -96,128 +211,56 @@ type RocketPoolResources struct {
 	RplTwapPoolAddress *common.Address
 }
 
-// Creates a new resource collection for the given network
-func NewRocketPoolResources(network config.Network) *RocketPoolResources {
-	// Mainnet
-	mainnetResources := &RocketPoolResources{
-		NetworkResources:               config.NewResources(config.Network_Mainnet),
-		StakeUrl:                       "https://stake.rocketpool.net",
-		StorageAddress:                 common.HexToAddress("0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46"),
-		RethAddress:                    common.HexToAddress("0xae78736Cd615f374D3085123A210448E74Fc6393"),
-		RplTokenAddress:                common.HexToAddress("0xD33526068D116cE69F19A9ee46F0bd304F21A51f"),
-		V1_0_0_RewardsPoolAddress:      hexToAddressPtr("0xA3a18348e6E2d3897B6f2671bb8c120e36554802"),
-		V1_0_0_ClaimNodeAddress:        hexToAddressPtr("0x899336A2a86053705E65dB61f52C686dcFaeF548"),
-		V1_0_0_ClaimTrustedNodeAddress: hexToAddressPtr("0x6af730deB0463b432433318dC8002C0A4e9315e8"),
-		V1_0_0_MinipoolManagerAddress:  hexToAddressPtr("0x6293B8abC1F36aFB22406Be5f96D893072A8cF3a"),
-		V1_1_0_NetworkPricesAddress:    hexToAddressPtr("0xd3f500F550F46e504A4D2153127B47e007e11166"),
-		V1_1_0_NodeStakingAddress:      hexToAddressPtr("0xA73ec45Fe405B5BFCdC0bF4cbc9014Bb32a01cd2"),
-		V1_1_0_NodeDepositAddress:      hexToAddressPtr("0x1Cc9cF5586522c6F483E84A19c3C2B0B6d027bF0"),
-		V1_1_0_MinipoolQueueAddress:    hexToAddressPtr("0x5870dA524635D1310Dc0e6F256Ce331012C9C19E"),
-		V1_1_0_MinipoolFactoryAddress:  hexToAddressPtr("0x54705f80D7C51Fcffd9C659ce3f3C9a7dCCf5788"),
-		V1_2_0_NetworkPricesAddress:    hexToAddressPtr("0x751826b107672360b764327631cC5764515fFC37"),
-		V1_2_0_NetworkBalancesAddress:  hexToAddressPtr("0x07FCaBCbe4ff0d80c2b1eb42855C0131b6cba2F4"),
-		SnapshotDelegationAddress:      hexToAddressPtr("0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446"),
-		SnapshotApiDomain:              "hub.snapshot.org",
-		PreviousRewardsPoolAddresses: []common.Address{
-			common.HexToAddress("0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1"),
-		},
-		PreviousProtocolDaoVerifierAddresses: []common.Address{},
-		OptimismPriceMessengerAddress:        hexToAddressPtr("0xdddcf2c25d50ec22e67218e873d46938650d03a7"),
-		PolygonPriceMessengerAddress:         hexToAddressPtr("0xb1029Ac2Be4e08516697093e2AFeC435057f3511"),
-		ArbitrumPriceMessengerAddress:        hexToAddressPtr("0x05330300f829AD3fC8f33838BC88CFC4093baD53"),
-		ArbitrumPriceMessengerAddressV2:      hexToAddressPtr("0x312FcFB03eC9B1Ea38CB7BFCd26ee7bC3b505aB1"),
-		ZkSyncEraPriceMessengerAddress:       hexToAddressPtr("0x6cf6CB29754aEBf88AF12089224429bD68b0b8c8"),
-		BasePriceMessengerAddress:            hexToAddressPtr("0x64A5856869C06B0188C84A5F83d712bbAc03517d"),
-		ScrollPriceMessengerAddress:          hexToAddressPtr("0x0f22dc9b9c03757d4676539203d7549c8f22c15c"),
-		ScrollFeeEstimatorAddress:            hexToAddressPtr("0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B"),
-		RplTwapPoolAddress:                   hexToAddressPtr("0xe42318ea3b998e8355a3da364eb9d48ec725eb45"),
-	}
+// An aggregated collection of resources for the selected network, including Rocket Pool resources
+type MergedResources struct {
+	// Base network resources
+	*config.NetworkResources
 
-	// Holesky
-	holeskyResources := &RocketPoolResources{
-		NetworkResources:               config.NewResources(config.Network_Holesky),
-		StakeUrl:                       "https://testnet.rocketpool.net",
-		StorageAddress:                 common.HexToAddress("0x594Fb75D3dc2DFa0150Ad03F99F97817747dd4E1"),
-		RethAddress:                    common.HexToAddress("0x7322c24752f79c05FFD1E2a6FCB97020C1C264F1"),
-		RplTokenAddress:                common.HexToAddress("0x1Cc9cF5586522c6F483E84A19c3C2B0B6d027bF0"),
-		V1_0_0_RewardsPoolAddress:      nil,
-		V1_0_0_ClaimNodeAddress:        nil,
-		V1_0_0_ClaimTrustedNodeAddress: nil,
-		V1_0_0_MinipoolManagerAddress:  nil,
-		V1_1_0_NetworkPricesAddress:    nil,
-		V1_1_0_NodeStakingAddress:      nil,
-		V1_1_0_NodeDepositAddress:      nil,
-		V1_1_0_MinipoolQueueAddress:    nil,
-		V1_1_0_MinipoolFactoryAddress:  nil,
-		V1_2_0_NetworkPricesAddress:    hexToAddressPtr("0x029d946F28F93399a5b0D09c879FC8c94E596AEb"),
-		V1_2_0_NetworkBalancesAddress:  hexToAddressPtr("0x9294Fc6F03c64Cc217f5BE8697EA3Ed2De77e2F8"),
-		SnapshotDelegationAddress:      nil,
-		SnapshotApiDomain:              "",
-		PreviousRewardsPoolAddresses: []common.Address{
-			common.HexToAddress("0x4a625C617a44E60F74E3fe3bf6d6333b63766e91"),
-		},
-		PreviousProtocolDaoVerifierAddresses: nil,
-		OptimismPriceMessengerAddress:        nil,
-		PolygonPriceMessengerAddress:         nil,
-		ArbitrumPriceMessengerAddress:        nil,
-		ArbitrumPriceMessengerAddressV2:      nil,
-		ZkSyncEraPriceMessengerAddress:       nil,
-		BasePriceMessengerAddress:            nil,
-		ScrollPriceMessengerAddress:          nil,
-		ScrollFeeEstimatorAddress:            nil,
-		RplTwapPoolAddress:                   hexToAddressPtr("0x7bb10d2a3105ed5cc150c099a06cafe43d8aa15d"),
-	}
-
-	// Devnet
-	devnetResources := &RocketPoolResources{
-		NetworkResources:               config.NewResources(config.Network_Holesky),
-		StakeUrl:                       "TBD",
-		StorageAddress:                 common.HexToAddress("0xf04de123993761Bb9F08c9C39112b0E0b0eccE50"),
-		RethAddress:                    common.HexToAddress("0x4be7161080b5d890500194cee2c40B1428002Bd3"),
-		RplTokenAddress:                common.HexToAddress("0x59A1a7AebCbF103B3C4f85261fbaC166117E1979"),
-		V1_0_0_RewardsPoolAddress:      nil,
-		V1_0_0_ClaimNodeAddress:        nil,
-		V1_0_0_ClaimTrustedNodeAddress: nil,
-		V1_0_0_MinipoolManagerAddress:  nil,
-		V1_1_0_NetworkPricesAddress:    nil,
-		V1_1_0_NodeStakingAddress:      nil,
-		V1_1_0_NodeDepositAddress:      nil,
-		V1_1_0_MinipoolQueueAddress:    nil,
-		V1_1_0_MinipoolFactoryAddress:  nil,
-		V1_2_0_NetworkPricesAddress:    hexToAddressPtr("0xBba3FBCD4Bdbfc79118B1B31218602E5A71B426c"),
-		V1_2_0_NetworkBalancesAddress:  hexToAddressPtr("0xBe8Dc8CA5f339c196Aef634DfcDFbA61E30DC743"),
-		SnapshotDelegationAddress:      nil,
-		SnapshotApiDomain:              "",
-		PreviousRewardsPoolAddresses: []common.Address{
-			common.HexToAddress("0x4d581a552490fb6fce5F978e66560C8b7E481818"),
-		},
-		PreviousProtocolDaoVerifierAddresses: nil,
-		OptimismPriceMessengerAddress:        nil,
-		PolygonPriceMessengerAddress:         nil,
-		ArbitrumPriceMessengerAddress:        nil,
-		ArbitrumPriceMessengerAddressV2:      nil,
-		ZkSyncEraPriceMessengerAddress:       nil,
-		BasePriceMessengerAddress:            nil,
-		ScrollPriceMessengerAddress:          nil,
-		ScrollFeeEstimatorAddress:            nil,
-		RplTwapPoolAddress:                   hexToAddressPtr("0x7bb10d2a3105ed5cc150c099a06cafe43d8aa15d"),
-	}
-	devnetResources.NetworkResources.Network = Network_Devnet
-
-	switch network {
-	case config.Network_Mainnet:
-		return mainnetResources
-	case config.Network_Holesky:
-		return holeskyResources
-	case Network_Devnet:
-		return devnetResources
-	}
-
-	panic(fmt.Sprintf("network %s is not supported", network))
+	// Rocket Pool resources
+	*SmartNodeResources
 }
 
-// Convert a hex string to an address, wrapped in a pointer
-func hexToAddressPtr(hexAddress string) *common.Address {
-	address := common.HexToAddress(hexAddress)
-	return &address
+// Load network settings from a folder
+func LoadSettingsFiles(sourceDir string) ([]*SmartNodeSettings, error) {
+	// Make sure the folder exists
+	_, err := os.Stat(sourceDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("network settings folder [%s] does not exist", sourceDir)
+	}
+
+	// Enumerate the dir
+	files, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("error enumerating override source folder: %w", err)
+	}
+
+	settingsList := []*SmartNodeSettings{}
+	for _, file := range files {
+		// Ignore dirs and nonstandard files
+		if file.IsDir() || !file.Type().IsRegular() {
+			continue
+		}
+
+		// Load the file
+		filename := file.Name()
+		ext := filepath.Ext(filename)
+		if ext != ".yaml" && ext != ".yml" {
+			// Only load YAML files
+			continue
+		}
+		settingsFilePath := filepath.Join(sourceDir, filename)
+		bytes, err := os.ReadFile(settingsFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading network settings file [%s]: %w", settingsFilePath, err)
+		}
+
+		// Unmarshal the settings
+		settings := new(SmartNodeSettings)
+		err = yaml.Unmarshal(bytes, settings)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling network settings file [%s]: %w", settingsFilePath, err)
+		}
+		settingsList = append(settingsList, settings)
+	}
+	return settingsList, nil
 }

--- a/shared/config/resources.go
+++ b/shared/config/resources.go
@@ -97,7 +97,7 @@ type RocketPoolResources struct {
 }
 
 // Creates a new resource collection for the given network
-func newRocketPoolResources(network config.Network) *RocketPoolResources {
+func NewRocketPoolResources(network config.Network) *RocketPoolResources {
 	// Mainnet
 	mainnetResources := &RocketPoolResources{
 		NetworkResources:               config.NewResources(config.Network_Mainnet),

--- a/shared/config/settings.go
+++ b/shared/config/settings.go
@@ -33,7 +33,8 @@ const (
 	MevBoostStartScript string = "start-mev-boost.sh"
 
 	// HTTP
-	ClientTimeout time.Duration = 1 * time.Minute
+	ClientTimeout     time.Duration = 1 * time.Minute
+	ExternalIPTimeout time.Duration = 3 * time.Second
 
 	// Volumes
 	ExecutionClientDataVolume string = "eth1clientdata"

--- a/shared/config/smartnode-config.go
+++ b/shared/config/smartnode-config.go
@@ -78,7 +78,6 @@ type SmartNodeConfig struct {
 	Version             string
 	rocketPoolDirectory string
 	IsNativeMode        bool
-	resources           *RocketPoolResources
 }
 
 // Load configuration settings from a file
@@ -568,7 +567,6 @@ func (cfg *SmartNodeConfig) Deserialize(masterMap map[string]any) error {
 		return fmt.Errorf("expected a native toggle parameter named [%s] but it was not found", ids.IsNativeKey)
 	}
 	cfg.IsNativeMode, _ = strconv.ParseBool(isNativeMode.(string))
-	cfg.updateResources()
 
 	return nil
 }
@@ -584,7 +582,6 @@ func (cfg *SmartNodeConfig) ChangeNetwork(newNetwork config.Network) {
 
 	// Run the changes
 	config.ChangeNetwork(cfg, oldNetwork, newNetwork)
-	cfg.updateResources()
 }
 
 // Create a copy of this configuration.
@@ -592,7 +589,6 @@ func (cfg *SmartNodeConfig) CreateCopy() *SmartNodeConfig {
 	network := cfg.Network.Value
 	copy := NewSmartNodeConfig(cfg.rocketPoolDirectory, cfg.IsNativeMode)
 	config.Clone(cfg, copy, network)
-	copy.updateResources()
 	copy.Version = cfg.Version
 	return copy
 }
@@ -741,12 +737,6 @@ func (cfg *SmartNodeConfig) Validate() []string {
 func (cfg *SmartNodeConfig) applyAllDefaults() {
 	network := cfg.Network.Value
 	config.ApplyDefaults(cfg, network)
-	cfg.updateResources()
-}
-
-// Update the config's resource cache
-func (cfg *SmartNodeConfig) updateResources() {
-	cfg.resources = newRocketPoolResources(cfg.Network.Value)
 }
 
 // Get the list of options for networks to run on

--- a/shared/config/templating.go
+++ b/shared/config/templating.go
@@ -215,7 +215,7 @@ func (cfg *SmartNodeConfig) GetEcAdditionalFlags() (string, error) {
 // Used by text/template to format ec.yml
 func (cfg *SmartNodeConfig) GetExternalIP() string {
 	// Get the external IP address
-	ip, err := config.GetExternalIP()
+	ip, err := config.GetExternalIP(ExternalIPTimeout)
 	if err != nil {
 		fmt.Println("Warning: couldn't get external IP address; if you're using Nimbus or Besu, it may have trouble finding peers:")
 		fmt.Println(err.Error())

--- a/shared/config/utils.go
+++ b/shared/config/utils.go
@@ -8,14 +8,6 @@ import (
 	"github.com/rocket-pool/node-manager-core/log"
 )
 
-func (cfg *SmartNodeConfig) GetNetworkResources() *config.NetworkResources {
-	return cfg.GetRocketPoolResources().NetworkResources
-}
-
-func (cfg *SmartNodeConfig) GetRocketPoolResources() *RocketPoolResources {
-	return cfg.resources
-}
-
 func (cfg *SmartNodeConfig) GetVotingPath() string {
 	return filepath.Join(cfg.UserDataPath.Value, VotingFolder, string(cfg.Network.Value))
 }


### PR DESCRIPTION
This allows the Smart Node to load its network settings and resources from disk, rather than hardcoding them directly into the app. Patches and I have been talking about this for a while and better late than never!

Benefits are:
- Ability to add new network configurations for new networks like Kurtosis
- Ability to modify parameters (like URLs or addresses) for existing networks (e.g, add new `previousRocketRewardsPoolAddresses` directly in the settings file instead of having to build a new SN release with an updated address list).

I did my best to port the structure over from HD, but I'd test this all-the-same just to make sure I didn't miss anything. I haven't actually run this build of the SN in a vacuum to make sure all of the template parameters have been updated so pay particular attention to that. Otherwise, enjoy!