### PR TITLE
The snapshot field updated from string -> int64

### DIFF
--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -619,7 +619,7 @@ type SnapshotProposal struct {
 	Start         int64     `json:"start"`
 	End           int64     `json:"end"`
 	State         string    `json:"state"`
-	Snapshot      string    `json:"snapshot"`
+	Snapshot      int64     `json:"snapshot"`
 	Author        string    `json:"author"`
 	Choices       []string  `json:"choices"`
 	Scores        []float64 `json:"scores"`


### PR DESCRIPTION
The Snapshot API response changed the `snapshot` type.