### PR TITLE
Fix panic in config

### DIFF
--- a/shared/services/config/nethermind-params.go
+++ b/shared/services/config/nethermind-params.go
@@ -136,7 +136,7 @@ func NewNethermindConfig(cfg *RocketPoolConfig) *NethermindConfig {
 			Name:               "Full pruning parallelism",
 			Description:        "This option will be used to determine the number of threads allocated to concurrently by Nethermind to prune data.",
 			Type:               config.ParameterType_Int,
-			Default:            map[config.Network]interface{}{config.Network_All: 0},
+			Default:            map[config.Network]interface{}{config.Network_All: int64(0)},
 			AffectsContainers:  []config.ContainerID{config.ContainerID_Eth1},
 			CanBeBlank:         false,
 			OverwriteOnUpgrade: false,


### PR DESCRIPTION
L139 in `shared/services/config/nethermind-params.go` expects an int64 

panic introduced in #613 

```
panic: interface conversion: interface {} is int, not int64

goroutine 1 [running]:
github.com/rocket-pool/smartnode/rocketpool-cli/service.createFlagsFromConfigParams({0xff6738, 0xa}, {0xc0005e7770, 0xa, 0xc0005dea00?}, {0xc000581000?, 0xc00058f6f0?, 0xc0005c8640?}, {0xff0fc0, 0x7})
	/home/tpan/Dev/smartnode/rocketpool-cli/service/commands.go:40 +0xfc9
github.com/rocket-pool/smartnode/rocketpool-cli/service.RegisterCommands(0xc000182a80, {0xff0a10, 0x7}, {0xc00058f9d0, 0x1, 0x1})
	/home/tpan/Dev/smartnode/rocketpool-cli/service/commands.go:94 +0x337
main.main()
	/home/tpan/Dev/smartnode/rocketpool-cli/rocketpool-cli.go:119 +0xd91
```