### PR TITLE
V1 changes for Saturn 0

### DIFF
--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -503,10 +503,6 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 						Name:  "max-slippage, s",
 						Usage: "The maximum acceptable slippage in node commission rate for the deposit (or 'auto'). Only relevant when the commission rate is not fixed.",
 					},
-					cli.BoolFlag{
-						Name:  "yes, y",
-						Usage: "Automatically confirm deposit",
-					},
 					cli.StringFlag{
 						Name:  "salt, l",
 						Usage: "An optional seed to use when generating the new minipool's address. Use this if you want it to have a custom vanity address.",

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -320,7 +320,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "amount, a",
-						Usage: "The amount of RPL to stake (also accepts 'min8' / 'max8' for 8-ETH minipools, 'min16' / 'max16' for 16-ETH minipools, or 'all' for all of your RPL)",
+						Usage: "The amount of RPL to stake (also accepts 'min8' for 8-ETH minipools, or 'all' for all of your RPL)",
 					},
 					cli.BoolFlag{
 						Name:  "yes, y",

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -500,10 +500,6 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				UsageText: "rocketpool node deposit [options]",
 				Flags: []cli.Flag{
 					cli.StringFlag{
-						Name:  "amount, a",
-						Usage: "The amount of ETH to deposit (8 or 16)",
-					},
-					cli.StringFlag{
 						Name:  "max-slippage, s",
 						Usage: "The maximum acceptable slippage in node commission rate for the deposit (or 'auto'). Only relevant when the commission rate is not fixed.",
 					},

--- a/rocketpool-cli/node/create-vacant-minipool.go
+++ b/rocketpool-cli/node/create-vacant-minipool.go
@@ -61,7 +61,7 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 	}
 
 	// Print a notification about the pubkey
-	fmt.Printf("You are about to convert the solo staker %s into a Rocket Pool minipool. This will convert your 32 ETH deposit into either an 8 ETH or 16 ETH deposit (your choice), and convert the remaining 24 or 16 ETH into a deposit from the Rocket Pool staking pool. The staking pool portion will be credited to your node's account, allowing you to create more validators without depositing additional ETH onto the Beacon Chain. Your excess balance (your existing Beacon rewards) will be preserved and not shared with the pool stakers.\n\nPlease thoroughly read our documentation at https://docs.rocketpool.net/guides/atlas/solo-staker-migration.html to learn about the process and its implications.\n\n1. First, we'll create the new minipool.\n2. Next, we'll ask whether you want to import the validator's private key into your Smartnode's Validator Client, or keep running your own externally-managed validator.\n3. Finally, we'll help you migrate your validator's withdrawal credentials to the minipool address.\n\n%sNOTE: If you intend to use the credit balance to create additional validators, you will need to have enough RPL staked to support them.%s\n\n", pubkey.Hex(), colorYellow, colorReset)
+	fmt.Printf("You are about to convert the solo staker %s into a Rocket Pool minipool. This will convert your 32 ETH deposit into an 8 ETH deposit, and convert the remaining 24 ETH into a deposit from the Rocket Pool staking pool. The staking pool portion will be credited to your node's account, allowing you to create more validators without depositing additional ETH onto the Beacon Chain. Your excess balance (your existing Beacon rewards) will be preserved and not shared with the pool stakers.\n\nPlease thoroughly read our documentation at https://docs.rocketpool.net/guides/atlas/solo-staker-migration.html to learn about the process and its implications.\n\n1. First, we'll create the new minipool.\n2. Next, we'll ask whether you want to import the validator's private key into your Smartnode's Validator Client, or keep running your own externally-managed validator.\n3. Finally, we'll help you migrate your validator's withdrawal credentials to the minipool address.\n\n%sNOTE: If you intend to use the credit balance to create additional validators, you will need to have enough RPL staked to support them.%s\n\n", pubkey.Hex(), colorYellow, colorReset)
 
 	// Get deposit amount
 	var amount float64
@@ -79,7 +79,6 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 		// Get deposit amount options
 		amountOptions := []string{
 			"8 ETH",
-			"16 ETH",
 		}
 
 		// Prompt for amount
@@ -87,8 +86,6 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 		switch selected {
 		case 0:
 			amount = 8
-		case 1:
-			amount = 16
 		}
 
 	}
