### PR TITLE
Besu v24.7.0

### DIFF
--- a/shared/services/config/besu-params.go
+++ b/shared/services/config/besu-params.go
@@ -6,8 +6,8 @@ import (
 
 // Constants
 const (
-	besuTagTest          string = "hyperledger/besu:24.6.0"
-	besuTagProd          string = "hyperledger/besu:24.6.0"
+	besuTagTest          string = "hyperledger/besu:24.7.0"
+	besuTagProd          string = "hyperledger/besu:24.7.0"
 	besuEventLogInterval int    = 1000
 	besuMaxPeers         uint16 = 25
 	besuStopSignal       string = "SIGTERM"


### PR DESCRIPTION
Update to new version. There is a change on smartnode-install to remove a deprecated param.