### PR TITLE
Update node status

### DIFF
--- a/rocketpool-cli/commands/node/status.go
+++ b/rocketpool-cli/commands/node/status.go
@@ -147,15 +147,15 @@ func getStatus(c *cli.Context) error {
 			fmt.Println()
 		}
 
-		// Snapshot voting status
-		fmt.Printf("%s=== DAO Voting ===%s\n", terminal.ColorGreen, terminal.ColorReset)
+		// Signalling Status
+		fmt.Printf("%s=== Signalling on Snapshot ===%s\n", terminal.ColorGreen, terminal.ColorReset)
 		blankAddress := common.Address{}
-		if status.Data.SnapshotVotingDelegate == blankAddress {
-			fmt.Println("The node does not currently have a voting delegate set, which means it can only vote directly on Snapshot proposals (using a hardware wallet with the node mnemonic loaded).\nRun `rocketpool n sv <address>` to vote from a different wallet or have a delegate represent you. (See https://delegates.rocketpool.net for options)")
+		if status.Data.SignallingAddress == blankAddress {
+			fmt.Println("The node does not currently have a snapshot signalling address set.")
+			fmt.Println("To learn more about snapshot signalling, please visit https://docs.rocketpool.net/guides/houston/participate#setting-your-snapshot-signalling-address/")
 		} else {
-			fmt.Printf("The node has a voting delegate of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", terminal.ColorBlue, status.Data.SnapshotVotingDelegateFormatted, terminal.ColorReset)
+			fmt.Printf("The node has a signalling address of %s%s%s which can represent it when voting on Rocket Pool Snapshot governance proposals.\n", terminal.ColorBlue, status.Data.SignallingAddressFormatted, terminal.ColorReset)
 		}
-
 		if status.Data.SnapshotResponse.Error != "" {
 			fmt.Printf("Unable to fetch latest voting information from snapshot.org: %s\n", status.Data.SnapshotResponse.Error)
 		} else {
@@ -167,12 +167,12 @@ func getStatus(c *cli.Context) error {
 				}
 			}
 			if len(status.Data.SnapshotResponse.ActiveSnapshotProposals) == 0 {
-				fmt.Print("Rocket Pool has no Snapshot governance proposals being voted on.\n")
+				fmt.Println("Rocket Pool has no Snapshot governance proposals being voted on.")
 			} else {
 				fmt.Printf("Rocket Pool has %d Snapshot governance proposal(s) being voted on. You have voted on %d of those. See details using 'rocketpool network dao-proposals'.\n", len(status.Data.SnapshotResponse.ActiveSnapshotProposals), voteCount)
 			}
-			fmt.Println("")
 		}
+		fmt.Println()
 
 		// Onchain voting status
 		fmt.Printf("%s=== Onchain Voting ===%s\n", terminal.ColorGreen, terminal.ColorReset)

--- a/rocketpool-cli/commands/node/status.go
+++ b/rocketpool-cli/commands/node/status.go
@@ -104,7 +104,7 @@ func getStatus(c *cli.Context) error {
 		if status.Data.Trusted {
 			fmt.Println("The node is a member of the oracle DAO - it can vote on DAO proposals and perform watchtower duties.")
 		}
-		fmt.Println("")
+		fmt.Println()
 
 		// Penalties
 		fmt.Printf("%s=== Penalty Status ===%s\n", terminal.ColorGreen, terminal.ColorReset)
@@ -198,7 +198,7 @@ func getStatus(c *cli.Context) error {
 		} else {
 			fmt.Print("The node is NOT allowed to lock RPL to create governance proposals/challenges.\n")
 		}
-		fmt.Println("")
+		fmt.Println()
 
 		// Primary withdrawal address & balances
 		fmt.Printf("%s=== Primary Withdrawal Address ===%s\n", terminal.ColorGreen, terminal.ColorReset)
@@ -214,11 +214,11 @@ func getStatus(c *cli.Context) error {
 			fmt.Printf("%sThe node's primary withdrawal address has not been changed, so ETH rewards and minipool withdrawals will be sent to the node itself.\n", terminal.ColorYellow)
 			fmt.Printf("Consider changing this to a cold wallet address that you control using the `set-withdrawal-address` command.\n%s", terminal.ColorReset)
 		}
-		fmt.Println("")
+		fmt.Println()
 		if status.Data.PendingPrimaryWithdrawalAddress.Hex() != blankAddress.Hex() {
 			fmt.Printf("%sThe node's primary withdrawal address has a pending change to %s which has not been confirmed yet.\n", terminal.ColorYellow, status.Data.PendingPrimaryWithdrawalAddressFormatted)
 			fmt.Printf("Please visit the Rocket Pool website with a web3-compatible wallet to complete this change.%s\n", terminal.ColorReset)
-			fmt.Println("")
+			fmt.Println()
 		}
 
 		// RPL withdrawal address & balances
@@ -238,7 +238,7 @@ func getStatus(c *cli.Context) error {
 				math.RoundDown(eth.WeiToEth(status.Data.RplWithdrawalBalances.Eth), 6),
 				math.RoundDown(eth.WeiToEth(status.Data.RplWithdrawalBalances.Rpl), 6))
 		}
