### PR TITLE
Update initialize voting text 

### DIFF
--- a/rocketpool-cli/pdao/initialize-voting.go
+++ b/rocketpool-cli/pdao/initialize-voting.go
@@ -2,6 +2,7 @@ package pdao
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rocket-pool/smartnode/shared/services/gas"
 	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
@@ -10,12 +11,33 @@ import (
 )
 
 func initializeVotingPrompt(c *cli.Context) error {
+	fmt.Println("Thanks for initializing your voting power!")
+	fmt.Println("")
+	fmt.Println("You have two options:")
+	fmt.Println("")
+	fmt.Println("1. Vote directly (delegate vote power to yourself)")
+	fmt.Println("   This will allow you to vote on proposals directly,")
+	fmt.Println("   allowing you to personally shape the direction of the protocol.")
+	fmt.Println("")
+	fmt.Println("2. Delegate your vote")
+	fmt.Println("   This will delegate your vote power to someone you trust,")
+	fmt.Println("   giving them the power to vote on your behalf. You will have the option to override.")
+	fmt.Println("")
+	fmt.Printf("You can see a list of existing public delegates at %s,\n", "https://delegates.rocketpool.net")
+	fmt.Println("however, you can delegate to any node address.")
+	fmt.Println("")
+	fmt.Printf("Learn more about how this all works via: %s\n", "https://docs.rocketpool.net/guides/houston/participate#participating-in-on-chain-pdao-proposals")
+	fmt.Println("")
 
-	if cliutils.Confirm(fmt.Sprintf("Would you like to specify a delegate that can vote on your behalf on Protocol DAO proposals?")) {
-		return initializeVotingWithDelegate(c)
-	} else {
+	inputString := cliutils.Prompt("Please type `direct` or `delegate` to continue:", "^(?i)(direct|delegate)$", "Please type `direct` or `delegate` to continue:")
+	switch strings.ToLower(inputString) {
+	case "direct":
 		return initializeVoting(c)
+	case "delegate":
+		return initializeVotingWithDelegate(c)
 	}
+	return nil
+
 }
 
 func initializeVoting(c *cli.Context) error {


### PR DESCRIPTION
Updated the text to:
- provide more context
- prompt users to carefully review and select a choice
```
:~$ rocketpool pdao initialize-voting

Thanks for initializing your voting power!

You have two options:

1. Vote directly (delegate vote power to yourself)
   This will allow you to vote on proposals directly,
   allowing you to personally shape the direction of the protocol.

2. Delegate your vote
   This will delegate your vote power to someone you trust,
   giving them the power to vote on your behalf. You will have the option to override.

You can see a list of existing public delegates at https://delegates.rocketpool.net,
however, you can delegate to any node address.

Learn more about how this all works via: https://docs.rocketpool.net/guides/houston/participate#participating-in-on-chain-pdao-proposals

Please type `direct` or `delegate` to continue:
```