### PR TITLE
V2 Fixed comparison of MinNodeFee and MaxNodeFee

### DIFF
--- a/rocketpool-cli/commands/node/deposit.go
+++ b/rocketpool-cli/commands/node/deposit.go
@@ -136,7 +136,7 @@ func newDepositPrompts(c *cli.Context, rp *client.Client, soloConversionPubkey *
 		}
 	} else {
 		// Prompt for min node fee
-		if nodeFeeResponse.Data.MinNodeFee == nodeFeeResponse.Data.MaxNodeFee {
+		if nodeFeeResponse.Data.MinNodeFee.Cmp(nodeFeeResponse.Data.MaxNodeFee) == 0 {
 			fmt.Printf("Your minipool will use the current fixed commission rate of %.2f%%.\n", eth.WeiToEth(nodeFeeResponse.Data.MinNodeFee)*100)
 			minNodeFee = eth.WeiToEth(nodeFeeResponse.Data.MinNodeFee)
 		} else {


### PR DESCRIPTION
 `MinNodeFee` and `MaxNodeFee` are stored as `*big.Int`, as oppposed to being stored as `float64` in V1. 

This means we'll need to use `.cmp()` instead of `==` to compare these values.  