### PR TITLE
Added a check to handle bond reductions being disabled

### DIFF
--- a/rocketpool-cli/commands/minipool/reduce-bond.go
+++ b/rocketpool-cli/commands/minipool/reduce-bond.go
@@ -26,6 +26,12 @@ func reduceBondAmount(c *cli.Context) error {
 		return err
 	}
 
+	// Print message and exit if bond reductions are disabled
+	if details.Data.BondReductionDisabled {
+		fmt.Println("Cannot perform a bond reduction: bond reductions are currently disabled")
+		return nil
+	}
+
 	// Check the fee distributor
 	if !details.Data.IsFeeDistributorInitialized {
 		fmt.Println("Minipools cannot have their bonds reduced until your fee distributor has been initialized.")

--- a/rocketpool-daemon/common/rewards/utils.go
+++ b/rocketpool-daemon/common/rewards/utils.go
@@ -374,7 +374,7 @@ func DownloadRewardsFile(cfg *config.SmartNodeConfig, i *sharedtypes.IntervalInf
 		errBuilder.WriteString(fmt.Sprintf("Downloading files with timeout %v failed.\n", timeout))
 	}
 
-	return fmt.Errorf(errBuilder.String())
+	return fmt.Errorf("%s", errBuilder.String())
 }
 
 // Gets the start slot for the given interval


### PR DESCRIPTION
When bond reductions are disabled, `rocketpool minipool reduce-bond` doesn't populate data fields in the API response. This PR addresses #637 by adding a check in the CLI to properly handle the case of bond reductions being disabled. 