### PR TITLE
V2 Fixed a bug in odao setting/propose

### DIFF
--- a/rocketpool-daemon/api/odao/propose-settings.go
+++ b/rocketpool-daemon/api/odao/propose-settings.go
@@ -132,7 +132,7 @@ func (c *oracleDaoProposeSettingContext) PrepareData(data *api.OracleDaoProposeS
 			data.TxInfo = txInfo
 		}
 	}
-	return types.ResponseStatus_Error, nil
+	return types.ResponseStatus_Success, nil
 }
 
 func (c *oracleDaoProposeSettingContext) createProposalTx(category oracle.SettingsCategory, opts *bind.TransactOpts) (bool, *eth.TransactionInfo, error, error) {


### PR DESCRIPTION
This PR addresses a segfault while creating odao setting proposals: #636

```
2024/09/17 22:10:10 http: panic serving 127.0.0.1:47816: runtime error: invalid memory address or nil pointer dereference
goroutine 218 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1903 +0xbe
panic({0x152e1c0?, 0x25b1fb0?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/rocket-pool/node-manager-core/api/server.HandleServerError(0xc00013ba10, {0x1b45470, 0xc0001da2a0}, {0x0, 0x0})
	/home/tpan/go/pkg/mod/github.com/rocket-pool/node-manager-core@v0.5.0/api/server/handle-response.go:71 +0x3a
github.com/rocket-pool/node-manager-core/api/server.HandleFailedResponse(0x0?, {0x1b45470?, 0xc0001da2a0?}, 0x1b448d0?, {0x0?, 0x0?})
	/home/tpan/go/pkg/mod/github.com/rocket-pool/node-manager-core@v0.5.0/api/server/handle-response.go:106 +0x49
github.com/rocket-pool/node-manager-core/api/server.HandleResponse(0x1b3efc0?, {0x1b45470?, 0xc0001da2a0?}, 0xfffffffffffffffc?, {0x1473ea0?, 0xc0001380c0?}, {0x0?, 0x0?})
	/home/tpan/go/pkg/mod/github.com/rocket-pool/node-manager-core@v0.5.0/api/server/handle-response.go:118 +0x4e
github.com/rocket-pool/node-manager-core/api/server.RegisterSingleStageRoute[...].func1(0xc001a90480)
	/home/tpan/go/pkg/mod/github.com/rocket-pool/node-manager-core@v0.5.0/api/server/single-stage.go:84 +0x567
net/http.HandlerFunc.ServeHTTP(0xc001a90360?, {0x1b45470?, 0xc0001da2a0?}, 0x4eaccf?)
	/usr/local/go/src/net/http/server.go:2171 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000000780, {0x1b45470, 0xc0001da2a0}, 0xc001a90240)
	/home/tpan/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
net/http.serverHandler.ServeHTTP({0xc00108c300?}, {0x1b45470?, 0xc0001da2a0?}, 0x6?)
	/usr/local/go/src/net/http/server.go:3142 +0x8e
net/http.(*conn).serve(0xc001244000, {0x1b4a160, 0xc00108c0f0})
	/usr/local/go/src/net/http/server.go:2044 +0x5e8
created by net/http.(*Server).Serve in goroutine 50
	/usr/local/go/src/net/http/server.go:3290 +0x4b4
```