-		fmt.Println("")
+		fmt.Println()
 		if status.Data.PendingRplWithdrawalAddress.Hex() != blankAddress.Hex() {
 			fmt.Printf("%sThe node's RPL withdrawal address has a pending change to %s which has not been confirmed yet.\n", terminal.ColorYellow, status.Data.PendingRplWithdrawalAddressFormatted)
 			fmt.Printf("Please visit the Rocket Pool website with a web3-compatible wallet to complete this change.%s\n", terminal.ColorReset)
@@ -275,7 +275,8 @@ func getStatus(c *cli.Context) error {
 			fmt.Printf("%sNOTE: You are in Native Mode; you MUST ensure that your Validator Client is using this address as its fee recipient!%s\n", terminal.ColorYellow, terminal.ColorReset)
 		}
 		if !status.Data.IsFeeDistributorInitialized {
-			fmt.Printf("\n%sThe fee distributor hasn't been initialized yet. When you are able, please initialize it with `rocketpool node initialize-fee-distributor`.%s\n", terminal.ColorYellow, terminal.ColorReset)
+			fmt.Println()
+			fmt.Printf("%sThe fee distributor hasn't been initialized yet. When you are able, please initialize it with `rocketpool node initialize-fee-distributor`.%s\n", terminal.ColorYellow, terminal.ColorReset)
 		}
 
 		fmt.Println()
@@ -290,6 +291,8 @@ func getStatus(c *cli.Context) error {
 			math.RoundDown(eth.WeiToEth(status.Data.EffectiveRplStake), 6))
 		if status.Data.BorrowedCollateralRatio > 0 {
 			rplTooLow := (status.Data.RplStake.Cmp(status.Data.MinimumRplStake) < 0)
+			rplTotalStake := math.RoundDown(eth.WeiToEth(status.Data.RplStake), 6)
+			rplWithdrawalLimit := math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6)
 			if rplTooLow {
 				fmt.Printf(
 					"This is currently %s%.2f%% of its borrowed ETH%s and %.2f%% of its bonded ETH.\n",
@@ -303,6 +306,12 @@ func getStatus(c *cli.Context) error {
 				"It must keep at least %.6f RPL staked to claim RPL rewards (10%% of borrowed ETH).\n", math.RoundDown(eth.WeiToEth(status.Data.MinimumRplStake), 6))
 			fmt.Printf(
 				"RPIP-30 is in effect and the node will gradually earn rewards in amounts above the previous limit of %.6f RPL (150%% of bonded ETH). Read more at https://github.com/rocket-pool/RPIPs/blob/main/RPIPs/RPIP-30.md\n", math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6))
+			if rplTotalStake > rplWithdrawalLimit {
+				fmt.Printf(
+					"You can now withdraw down to %.6f RPL (%.0f%% of bonded eth)\n",
+					math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6),
+					eth.WeiToEth(status.Data.MaximumStakeFraction)*100)
+			}
 			if rplTooLow {
 				fmt.Printf("%sWARNING: you are currently undercollateralized. You must stake at least %.6f more RPL in order to claim RPL rewards.%s\n", terminal.ColorRed, math.RoundUp(eth.WeiToEth(big.NewInt(0).Sub(status.Data.MinimumRplStake, status.Data.RplStake)), 6), terminal.ColorReset)
 			}

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -69,8 +69,6 @@ type NodeStatusData struct {
 	PendingMaximumRplStake            *big.Int       `json:"pendingMaximumRplStake"`
 	PendingBorrowedCollateralRatio    float64        `json:"pendingBorrowedCollateralRatio"`
 	PendingBondedCollateralRatio      float64        `json:"pendingBondedCollateralRatio"`
-	SnapshotVotingDelegate            common.Address `json:"votingDelegate"`
-	SnapshotVotingDelegateFormatted   string         `json:"votingDelegateFormatted"`
 	IsVotingInitialized               bool           `json:"isVotingInitialized"`
 	OnchainVotingDelegate             common.Address `json:"onchainVotingDelegate"`
 	OnchainVotingDelegateFormatted    string         `json:"onchainVotingDelegateFormatted"`

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -100,7 +100,9 @@ type NodeStatusData struct {
 		Error                   string                          `json:"error"`
 		ActiveSnapshotProposals []*sharedtypes.SnapshotProposal `json:"activeSnapshotProposals"`
 	} `json:"snapshotResponse"`
-	Alerts []NodeAlert `json:"alerts"`
+	Alerts                     []NodeAlert    `json:"alerts"`
+	SignallingAddress          common.Address `json:"signallingAddress"`
+	SignallingAddressFormatted string         `json:"signallingAddressFormatted"`
 }
 
 type NodeRegisterData struct {


### PR DESCRIPTION
Some small changes so v2 `node status` has parity with v1

Deprecated:
```
=== DAO Voting ===
The node does not currently have a voting delegate set, which means it can only vote directly on Snapshot proposals (using a hardware wallet with the node mnemonic loaded).
Run `rocketpool n sv <address>` to vote from a different wallet or have a delegate represent you. (See https://delegates.rocketpool.net for options)
Rocket Pool has no Snapshot governance proposals being voted on.
```

New:
```
=== Signalling on Snapshot ===
The node has a signalling address of tptest.eth (0x18eea3fBe5008d6f7a95d963a4BE403E82d35758) which can represent it when voting on Rocket Pool Snapshot governance proposals.
Rocket Pool has no Snapshot governance proposals being voted on.
```

Also added this to the `=== RPL Stake ===` output:
```
You can now withdraw down to 606.056977 RPL (60% of bonded eth)
```
