### PR TITLE
Fixed segfault by populating nil pointer

### DIFF
--- a/rocketpool-daemon/api/node/set-rpl-withdrawal-address.go
+++ b/rocketpool-daemon/api/node/set-rpl-withdrawal-address.go
@@ -82,6 +82,7 @@ func (c *nodeSetRplWithdrawalAddressContext) GetState(mc *batch.MultiCaller) {
 		c.node.IsRplWithdrawalAddressSet,
 		c.node.RplWithdrawalAddress,
 		c.node.PrimaryWithdrawalAddress,
+		c.node.RplStake,
 	)
 }
 
@@ -90,6 +91,7 @@ func (c *nodeSetRplWithdrawalAddressContext) PrepareData(data *api.NodeSetRplWit
 	data.PrimaryAddressDiffers = (c.node.PrimaryWithdrawalAddress.Get() != c.nodeAddress || isRplWithdrawalAddressSet)
 	data.RplAddressDiffers = (isRplWithdrawalAddressSet && c.node.RplWithdrawalAddress.Get() != c.nodeAddress)
 	data.CanSet = !(data.PrimaryAddressDiffers || data.RplAddressDiffers)
+	data.RplStake = c.node.RplStake.Get()
 
 	if data.CanSet {
 		txInfo, err := c.node.SetRplWithdrawalAddress(c.address, c.confirm, opts)


### PR DESCRIPTION
Addresses #634 

`rp-cli` segfaults [here](https://github.com/rocket-pool/smartnode/blob/76440160cd8fbbb49927db0b8247dd5e6defce85/rocketpool-cli/commands/node/set-rpl-withdrawal-address.go#L122) because`rp-daemon` never populates `response.Data.RplStake`