### PR TITLE
V2 Handle a case where priorityFee > maxFee in the task loop

### DIFF
--- a/rocketpool-daemon/node/applyto_test.go
+++ b/rocketpool-daemon/node/applyto_test.go
@@ -1,0 +1,81 @@
+package node
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+)
+
+func TestApplyTo(t *testing.T) {
+	tests := []struct {
+		name              string
+		maxPriorityFee    *big.Int
+		maxFee            *big.Int
+		expectedGasFeeCap *big.Int
+		expectedGasTipCap *big.Int
+	}{
+		{
+			name:              "maxPriorityFee less than maxFee",
+			maxPriorityFee:    big.NewInt(50),
+			maxFee:            big.NewInt(100),
+			expectedGasFeeCap: big.NewInt(100),
+			expectedGasTipCap: big.NewInt(50),
+		},
+		{
+			name:              "maxPriorityFee equal to maxFee",
+			maxPriorityFee:    big.NewInt(100),
+			maxFee:            big.NewInt(100),
+			expectedGasFeeCap: big.NewInt(100),
+			expectedGasTipCap: big.NewInt(25),
+		},
+		{
+			name:              "maxPriorityFee greater than maxFee",
+			maxPriorityFee:    big.NewInt(150),
+			maxFee:            big.NewInt(100),
+			expectedGasFeeCap: big.NewInt(100),
+			expectedGasTipCap: big.NewInt(25),
+		},
+		{
+			name:              "maxPriorityFee less than 25%% of maxFee",
+			maxPriorityFee:    big.NewInt(20),
+			maxFee:            big.NewInt(100),
+			expectedGasFeeCap: big.NewInt(100),
+			expectedGasTipCap: big.NewInt(20),
+		},
+		{
+			name:              "maxPriorityFee equal to 25%% of maxFee",
+			maxPriorityFee:    big.NewInt(25),
+			maxFee:            big.NewInt(100),
+			expectedGasFeeCap: big.NewInt(100),
+			expectedGasTipCap: big.NewInt(25),
+		},
+		{
+			name:              "maxPriorityFee less than maxFee but greater than 25%% of maxFee",
+			maxPriorityFee:    big.NewInt(30),
+			maxFee:            big.NewInt(100),
+			expectedGasFeeCap: big.NewInt(100),
+			expectedGasTipCap: big.NewInt(30),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := &GasSettings{
+				maxFee:         testCase.maxFee,
+				maxPriorityFee: testCase.maxPriorityFee,
+			}
+
+			opts := &bind.TransactOpts{}
+
+			g.ApplyTo(opts)
+
+			if opts.GasFeeCap.Cmp(testCase.expectedGasFeeCap) != 0 {
+				t.Errorf("expected GasFeeCap %s, got %s", testCase.expectedGasFeeCap.String(), opts.GasFeeCap.String())
+			}
+			if opts.GasTipCap.Cmp(testCase.expectedGasTipCap) != 0 {
+				t.Errorf("expected GasTipCap %s, got %s", testCase.expectedGasTipCap.String(), opts.GasTipCap.String())
+			}
+		})
+	}
+}

--- a/rocketpool-daemon/node/node.go
+++ b/rocketpool-daemon/node/node.go
@@ -88,6 +88,12 @@ type TaskLoop struct {
 	secondsDelta                float64
 }
 
+type GasSettings struct {
+	maxFee         *big.Int
+	maxPriorityFee *big.Int
+	gasThreshold   float64
+}
+
 func NewTaskLoop(sp *services.ServiceProvider, wg *sync.WaitGroup) *TaskLoop {
 	logger := sp.GetTasksLogger()
 	ctx := logger.CreateContextWithLogger(sp.GetBaseContext())
@@ -464,4 +470,24 @@ func calculateTotalEffectiveStakeForNetwork(state *state.NetworkState) *big.Int 
 		}
 	}
 	return total
+}
+
+// Applies GasFeeCap and GasTipCap to opts and handles a case where the user-inputted maxPriorityFee is greater than the oracle based maxFee
+// If so, maxPriorityFee is appplied to opts as the min(maxPriorityFee, 25% of the oracle based maxFee)
+func (g *GasSettings) ApplyTo(opts *bind.TransactOpts) *bind.TransactOpts {
+	opts.GasFeeCap = g.maxFee
+	// If maxPriorityFee < maxFee, apply maxPriorityFee to opts
+	if g.maxPriorityFee.Cmp(g.maxFee) < 0 {
+		opts.GasTipCap = g.maxPriorityFee
+		return opts
+	}
+	quarterMaxFee := new(big.Int).Div(g.maxFee, big.NewInt(4))
+	// Otherwise apply maxPriorityFee to opts as min(priorityFee, 25% of the oracle based maxFee)
+	if g.maxPriorityFee.Cmp(quarterMaxFee) < 0 {
+		opts.GasTipCap = g.maxPriorityFee
+	} else {
+		opts.GasTipCap = quarterMaxFee
+	}
+	return opts
+
 }

--- a/rocketpool-daemon/node/node.go
+++ b/rocketpool-daemon/node/node.go
@@ -482,7 +482,8 @@ func (g *GasSettings) ApplyTo(opts *bind.TransactOpts) *bind.TransactOpts {
 		return opts
 	}
 	quarterMaxFee := new(big.Int).Div(g.maxFee, big.NewInt(4))
-	// Otherwise apply maxPriorityFee to opts as min(priorityFee, 25% of the oracle based maxFee)
+
+	// Otherwise apply maxPriorityFee to opts as min(maxPriorityFee, 25% of the oracle based maxFee)
 	if g.maxPriorityFee.Cmp(quarterMaxFee) < 0 {
 		opts.GasTipCap = g.maxPriorityFee
 	} else {


### PR DESCRIPTION
Automatic transactions in the task loop fail when the user-inputted priorityFee is greater than the oracle based maxFee. This PR addresses this case by setting priorityFee to min(priorityFee, 25% of the oracle based maxFee) when priorityFee > maxFee for transactions in the node task loop.

This PR slightly differs from #655 because it includes: 
- A new type: `GasSettings` to consolidate related gas fields and a pointer reciever `ApplyTo` to apply the gas settings to `opts *bind.TransactOpts`
- A unit test for `ApplyTo`