### PR TITLE
Update V2 initialize voting to mirror V1 behaviour 

### DIFF
--- a/client/pdao.go
+++ b/client/pdao.go
@@ -195,12 +195,17 @@ func (r *PDaoRequester) ProposeSetting(contractName rocketpool.ContractName, set
 	return client.SendGetRequest[api.ProtocolDaoProposeSettingData](r, "setting/propose", "ProposeSetting", args)
 }
 
-// Initialize voting so the node can vote on Protocol DAO proposals
-func (r *PDaoRequester) InitializeVoting(delegate common.Address) (*types.ApiResponse[api.ProtocolDaoInitializeVotingData], error) {
+// Initialize voting with delegate unlocks the node's voting power and sets the delegate in one transasction
+func (r *PDaoRequester) InitializeVotingWithDelegate(delegate common.Address) (*types.ApiResponse[api.ProtocolDaoInitializeVotingData], error) {
 	args := map[string]string{
 		"delegate": delegate.Hex(),
 	}
-	return client.SendGetRequest[api.ProtocolDaoInitializeVotingData](r, "initialize-voting", "InitializeVoting", args)
+	return client.SendGetRequest[api.ProtocolDaoInitializeVotingData](r, "initialize-voting-with-delegate", "InitializeVotingWithDelegate", args)
+}
+
+// Initialize voting so the node can vote on Protocol DAO proposals
+func (r *PDaoRequester) InitializeVoting() (*types.ApiResponse[api.ProtocolDaoInitializeVotingData], error) {
+	return client.SendGetRequest[api.ProtocolDaoInitializeVotingData](r, "initialize-voting", "InitializeVoting", nil)
 }
 
 // Set the delegate for voting on Protocol DAO proposals

--- a/rocketpool-cli/commands/pdao/commands.go
+++ b/rocketpool-cli/commands/pdao/commands.go
@@ -160,7 +160,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Usage:   "Unlocks a node operator's voting power (only required for node operators who registered before governance structure was in place)",
 				Action: func(c *cli.Context) error {
 					// Run
-					return initializeVoting(c)
+					return initializeVotingPrompt(c)
 				},
 			},
 

