### PR TITLE
V1 Update authors and copyright year

### DIFF
--- a/rocketpool-cli/rocketpool-cli.go
+++ b/rocketpool-cli/rocketpool-cli.go
@@ -32,6 +32,17 @@ ______           _        _    ______           _
 |    // _ \ / __| |/ / _ \ __| |  __/ _ \ / _ \| |
 | |\ \ (_) | (__|   <  __/ |_  | | | (_) | (_) | |
 \_| \_\___/ \___|_|\_\___|\__| \_|  \___/ \___/|_|
++---------------------------------------------------+
+|    DECENTRALISED STAKING PROTOCOL FOR ETHEREUM    |
++---------------------------------------------------+
+
+Rocket Pool is a first-of-its-kind Ethereum staking pool protocol, designed to
+be community-owned, decentralised, permissionless, & trustless.
+
+For more information about Rocket Pool, visit https://rocketpool.net
+
+Authored by the Rocket Pool Core Team
+A special thanks to the Rocket Pool community for all their contributions.
 
 %s`, cli.AppHelpTemplate)
 
@@ -42,25 +53,7 @@ ______           _        _    ______           _
 	app.Name = "rocketpool"
 	app.Usage = "Rocket Pool CLI"
 	app.Version = shared.RocketPoolVersion
-	app.Authors = []cli.Author{
-		{
-			Name:  "David Rugendyke",
-			Email: "david@rocketpool.net",
-		},
-		{
-			Name:  "Jake Pospischil",
-			Email: "jake@rocketpool.net",
-		},
-		{
-			Name:  "Joe Clapis",
-			Email: "joe@rocketpool.net",
-		},
-		{
-			Name:  "Kane Wallmann",
-			Email: "kane@rocketpool.net",
-		},
-	}
-	app.Copyright = "(c) 2023 Rocket Pool Pty Ltd"
+	app.Copyright = "(c) 2024 Rocket Pool Pty Ltd"
 
 	// Initialize app metadata
 	app.Metadata = make(map[string]interface{})

--- a/rocketpool/rocketpool.go
+++ b/rocketpool/rocketpool.go
@@ -23,25 +23,7 @@ func main() {
 	app.Name = "rocketpool"
 	app.Usage = "Rocket Pool service"
 	app.Version = shared.RocketPoolVersion
-	app.Authors = []cli.Author{
-		{
-			Name:  "David Rugendyke",
-			Email: "david@rocketpool.net",
-		},
-		{
-			Name:  "Jake Pospischil",
-			Email: "jake@rocketpool.net",
-		},
-		{
-			Name:  "Joe Clapis",
-			Email: "joe@rocketpool.net",
-		},
-		{
-			Name:  "Kane Wallmann",
-			Email: "kane@rocketpool.net",
-		},
-	}
-	app.Copyright = "(c) 2022 Rocket Pool Pty Ltd"
+	app.Copyright = "(c) 2024 Rocket Pool Pty Ltd"
 
 	// Set application flags
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
We use [this](https://raw.githubusercontent.com/rocket-pool/rocketpool.net/refs/heads/main/src/utils/console-message.js?token=GHSAT0AAAAAACLW3W4XV7WEWCI5QKEXXQFSZYPMGLQ) on our sites, so the SN should reflect it as well. 