### PR TITLE
Handle a case where priorityFee > maxFee in the task loop

### DIFF
--- a/rocketpool/node/auto-init-voting-power.go
+++ b/rocketpool/node/auto-init-voting-power.go
@@ -144,7 +144,7 @@ func (t *autoInitVotingPower) submitInitializeVotingPower() error {
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Initialize the Voting Power

--- a/rocketpool/node/defend-pdao-props.go
+++ b/rocketpool/node/defend-pdao-props.go
@@ -268,7 +268,7 @@ func (t *defendPdaoProps) defendProposal(prop defendableProposal) error {
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Respond to the challenge

--- a/rocketpool/node/distribute-minipools.go
+++ b/rocketpool/node/distribute-minipools.go
@@ -254,7 +254,7 @@ func (t *distributeMinipools) distributeMinipool(mpd *rpstate.NativeMinipoolDeta
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Distribute minipool

--- a/rocketpool/node/node.go
+++ b/rocketpool/node/node.go
@@ -394,6 +394,24 @@ func updateNetworkState(m *state.NetworkStateManager, log *log.ColorLogger, node
 	return state, totalEffectiveStake, nil
 }
 
+// Checks if the user-inputted priorityFee is greater than the oracle based maxFee
+// If so, return the min(priorityFee, 25% of the oracle based maxFee)
+func GetPriorityFee(priorityFee *big.Int, maxFee *big.Int) *big.Int {
+	// Check if priorityFee is less than maxFee
+	if priorityFee.Cmp(maxFee) < 0 {
+		return priorityFee
+	}
+
+	quarterMaxFee := new(big.Int).Div(maxFee, big.NewInt(4))
+
+	// Gets the min(priorityFee, 25% of the oracle based maxFee)
+	if priorityFee.Cmp(quarterMaxFee) < 0 {
+		return priorityFee
+	} else {
+		return quarterMaxFee
+	}
+}
+
 // Check if Houston has been deployed yet
 func printHoustonMessage(log *log.ColorLogger) {
 	log.Println(`

--- a/rocketpool/node/promote-minipools.go
+++ b/rocketpool/node/promote-minipools.go
@@ -236,7 +236,7 @@ func (t *promoteMinipools) promoteMinipool(mpd *rpstate.NativeMinipoolDetails, c
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Promote minipool

--- a/rocketpool/node/reduce-bonds.go
+++ b/rocketpool/node/reduce-bonds.go
@@ -281,7 +281,7 @@ func (t *reduceBonds) forceFeeDistribution() (bool, error) {
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Distribute
@@ -400,7 +400,7 @@ func (t *reduceBonds) reduceBond(mpd *rpstate.NativeMinipoolDetails, windowStart
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Reduce bond

--- a/rocketpool/node/stake-prelaunch-minipools.go
+++ b/rocketpool/node/stake-prelaunch-minipools.go
@@ -287,7 +287,7 @@ func (t *stakePrelaunchMinipools) stakeMinipool(mpd *rpstate.NativeMinipoolDetai
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Stake minipool

--- a/rocketpool/node/verify-pdao-props.go
+++ b/rocketpool/node/verify-pdao-props.go
@@ -383,7 +383,7 @@ func (t *verifyPdaoProps) submitChallenge(challenge challenge) error {
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Respond to the challenge
@@ -439,7 +439,7 @@ func (t *verifyPdaoProps) submitDefeat(defeat defeat) error {
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	// Respond to the challenge

--- a/rocketpool/watchtower/process-penalties.go
+++ b/rocketpool/watchtower/process-penalties.go
@@ -26,6 +26,7 @@ import (
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 
+	fee "github.com/rocket-pool/smartnode/rocketpool/node"
 	"github.com/rocket-pool/smartnode/shared/services"
 	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/utils/api"
@@ -516,7 +517,7 @@ func (t *processPenalties) submitPenalty(minipoolAddress common.Address, block *
 	}
 
 	opts.GasFeeCap = maxFee
-	opts.GasTipCap = t.maxPriorityFee
+	opts.GasTipCap = fee.GetPriorityFee(t.maxPriorityFee, maxFee)
 	opts.GasLimit = gas.Uint64()
 
 	hash, err := network.SubmitPenalty(t.rp, minipoolAddress, slotBig, opts)


### PR DESCRIPTION
Automatic transactions in the task loop fail when the user-inputted `priorityFee` is greater than the oracle based `maxFee`. This PR addresses this case by setting `priorityFee` to `min(priorityFee, 25% of the oracle based maxFee`) when `priorityFee > maxFee` for transactions in the node task loop. 

For example: automatically initializing vote power, defending pDAO proposals, bond reductions and so on. 

The change is also applied to watchtower task `process-penalties.go`