### PR TITLE
V2 fixed outdated and hardcoded value in stake rpl

### DIFF
--- a/rocketpool-cli/commands/node/stake-rpl.go
+++ b/rocketpool-cli/commands/node/stake-rpl.go
@@ -128,7 +128,10 @@ func nodeStakeRpl(c *cli.Context) error {
 
 	// Run the stake TX
 	validated, err := tx.HandleTx(c, rp, stakeResponse.Data.StakeTxInfo,
-		fmt.Sprintf("Are you sure you want to stake %.6f RPL? You will not be able to unstake this RPL until you exit your validators and close your minipools, or reach over 100%% collateral!", math.RoundDown(eth.WeiToEth(amountWei), 6)),
+		fmt.Sprintf("Are you sure you want to stake %.6f RPL? You will not be able to unstake this RPL until you exit your validators and close your minipools, or reach %.6f staked RPL (%.0f%% of bonded eth)!",
+			math.RoundDown(eth.WeiToEth(amountWei), 6),
+			math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6),
+			eth.WeiToEth(status.Data.MaximumStakeFraction)*100),
 		"staking RPL",
 		"Staking RPL...",
 	)

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -151,11 +151,13 @@ type NodeSwapRplData struct {
 }
 
 type NodeStakeRplData struct {
-	CanStake            bool                 `json:"canStake"`
-	InsufficientBalance bool                 `json:"insufficientBalance"`
-	Allowance           *big.Int             `json:"allowance"`
-	ApproveTxInfo       *eth.TransactionInfo `json:"approveTxInfo"`
-	StakeTxInfo         *eth.TransactionInfo `json:"stakeTxInfo"`
+	CanStake             bool                 `json:"canStake"`
+	InsufficientBalance  bool                 `json:"insufficientBalance"`
+	Allowance            *big.Int             `json:"allowance"`
+	ApproveTxInfo        *eth.TransactionInfo `json:"approveTxInfo"`
+	StakeTxInfo          *eth.TransactionInfo `json:"stakeTxInfo"`
+	MaximumStakeFraction *big.Int             `json:"maximumStakeFraction"`
+	MaximumRplStake      *big.Int             `json:"maximumRplStake"`
 }
 
 type NodeSetStakeRplForAllowedData struct {


### PR DESCRIPTION
This PR fixes a message in stake-rpl that was outdated and hardcoded 

Old:
```
Are you sure you want to stake 543.482558 RPL? You will not be able to unstake this RPL until you exit your validators and close your minipools, or reach over 100% collateral! [y/n]
```
New:
```
Are you sure you want to stake 543.482558 RPL? You will not be able to unstake this RPL until you exit your validators and close your minipools, or reach 1086.965117 staked RPL (60% of bonded eth)! [y/n]
```