### PR TITLE
V2 Fixed bugs in odao/sec proposals list and details 

### DIFF
--- a/rocketpool-daemon/api/odao/proposals.go
+++ b/rocketpool-daemon/api/odao/proposals.go
@@ -106,6 +106,7 @@ func (c *oracleDaoProposalsContext) PrepareData(data *api.OracleDaoProposalsData
 			IsCancelled:     odaoProp.IsCancelled.Get(),
 			IsExecuted:      odaoProp.IsExecuted.Get(),
 			Payload:         odaoProp.Payload.Get(),
+			State:           odaoProp.State.Formatted(),
 		}
 		prop.PayloadStr, err = odaoProp.GetPayloadAsString()
 		if err != nil {

--- a/rocketpool-daemon/api/odao/proposals.go
+++ b/rocketpool-daemon/api/odao/proposals.go
@@ -93,6 +93,7 @@ func (c *oracleDaoProposalsContext) PrepareData(data *api.OracleDaoProposalsData
 	for _, odaoProp := range odaoProps {
 		prop := api.OracleDaoProposalDetails{
 			ID:              odaoProp.ID,
+			DAO:             "rocketDAONodeTrustedProposals",
 			ProposerAddress: odaoProp.ProposerAddress.Get(),
 			Message:         odaoProp.Message.Get(),
 			CreatedTime:     odaoProp.CreatedTime.Formatted(),

--- a/rocketpool-daemon/api/security/proposals.go
+++ b/rocketpool-daemon/api/security/proposals.go
@@ -98,6 +98,7 @@ func (c *securityProposalsContext) PrepareData(data *api.SecurityProposalsData, 
 	for _, scProp := range scProps {
 		prop := api.SecurityProposalDetails{
 			ID:              scProp.ID,
+			DAO:             "rocketDAOSecurityProposals",
 			ProposerAddress: scProp.ProposerAddress.Get(),
 			Message:         scProp.Message.Get(),
 			CreatedTime:     scProp.CreatedTime.Formatted(),


### PR DESCRIPTION
This PR addresses #635 

**oDAO**
- Issue with the oDAO list saying proposals are pending when they are not
- Issue with the oDAO detail not displaying details of a valid proposal

**Security Council**
- Security council proposal detail is not showing the detail of a proposal

The commands `rp odao proposals details` and `rp security proposals details`  and `rp odao proposals list` should display the correct state now. 