### PR TITLE
V2 Deprecate `service stats`

### DIFF
--- a/rocketpool-cli/client/service.go
+++ b/rocketpool-cli/client/service.go
@@ -270,23 +270,6 @@ func (c *Client) PrintNodeLogs(composeFiles []string, tail string, logPaths ...s
 	return c.printOutput(cmd)
 }
 
-// Print the Rocket Pool service stats
-func (c *Client) PrintServiceStats(composeFiles []string) error {
-	// Get service container IDs
-	cmd, err := c.compose(composeFiles, "ps -q")
-	if err != nil {
-		return err
-	}
-	containers, err := c.readOutput(cmd)
-	if err != nil {
-		return err
-	}
-	containerIds := strings.Split(strings.TrimSpace(string(containers)), "\n")
-
-	// Print stats
-	return c.printOutput(fmt.Sprintf("docker stats %s", strings.Join(containerIds, " ")))
-}
-
 // Print the Rocket Pool service compose config
 func (c *Client) PrintServiceCompose(composeFiles []string) error {
 	cmd, err := c.compose(composeFiles, "config")

--- a/rocketpool-cli/commands/service/commands.go
+++ b/rocketpool-cli/commands/service/commands.go
@@ -286,13 +286,11 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:    "stats",
 				Aliases: []string{"a"},
-				Usage:   "View the Rocket Pool service stats",
+				Usage:   "DEPRECATED - No longer supported",
 				Action: func(c *cli.Context) error {
-					// Validate args
-					utils.ValidateArgCount(c, 0)
 
 					// Run command
-					return serviceStats(c)
+					return serviceStats()
 				},
 			},
 

--- a/rocketpool-cli/commands/service/stats.go
+++ b/rocketpool-cli/commands/service/stats.go
@@ -1,18 +1,11 @@
 package service
 
 import (
-	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/client"
-	"github.com/urfave/cli/v2"
+	"fmt"
 )
 
 // View the Rocket Pool service stats
-func serviceStats(c *cli.Context) error {
-	// Get RP client
-	rp, err := client.NewClientFromCtx(c)
-	if err != nil {
-		return err
-	}
-
-	// Print service stats
-	return rp.PrintServiceStats(getComposeFiles(c))
+func serviceStats() error {
+	fmt.Println("No longer supported - please run `docker stats -a` instead.")
+	return nil
 }


### PR DESCRIPTION
An issue with `rp service stats` prevents it from exiting when using `ctrl + c`, so it should be deprecated in favor of `docker stats -a`


Ported over from https://github.com/nodeset-org/hyperdrive/pull/151, thanks Joe for sending this over! 