### PR TITLE
V2 stake/deposit warning

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -90,3 +90,8 @@ func (r *NetworkRequester) Stats() (*types.ApiResponse[api.NetworkStatsData], er
 func (r *NetworkRequester) TimezoneMap() (*types.ApiResponse[api.NetworkTimezonesData], error) {
 	return client.SendGetRequest[api.NetworkTimezonesData](r, "timezone-map", "TimezoneMap", nil)
 }
+
+// Get the timezone map
+func (r *NetworkRequester) IsHoustonHotfixDeployed() (*types.ApiResponse[api.NetworkHotfixDeployedData], error) {
+	return client.SendGetRequest[api.NetworkHotfixDeployedData](r, "is-hotfix-deployed", "IsHoustonHotfixDeployed", nil)
+}

--- a/client/pdao.go
+++ b/client/pdao.go
@@ -239,3 +239,8 @@ func (r *PDaoRequester) SetSignallingAddress(signallingAddress common.Address, s
 func (r *PDaoRequester) ClearSignallingAddress() (*types.ApiResponse[types.TxInfoData], error) {
 	return client.SendGetRequest[types.TxInfoData](r, "clear-signalling-address", "ClearSignallingAddress", nil)
 }
+
+// IsVotingInitialized checks if a node has initialized voting power
+func (r *PDaoRequester) IsVotingInitialized() (*types.ApiResponse[api.ProtocolDaoIsVotingInitializedData], error) {
+	return client.SendGetRequest[api.ProtocolDaoIsVotingInitializedData](r, "is-voting-initialized", "IsVotingInitialized", nil)
+}

--- a/rocketpool-cli/commands/node/deposit.go
+++ b/rocketpool-cli/commands/node/deposit.go
@@ -45,6 +45,7 @@ func newDepositPrompts(c *cli.Context, rp *client.Client, soloConversionPubkey *
 		return nil, nil
 	}
 
+	// If hotfix is live and voting isn't initialized, display a warning
 	err = warnIfVotingUninitialized(rp, c, depositWarningMessage)
 	if err != nil {
 		return nil, err

--- a/rocketpool-cli/commands/node/deposit.go
+++ b/rocketpool-cli/commands/node/deposit.go
@@ -23,6 +23,7 @@ const (
 	maxSlippageFlag           string  = "max-slippage"
 	saltFlag                  string  = "salt"
 	defaultMaxNodeFeeSlippage float64 = 0.01 // 1% below current network fee
+	depositWarningMessage     string  = "NOTE: by creating a new minipool, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before creating a new minipool."
 )
 
 type deposit struct {
@@ -42,6 +43,11 @@ func newDepositPrompts(c *cli.Context, rp *client.Client, soloConversionPubkey *
 	}
 	if depositContractInfo.Data.PrintMismatch() {
 		return nil, nil
+	}
+
+	err = warnIfVotingUninitialized(rp, c, depositWarningMessage)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check if the fee distributor has been initialized

--- a/rocketpool-cli/commands/node/stake-rpl.go
+++ b/rocketpool-cli/commands/node/stake-rpl.go
@@ -34,6 +34,7 @@ func nodeStakeRpl(c *cli.Context) error {
 		return err
 	}
 
+	// If hotfix is live and voting isn't initialized, display a warning
 	err = warnIfVotingUninitialized(rp, c, stakeRPLWarningMessage)
 	if err != nil {
 		return err

--- a/rocketpool-cli/commands/node/stake-rpl.go
+++ b/rocketpool-cli/commands/node/stake-rpl.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	swapFlag string = "swap"
+	swapFlag               string = "swap"
+	stakeRPLWarningMessage string = "NOTE: by staking RPL, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before staking RPL."
 )
 
 func nodeStakeRpl(c *cli.Context) error {
@@ -29,6 +30,11 @@ func nodeStakeRpl(c *cli.Context) error {
 
 	// Get node status
 	status, err := rp.Api.Node.Status()
+	if err != nil {
+		return err
+	}
+
+	err = warnIfVotingUninitialized(rp, c, stakeRPLWarningMessage)
 	if err != nil {
 		return err
 	}

--- a/rocketpool-cli/commands/node/utils.go
+++ b/rocketpool-cli/commands/node/utils.go
@@ -384,20 +384,24 @@ func SwapRpl(c *cli.Context, rp *client.Client, amountWei *big.Int) error {
 
 // Display a warning if hotfix is live and voting is uninitialized
 func warnIfVotingUninitialized(rp *client.Client, c *cli.Context, warningMessage string) error {
-	// TODO check if houston hotfix is deployed
-
-	// Check if voting is initialized
-	votingInitializedResponse, err := rp.Api.PDao.IsVotingInitialized()
+	hotfix, err := rp.Api.Network.IsHoustonHotfixDeployed()
 	if err != nil {
 		return err
 	}
 
-	if !votingInitializedResponse.Data.VotingInitialized {
-		fmt.Println("Your voting power hasn't been initialized yet. Please visit https://docs.rocketpool.net/guides/houston/participate#initializing-voting to learn more.")
-		// Post a warning about initializing voting
-		if !(c.Bool("yes") || utils.Confirm(fmt.Sprintf("%s%s%s\nWould you like to continue?", terminal.ColorYellow, warningMessage, terminal.ColorReset))) {
-			fmt.Println("Cancelled.")
-			return fmt.Errorf("operation cancelled by user")
+	if hotfix.Data.IsHoustonHotfixDeployed {
+		// Check if voting is initialized
+		votingInitializedResponse, err := rp.Api.PDao.IsVotingInitialized()
+		if err != nil {
+			return fmt.Errorf("error checking if voting is initialized: %w", err)
+		}
+		if !votingInitializedResponse.Data.VotingInitialized {
+			fmt.Println("Your voting power hasn't been initialized yet. Please visit https://docs.rocketpool.net/guides/houston/participate#initializing-voting to learn more.")
+			// Post a warning about initializing voting
+			if !(c.Bool("yes") || utils.Confirm(fmt.Sprintf("%s%s%s\nWould you like to continue?", terminal.ColorYellow, warningMessage, terminal.ColorReset))) {
+				fmt.Println("Cancelled.")
+				return fmt.Errorf("operation cancelled by user")
+			}
 		}
 	}
 

--- a/rocketpool-cli/commands/node/utils.go
+++ b/rocketpool-cli/commands/node/utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rocket-pool/node-manager-core/utils/math"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/client"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/terminal"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
 )
 
@@ -378,5 +379,27 @@ func SwapRpl(c *cli.Context, rp *client.Client, amountWei *big.Int) error {
 
 	// Log & return
 	fmt.Printf("Successfully swapped %.6f legacy RPL for new RPL.\n", math.RoundDown(eth.WeiToEth(amountWei), 6))
+	return nil
+}
+
+// Display a warning if hotfix is live and voting is uninitialized
+func warnIfVotingUninitialized(rp *client.Client, c *cli.Context, warningMessage string) error {
+	// TODO check if houston hotfix is deployed
+
+	// Check if voting is initialized
+	votingInitializedResponse, err := rp.Api.PDao.IsVotingInitialized()
+	if err != nil {
+		return err
+	}
+
+	if !votingInitializedResponse.Data.VotingInitialized {
+		fmt.Println("Your voting power hasn't been initialized yet. Please visit https://docs.rocketpool.net/guides/houston/participate#initializing-voting to learn more.")
+		// Post a warning about initializing voting
+		if !(c.Bool("yes") || utils.Confirm(fmt.Sprintf("%s%s%s\nWould you like to continue?", terminal.ColorYellow, warningMessage, terminal.ColorReset))) {
+			fmt.Println("Cancelled.")
+			return fmt.Errorf("operation cancelled by user")
+		}
+	}
+
 	return nil
 }

--- a/rocketpool-daemon/api/network/handler.go
+++ b/rocketpool-daemon/api/network/handler.go
@@ -34,6 +34,7 @@ func NewNetworkHandler(logger *log.Logger, ctx context.Context, serviceProvider 
 		&networkPriceContextFactory{h},
 		&networkStatsContextFactory{h},
 		&networkTimezoneContextFactory{h},
+		&networkHotfixDeployedContextFactory{h},
 	}
 	return h
 }

--- a/rocketpool-daemon/api/network/is-hotfix-deployed.go
+++ b/rocketpool-daemon/api/network/is-hotfix-deployed.go
@@ -1,0 +1,62 @@
+package network
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/gorilla/mux"
+	"github.com/rocket-pool/node-manager-core/api/server"
+	"github.com/rocket-pool/node-manager-core/api/types"
+	"github.com/rocket-pool/smartnode/v2/rocketpool-daemon/common/state"
+	"github.com/rocket-pool/smartnode/v2/shared/types/api"
+)
+
+// ===============
+// === Factory ===
+// ===============
+
+type networkHotfixDeployedContextFactory struct {
+	handler *NetworkHandler
+}
+
+func (f *networkHotfixDeployedContextFactory) Create(args url.Values) (*networkHotfixDeployedContext, error) {
+	c := &networkHotfixDeployedContext{
+		handler: f.handler,
+	}
+	return c, nil
+}
+
+func (f *networkHotfixDeployedContextFactory) RegisterRoute(router *mux.Router) {
+	server.RegisterQuerylessGet[*networkHotfixDeployedContext, api.NetworkHotfixDeployedData](
+		router, "is-hotfix-deployed", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+	)
+}
+
+// ===============
+// === Context ===
+// ===============
+
+type networkHotfixDeployedContext struct {
+	handler *NetworkHandler
+}
+
+func (c *networkHotfixDeployedContext) PrepareData(data *api.NetworkHotfixDeployedData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
+	sp := c.handler.serviceProvider
+	rp := sp.GetRocketPool()
+
+	// Requirements
+	status, err := sp.RequireRocketPoolContracts(c.handler.ctx)
+	if err != nil {
+		return status, err
+	}
+
+	// Bindings
+	houstonHotfixDeployed, err := state.IsHoustonHotfixDeployed(rp, nil)
+	if err != nil {
+		return types.ResponseStatus_Error, fmt.Errorf("error getting the protocol version: %w", err)
+	}
+	data.IsHoustonHotfixDeployed = houstonHotfixDeployed
+
+	return types.ResponseStatus_Success, nil
+}

--- a/rocketpool-daemon/api/pdao/handler.go
+++ b/rocketpool-daemon/api/pdao/handler.go
@@ -50,6 +50,7 @@ func NewProtocolDaoHandler(logger *log.Logger, ctx context.Context, serviceProvi
 		&protocolDaoGetStatusContextFactory{h},
 		&protocolDaoClearSignallingAddressFactory{h},
 		&protocolDaoSetSignallingAddressFactory{h},
+		&protocolDaoIsVotingInitializedContextFactory{h},
 	}
 	return h
 }

--- a/rocketpool-daemon/api/pdao/is-voting-initialized.go
+++ b/rocketpool-daemon/api/pdao/is-voting-initialized.go
@@ -1,0 +1,80 @@
+package pdao
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/gorilla/mux"
+	batch "github.com/rocket-pool/batch-query"
+	"github.com/rocket-pool/node-manager-core/eth"
+	"github.com/rocket-pool/rocketpool-go/v2/node"
+	"github.com/rocket-pool/rocketpool-go/v2/rocketpool"
+
+	"github.com/rocket-pool/node-manager-core/api/server"
+	"github.com/rocket-pool/node-manager-core/api/types"
+	"github.com/rocket-pool/smartnode/v2/shared/types/api"
+)
+
+// ===============
+// === Factory ===
+// ===============
+
+type protocolDaoIsVotingInitializedContextFactory struct {
+	handler *ProtocolDaoHandler
+}
+
+func (f *protocolDaoIsVotingInitializedContextFactory) Create(args url.Values) (*protocolDaoIsVotingInitializedContext, error) {
+	c := &protocolDaoIsVotingInitializedContext{
+		handler: f.handler,
+	}
+	return c, nil
+}
+
+func (f *protocolDaoIsVotingInitializedContextFactory) RegisterRoute(router *mux.Router) {
+	server.RegisterSingleStageRoute[*protocolDaoIsVotingInitializedContext, api.ProtocolDaoIsVotingInitializedData](
+		router, "is-voting-initialized", f, f.handler.logger.Logger, f.handler.serviceProvider.ServiceProvider,
+	)
+}
+
+// ===============
+// === Context ===
+// ===============
+
+type protocolDaoIsVotingInitializedContext struct {
+	handler *ProtocolDaoHandler
+	rp      *rocketpool.RocketPool
+
+	node *node.Node
+}
+
+func (c *protocolDaoIsVotingInitializedContext) Initialize() (types.ResponseStatus, error) {
+	sp := c.handler.serviceProvider
+	c.rp = sp.GetRocketPool()
+	nodeAddress, _ := sp.GetWallet().GetAddress()
+
+	// Requirements
+	status, err := sp.RequireNodeRegistered(c.handler.ctx)
+	if err != nil {
+		return status, err
+	}
+
+	// Bindings
+	c.node, err = node.NewNode(c.rp, nodeAddress)
+	if err != nil {
+		return types.ResponseStatus_Error, fmt.Errorf("error creating node %s binding: %w", nodeAddress.Hex(), err)
+	}
+	return types.ResponseStatus_Success, nil
+}
+
+func (c *protocolDaoIsVotingInitializedContext) GetState(mc *batch.MultiCaller) {
+	eth.AddQueryablesToMulticall(mc,
+		c.node.IsVotingInitialized,
+	)
+}
+
+func (c *protocolDaoIsVotingInitializedContext) PrepareData(data *api.ProtocolDaoIsVotingInitializedData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
+	data.VotingInitialized = c.node.IsVotingInitialized.Get()
+
+	return types.ResponseStatus_Success, nil
+}

--- a/rocketpool-daemon/common/state/update-checks.go
+++ b/rocketpool-daemon/common/state/update-checks.go
@@ -38,3 +38,13 @@ func IsHoustonDeployed(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, er
 	constraint, _ := version.NewConstraint(">= 1.3.0")
 	return constraint.Check(currentVersion), nil
 }
+
+// Check if Houston Hotfix has been deployed
+func IsHoustonHotfixDeployed(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, error) {
+	currentVersion, err := rp.GetProtocolVersion(opts)
+	if err != nil {
+		return false, err
+	}
+	constraint, _ := version.NewConstraint(">= 1.3.1")
+	return constraint.Check(currentVersion), nil
+}

--- a/shared/types/api/network.go
+++ b/shared/types/api/network.go
@@ -102,3 +102,7 @@ func (ndcid *NetworkDepositContractInfoData) PrintMismatch() bool {
 	fmt.Printf("\tYour Beacon client is using deposit contract %s on chain %d.%s\n", ndcid.BeaconDepositContract.Hex(), ndcid.BeaconNetwork, terminal.ColorReset)
 	return true
 }
+
+type NetworkHotfixDeployedData struct {
+	IsHoustonHotfixDeployed bool `json:"isHoustonHotfixDeployed"`
+}

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -325,3 +325,7 @@ type SnapshotResponseData struct {
 	Error                   string                          `json:"error"`
 	ActiveSnapshotProposals []*sharedtypes.SnapshotProposal `json:"activeSnapshotProposals"`
 }
+
+type ProtocolDaoIsVotingInitializedData struct {
+	VotingInitialized bool `json:"votingInitialized"`
+}


### PR DESCRIPTION
Adds the warning to `rp node stake-rpl` and `rp node deposit` 

```
Your voting power hasn't been initialized yet. Please visit https://docs.rocketpool.net/guides/houston/participate#initializing-voting to learn more.
NOTE: by staking RPL, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before staking RPL.
Would you like to continue? [y/n]
n
```

`stake-rpl.go` and `deposit.go` only displays this warning after 1.3.1 hotfix has been deployed. This PR requires the following change from `rocketpool-go:tx-refactor` https://github.com/rocket-pool/rocketpool-go/pull/31