--- a/rocketpool-cli/commands/pdao/initialize-voting.go
+++ b/rocketpool-cli/commands/pdao/initialize-voting.go
@@ -11,7 +11,7 @@ import (
 )
 
 func initializeVotingPrompt(c *cli.Context) error {
-	if utils.Confirm(fmt.Sprintf("Would you like to specify a delegate that can vote on your behalf on Protocol DAO proposals?")) {
+	if utils.Confirm("Would you like to specify a delegate that can vote on your behalf on Protocol DAO proposals?") {
 		return initializeVotingWithDelegate(c)
 	}
 	return initializeVoting(c)

--- a/rocketpool-cli/commands/pdao/initialize-voting.go
+++ b/rocketpool-cli/commands/pdao/initialize-voting.go
@@ -2,19 +2,44 @@ package pdao
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rocket-pool/node-manager-core/utils/input"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/client"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
+	cliutils "github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
 	"github.com/urfave/cli/v2"
 )
 
 func initializeVotingPrompt(c *cli.Context) error {
-	if utils.Confirm("Would you like to specify a delegate that can vote on your behalf on Protocol DAO proposals?") {
+	fmt.Println("Thanks for initializing your voting power!")
+	fmt.Println("")
+	fmt.Println("You have two options:")
+	fmt.Println("")
+	fmt.Println("1. Vote directly (delegate vote power to yourself)")
+	fmt.Println("   This will allow you to vote on proposals directly,")
+	fmt.Println("   allowing you to personally shape the direction of the protocol.")
+	fmt.Println("")
+	fmt.Println("2. Delegate your vote")
+	fmt.Println("   This will delegate your vote power to someone you trust,")
+	fmt.Println("   giving them the power to vote on your behalf. You will have the option to override.")
+	fmt.Println("")
+	fmt.Printf("You can see a list of existing public delegates at %s,\n", "https://delegates.rocketpool.net")
+	fmt.Println("however, you can delegate to any node address.")
+	fmt.Println("")
+	fmt.Printf("Learn more about how this all works via: %s\n", "https://docs.rocketpool.net/guides/houston/participate#participating-in-on-chain-pdao-proposals")
+	fmt.Println("")
+
+	inputString := cliutils.Prompt("Please type `direct` or `delegate` to continue:", "^(?i)(direct|delegate)$", "Please type `direct` or `delegate` to continue:")
+	switch strings.ToLower(inputString) {
+	case "direct":
+		return initializeVoting(c)
+	case "delegate":
 		return initializeVotingWithDelegate(c)
 	}
-	return initializeVoting(c)
+	return nil
+
 }
 
 func initializeVoting(c *cli.Context) error {

--- a/rocketpool-cli/commands/pdao/initialize-voting.go
+++ b/rocketpool-cli/commands/pdao/initialize-voting.go
@@ -14,22 +14,22 @@ import (
 
 func initializeVotingPrompt(c *cli.Context) error {
 	fmt.Println("Thanks for initializing your voting power!")
-	fmt.Println("")
+	fmt.Println()
 	fmt.Println("You have two options:")
-	fmt.Println("")
+	fmt.Println()
 	fmt.Println("1. Vote directly (delegate vote power to yourself)")
 	fmt.Println("   This will allow you to vote on proposals directly,")
 	fmt.Println("   allowing you to personally shape the direction of the protocol.")
-	fmt.Println("")
+	fmt.Println()
 	fmt.Println("2. Delegate your vote")
 	fmt.Println("   This will delegate your vote power to someone you trust,")
 	fmt.Println("   giving them the power to vote on your behalf. You will have the option to override.")
-	fmt.Println("")
+	fmt.Println()
 	fmt.Printf("You can see a list of existing public delegates at %s,\n", "https://delegates.rocketpool.net")
 	fmt.Println("however, you can delegate to any node address.")
-	fmt.Println("")
+	fmt.Println()
 	fmt.Printf("Learn more about how this all works via: %s\n", "https://docs.rocketpool.net/guides/houston/participate#participating-in-on-chain-pdao-proposals")
-	fmt.Println("")
+	fmt.Println()
 
 	inputString := cliutils.Prompt("Please type `direct` or `delegate` to continue:", "^(?i)(direct|delegate)$", "Please type `direct` or `delegate` to continue:")
 	switch strings.ToLower(inputString) {

--- a/rocketpool-daemon/api/pdao/handler.go
+++ b/rocketpool-daemon/api/pdao/handler.go
@@ -44,6 +44,7 @@ func NewProtocolDaoHandler(logger *log.Logger, ctx context.Context, serviceProvi
 		&protocolDaoSettingsContextFactory{h},
 		&protocolDaoProposeSettingContextFactory{h},
 		&protocolDaoInitializeVotingContextFactory{h},
+		&protocolDaoInitializeVotingWithDelegateContextFactory{h},
 		&protocolDaoSetVotingDelegateContextFactory{h},
 		&protocolDaoCurrentVotingDelegateContextFactory{h},
 		&protocolDaoGetStatusContextFactory{h},

--- a/rocketpool-daemon/common/rewards/utils.go
+++ b/rocketpool-daemon/common/rewards/utils.go
@@ -374,7 +374,7 @@ func DownloadRewardsFile(cfg *config.SmartNodeConfig, i *sharedtypes.IntervalInf
 		errBuilder.WriteString(fmt.Sprintf("Downloading files with timeout %v failed.\n", timeout))
 	}
 
-	return fmt.Errorf(errBuilder.String())
+	return fmt.Errorf("%s", errBuilder.String())
 }
 
 // Gets the start slot for the given interval


### PR DESCRIPTION
`rp p iv` allows users to choose if they want to specify a delegate while initializing voting: `InitializeVotingWithDelegate(delegate common.Address)`

If not, voting power is initialized to their own node:  `InitializeVoting()`

This PR ports this feature from V1 into V2

Specifying a delegate: 
```
:~$ rp p iv

Would you like to specify a delegate that can vote on your behalf on Protocol DAO proposals? [y/n]
y

Please enter the delegate's address:
0x7ac4C35034D7d175583E9f5876257fBc59E9946E

+============== Suggested Gas Prices ==============+
```
Without specifying a delegate:
```
:~$ rp p iv

Would you like to specify a delegate that can vote on your behalf on Protocol DAO proposals? [y/n]
n

+============== Suggested Gas Prices ==============+
```

This PR mirrors #628 for smartnode V1, including the updated text 