### PR TITLE
Update optimism oracle price messenger address 

### DIFF
--- a/shared/services/config/smartnode-config.go
+++ b/shared/services/config/smartnode-config.go
@@ -585,7 +585,7 @@ func NewSmartnodeConfig(cfg *RocketPoolConfig) *SmartnodeConfig {
 		},
 
 		optimismPriceMessengerAddress: map[config.Network]string{
-			config.Network_Mainnet: "0xdddcf2c25d50ec22e67218e873d46938650d03a7",
+			config.Network_Mainnet: "0x16d468E69Dbb67Fb924a4c61D7D35F81d1B27A3F",
 			config.Network_Devnet:  "",
 			config.Network_Holesky: "",
 		},


### PR DESCRIPTION
`0x16d468E69Dbb67Fb924a4c61D7D35F81d1B27A3F` adds an additional call to rebase the WRETH token on optimism for the 4626 vault to work properly.