### PR TITLE
Populate empty data field

### DIFF
--- a/rocketpool-daemon/api/minipool/rescue-dissolved-details.go
+++ b/rocketpool-daemon/api/minipool/rescue-dissolved-details.go
@@ -89,6 +89,7 @@ func (c *minipoolRescueDissolvedDetailsContext) PrepareData(addresses []common.A
 			MinipoolState:   mpCommon.Status.Formatted(),
 			IsFinalized:     mpCommon.IsFinalised.Get(),
 			MinipoolVersion: mpCommon.Version,
+			BeaconBalance:   big.NewInt(0),
 		}
 
 		if mpDetails.MinipoolState != rptypes.MinipoolStatus_Dissolved || mpDetails.IsFinalized {


### PR DESCRIPTION
Fix for this segfault. 

```
~ $ rocketpool m rd

This command will allow you to manually deposit the remaining ETH for any dissolved minipools, activating them so you can exit them and retrieve your minipool's funds.
Please read our guide at https://docs.rocketpool.net/guides/node/rescue-dissolved.html to fully read about the process before continuing.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5c4458]

goroutine 1 [running]:
math/big.(*Int).Cmp(0x4040000000000000?, 0x109f874?)
    math/big/int.go:381 +0x18
github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/minipool.rescueDissolved(0xc0005b4ec0)
    github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/minipool/rescue-dissolved.go:77 +0x539
github.com/rocket-pool/smartnode/v2/rocketpool-cli/commands/minipool.RegisterCommands.func16(0xc0005b4ec0)
[9:24 PM]
```