### PR TITLE
Fix submission check.

### DIFF
--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -146,8 +146,8 @@ func (t *submitNetworkBalances) run(state *state.NetworkState) error {
 	}
 	targetBlockNumber := targetBlockHeader.Number.Uint64()
 
-	if targetBlockNumber < lastSubmissionBlock {
-		// No submission needed: target block older than the last submission
+	if targetBlockNumber > state.ElBlockNumber {
+		// No submission needed: target block in the future
 		return nil
 	}
 

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -377,8 +377,8 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 	}
 	targetBlockNumber := targetBlockHeader.Number.Uint64()
 
-	if targetBlockNumber < lastSubmissionBlock {
-		// No submission needed: target block older than the last submission
+	if targetBlockNumber > state.ElBlockNumber {
+		// No submission needed: target block in the future
 		return nil
 	}
 


### PR DESCRIPTION
Previous code was incorrectly comparing the `targetBlockNumber` with the `lastSubmissionBlock`, while the target block would always be after the last submission.