### PR TITLE
V2 Corrected balance comparison for eth withdrawal

### DIFF
--- a/rocketpool-daemon/api/node/withdraw-eth.go
+++ b/rocketpool-daemon/api/node/withdraw-eth.go
@@ -89,7 +89,7 @@ func (c *nodeWithdrawEthContext) PrepareData(data *api.NodeWithdrawEthData, opts
 	ethBalance := c.node.DonatedEthBalance.Get()
 	hasDifferentPrimaryWithdrawalAddress := c.nodeAddress != c.node.PrimaryWithdrawalAddress.Get()
 
-	data.InsufficientBalance = (c.amount.Cmp(ethBalance) >= 0)
+	data.InsufficientBalance = (c.amount.Cmp(ethBalance) > 0)
 	data.HasDifferentPrimaryWithdrawalAddress = hasDifferentPrimaryWithdrawalAddress
 
 	// Update & return response


### PR DESCRIPTION
This PR addresses a bug in `node withdraw-eth`:
```
~ $ rocketpool n we

Would you like to withdraw the maximum amount of staked ETH (10.000000 ETH)? [y/n]
y

Cannot withdraw staked ETH:
The node's staked ETH balance is insufficient.
```

`c.amount.Cmp(ethBalance) >= 0` causes `data.InsufficientBalance` to evaluate to `true` when the requested withdrawal amount `c.amount` is maxed (e.g equal to to your balance) 

It should be `c.amount.Cmp(ethBalance) > 0` 

Here it is in [V1](https://github.com/rocket-pool/smartnode/blob/master/rocketpool/api/node/withdraw-eth.go#L78)