@@ -130,7 +127,7 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 
 		// Prompt for min node fee
 		if nodeFees.MinNodeFee == nodeFees.MaxNodeFee {
-			fmt.Printf("Your minipool will use the current fixed commission rate of %.2f%%.\n", nodeFees.MinNodeFee*100)
+			fmt.Printf("Your minipool will use the current base commission rate of %.2f%%.\n", nodeFees.MinNodeFee*100)
 			minNodeFee = nodeFees.MinNodeFee
 		} else {
 			minNodeFee = promptMinNodeFee(nodeFees.NodeFee, nodeFees.MinNodeFee)

--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -72,25 +72,17 @@ func nodeDeposit(c *cli.Context) error {
 
 	// Get deposit amount
 	var amount float64
-	if c.String("amount") != "" {
-		// Parse amount
-		depositAmount, err := strconv.ParseFloat(c.String("amount"), 64)
-		if err != nil {
-			return fmt.Errorf("Invalid deposit amount '%s': %w", c.String("amount"), err)
-		}
-		amount = depositAmount
-	} else {
-		// Get deposit amount options
-		amountOptions := []string{
-			"8 ETH",
-		}
 
-		// Prompt for amount
-		selected, _ := cliutils.Select("Please choose an amount of ETH to deposit:", amountOptions)
-		switch selected {
-		case 0:
-			amount = 8
-		}
+	// Get deposit amount options
+	amountOptions := []string{
+		"8 ETH",
+	}
+
+	// Prompt for amount
+	selected, _ := cliutils.Select("Please choose an amount of ETH to deposit:", amountOptions)
+	switch selected {
+	case 0:
+		amount = 8
 	}
 
 	amountWei := eth.EthToWei(amount)

--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -83,7 +83,6 @@ func nodeDeposit(c *cli.Context) error {
 		// Get deposit amount options
 		amountOptions := []string{
 			"8 ETH",
-			"16 ETH",
 		}
 
 		// Prompt for amount
@@ -91,8 +90,6 @@ func nodeDeposit(c *cli.Context) error {
 		switch selected {
 		case 0:
 			amount = 8
-		case 1:
-			amount = 16
 		}
 	}
 

--- a/rocketpool-cli/node/stake-rpl.go
+++ b/rocketpool-cli/node/stake-rpl.go
@@ -203,12 +203,10 @@ func nodeStakeRpl(c *cli.Context) error {
 			return err
 		}
 		minAmount8 := rplPrice.MinPer8EthMinipoolRplStake
-		minAmount16 := rplPrice.MinPer16EthMinipoolRplStake
 
 		// Prompt for amount option
 		amountOptions := []string{
 			fmt.Sprintf("The minimum minipool stake amount for an 8-ETH minipool (%.6f RPL)?", math.RoundUp(eth.WeiToEth(minAmount8), 6)),
-			fmt.Sprintf("The minimum minipool stake amount for a 16-ETH minipool (%.6f RPL)?", math.RoundUp(eth.WeiToEth(minAmount16), 6)),
 			fmt.Sprintf("Your entire RPL balance (%.6f RPL)?", math.RoundDown(eth.WeiToEth(&rplBalance), 6)),
 			"A custom amount",
 		}
@@ -217,8 +215,6 @@ func nodeStakeRpl(c *cli.Context) error {
 		case 0:
 			amountWei = minAmount8
 		case 1:
-			amountWei = minAmount16
-		case 2:
 			amountWei = &rplBalance
 		}
 

--- a/rocketpool-cli/node/stake-rpl.go
+++ b/rocketpool-cli/node/stake-rpl.go
@@ -172,15 +172,6 @@ func nodeStakeRpl(c *cli.Context) error {
 		}
 		amountWei = rplPrice.MinPer8EthMinipoolRplStake
 
-	} else if c.String("amount") == "min16" {
-
-		// Set amount to min per 16 ETH minipool RPL stake
-		rplPrice, err := rp.RplPrice()
-		if err != nil {
-			return err
-		}
-		amountWei = rplPrice.MinPer16EthMinipoolRplStake
-
 	} else if c.String("amount") == "all" {
 
 		// Set amount to node's entire RPL balance

--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -78,6 +78,12 @@ func getStatus(c *cli.Context) error {
 		return err
 	}
 
+	// Check Houston 1.3.1 is Active
+	hotfix, err := rp.IsHoustonHotfixDeployed()
+	if err != nil {
+		return fmt.Errorf("error checking if Houston Hotfix has been deployed: %w", err)
+	}
+
 	// Account address & balances
 	fmt.Printf("%s=== Account and Balances ===%s\n", colorGreen, colorReset)
 	fmt.Printf(
@@ -294,6 +300,8 @@ func getStatus(c *cli.Context) error {
 			math.RoundDown(eth.WeiToEth(status.RplStake), 6))
 		if status.BorrowedCollateralRatio > 0 {
 			rplTooLow := (status.RplStake.Cmp(status.MinimumRplStake) < 0)
+			rplTotalStake := math.RoundDown(eth.WeiToEth(status.RplStake), 6)
+			rplWithdrawalLimit := math.RoundDown(eth.WeiToEth(status.MaximumRplStake), 6)
 			if rplTooLow {
 				fmt.Printf(
 					"This is currently %s%.2f%% of its borrowed ETH%s and %.2f%% of its bonded ETH.\n",
@@ -303,8 +311,36 @@ func getStatus(c *cli.Context) error {
 					"This is currently %.2f%% of its borrowed ETH and %.2f%% of its bonded ETH.\n",
 					status.BorrowedCollateralRatio*100, status.BondedCollateralRatio*100)
 			}
+			if !hotfix.IsHoustonHotfixDeployed {
+				fmt.Printf(
+					"It must keep at least %.6f RPL staked to claim RPL rewards (10%% of borrowed ETH).\n", math.RoundDown(eth.WeiToEth(status.MinimumRplStake), 6))
+				fmt.Printf(
+					"RPIP-30 is in effect and the node will gradually earn rewards in amounts above the previous limit of 150%% of bonded ETH. Read more at https://github.com/rocket-pool/RPIPs/blob/main/RPIPs/RPIP-30.md\n")
+				if rplTotalStake > rplWithdrawalLimit {
+					fmt.Printf(
+						"You can now withdraw down to %.6f RPL (%.0f%% of bonded eth)\n", math.RoundDown(eth.WeiToEth(status.MaximumRplStake), 6), (status.MaximumStakeFraction)*100)
+				}
+				if rplTooLow {
+					fmt.Printf("%sWARNING: you are currently undercollateralized. You must stake at least %.6f more RPL in order to claim RPL rewards.%s\n", colorRed, math.RoundUp(eth.WeiToEth(big.NewInt(0).Sub(status.MinimumRplStake, status.RplStake)), 6), colorReset)
+				}
+			}
 		}
 		fmt.Println()
+
+		if !hotfix.IsHoustonHotfixDeployed {
+			remainingAmount := big.NewInt(0).Sub(status.EthMatchedLimit, status.EthMatched)
+			remainingAmount.Sub(remainingAmount, status.PendingMatchAmount)
+			remainingAmountEth := int(eth.WeiToEth(remainingAmount))
+			remainingFor8EB := remainingAmountEth / 24
+			if remainingFor8EB < 0 {
+				remainingFor8EB = 0
+			}
+			remainingFor16EB := remainingAmountEth / 16
+			if remainingFor16EB < 0 {
+				remainingFor16EB = 0
+			}
+			fmt.Printf("The node has enough RPL staked to make %d more 8-ETH minipools (or %d more 16-ETH minipools).\n\n", remainingFor8EB, remainingFor16EB)
+		}
 
 		// Minipool details
 		fmt.Printf("%s=== Minipools ===%s\n", colorGreen, colorReset)

--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -294,8 +294,6 @@ func getStatus(c *cli.Context) error {
 			math.RoundDown(eth.WeiToEth(status.RplStake), 6))
 		if status.BorrowedCollateralRatio > 0 {
 			rplTooLow := (status.RplStake.Cmp(status.MinimumRplStake) < 0)
-			rplTotalStake := math.RoundDown(eth.WeiToEth(status.RplStake), 6)
-			rplWithdrawalLimit := math.RoundDown(eth.WeiToEth(status.MaximumRplStake), 6)
 			if rplTooLow {
 				fmt.Printf(
 					"This is currently %s%.2f%% of its borrowed ETH%s and %.2f%% of its bonded ETH.\n",
@@ -305,32 +303,8 @@ func getStatus(c *cli.Context) error {
 					"This is currently %.2f%% of its borrowed ETH and %.2f%% of its bonded ETH.\n",
 					status.BorrowedCollateralRatio*100, status.BondedCollateralRatio*100)
 			}
-			fmt.Printf(
-				"It must keep at least %.6f RPL staked to claim RPL rewards (10%% of borrowed ETH).\n", math.RoundDown(eth.WeiToEth(status.MinimumRplStake), 6))
-			fmt.Printf(
-				"RPIP-30 is in effect and the node will gradually earn rewards in amounts above the previous limit of 150%% of bonded ETH. Read more at https://github.com/rocket-pool/RPIPs/blob/main/RPIPs/RPIP-30.md\n")
-			if rplTotalStake > rplWithdrawalLimit {
-				fmt.Printf(
-					"You can now withdraw down to %.6f RPL (%.0f%% of bonded eth)\n", math.RoundDown(eth.WeiToEth(status.MaximumRplStake), 6), (status.MaximumStakeFraction)*100)
-			}
-			if rplTooLow {
-				fmt.Printf("%sWARNING: you are currently undercollateralized. You must stake at least %.6f more RPL in order to claim RPL rewards.%s\n", colorRed, math.RoundUp(eth.WeiToEth(big.NewInt(0).Sub(status.MinimumRplStake, status.RplStake)), 6), colorReset)
-			}
 		}
 		fmt.Println()
-
-		remainingAmount := big.NewInt(0).Sub(status.EthMatchedLimit, status.EthMatched)
-		remainingAmount.Sub(remainingAmount, status.PendingMatchAmount)
-		remainingAmountEth := int(eth.WeiToEth(remainingAmount))
-		remainingFor8EB := remainingAmountEth / 24
-		if remainingFor8EB < 0 {
-			remainingFor8EB = 0
-		}
-		remainingFor16EB := remainingAmountEth / 16
-		if remainingFor16EB < 0 {
-			remainingFor16EB = 0
-		}
-		fmt.Printf("The node has enough RPL staked to make %d more 8-ETH minipools (or %d more 16-ETH minipools).\n\n", remainingFor8EB, remainingFor16EB)
 
 		// Minipool details
 		fmt.Printf("%s=== Minipools ===%s\n", colorGreen, colorReset)

--- a/rocketpool-cli/node/utils.go
+++ b/rocketpool-cli/node/utils.go
@@ -399,7 +399,7 @@ func warnIfVotingUninitialized(rp *rocketpool.Client, c *cli.Context, warningMes
 		return fmt.Errorf("error checking if Houston Hotfix has been deployed: %w", err)
 	}
 
-	if !hotfix.IsHoustonHotfixDeployed {
+	if hotfix.IsHoustonHotfixDeployed {
 		// Check if voting power is initialized
 		isVotingInitializedResponse, err := rp.IsVotingInitialized()
 		if err != nil {


### PR DESCRIPTION
- Disabled 16ETH minipool options from `deposit`, `stake-rpl` and `create-vacant-minipool`
- Removed CLI `deposit` and `stake-rpl` flags that support 16ETH minipools 
- Temporarily removed the `-y` flag from `deposit` to prevent users from skipping Saturn 0 notice
- Removed irrelevant RPL stake text from `node status`
- Added a call to check if the node is opted into the smoothing pool 
- Added a Saturn 0 message to `deposit`. It includes a note on the new commission structure and a warning if the node is not opted into the smoothing pool 


![image](https://github.com/user-attachments/assets/5342d338-2957-4bfe-b233-60dcfa6c64cf)
