### PR TITLE
V1 Improved `node deposit` and `node stake-rpl` flow

### DIFF
--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -500,8 +500,16 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				UsageText: "rocketpool node deposit [options]",
 				Flags: []cli.Flag{
 					cli.StringFlag{
+						Name:  "amount, a",
+						Usage: "The amount of ETH to deposit (8 or 16)",
+					},
+					cli.StringFlag{
 						Name:  "max-slippage, s",
 						Usage: "The maximum acceptable slippage in node commission rate for the deposit (or 'auto'). Only relevant when the commission rate is not fixed.",
+					},
+					cli.BoolFlag{
+						Name:  "yes, y",
+						Usage: "Automatically confirm deposit",
 					},
 					cli.StringFlag{
 						Name:  "salt, l",

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -320,7 +320,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "amount, a",
-						Usage: "The amount of RPL to stake (also accepts 'min8' for 8-ETH minipools, or 'all' for all of your RPL)",
+						Usage: "The amount of RPL to stake (also accepts '5', '10', or '15' for 8-ETH minipools, or 'all' for all of your RPL)",
 					},
 					cli.BoolFlag{
 						Name:  "yes, y",

--- a/rocketpool-cli/node/create-vacant-minipool.go
+++ b/rocketpool-cli/node/create-vacant-minipool.go
@@ -55,7 +55,7 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 	}
 
 	// Post a warning about fee distribution
-	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sNOTE: by creating a new minipool, your node will automatically claim and distribute any balance you have in your fee distributor contract. If you don't want to claim your balance at this time, you should not create a new minipool.%s\nWould you like to continue?", colorYellow, colorReset))) {
+	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sNOTE: By creating a new minipool, your node will automatically claim and distribute any balance you have in your fee distributor contract. If you don't want to claim your balance at this time, you should not create a new minipool.%s\nWould you like to continue?", colorYellow, colorReset))) {
 		fmt.Println("Cancelled.")
 		return nil
 	}
@@ -75,19 +75,11 @@ func createVacantMinipool(c *cli.Context, pubkey types.ValidatorPubkey) error {
 		amount = depositAmount
 
 	} else {
-
-		// Get deposit amount options
-		amountOptions := []string{
-			"8 ETH",
+		if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sNOTE: Your new minipool will use an 8 ETH deposit (this will become your share of the balance, and the remainder will become the pool stakers' share):%s\nWould you like to continue?", colorYellow, colorReset))) {
+			fmt.Println("Cancelled.")
+			return nil
 		}
-
-		// Prompt for amount
-		selected, _ := cliutils.Select("Please choose an amount of ETH you want to use as your deposit for the new minipool (this will become your share of the balance, and the remainder will become the pool stakers' share):", amountOptions)
-		switch selected {
-		case 0:
-			amount = 8
-		}
-
+		amount = 8
 	}
 
 	amountWei := eth.EthToWei(amount)

--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -18,7 +18,7 @@ import (
 // Config
 const (
 	defaultMaxNodeFeeSlippage = 0.01 // 1% below current network fee
-	depositWarningMessage     = "NOTE: by creating a new minipool, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before creating a new minipool."
+	depositWarningMessage     = "NOTE: By creating a new minipool, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before creating a new minipool."
 )
 
 func nodeDeposit(c *cli.Context) error {
@@ -92,7 +92,7 @@ func nodeDeposit(c *cli.Context) error {
 	}
 
 	// Post a warning about fee distribution
-	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sNOTE: by creating a new minipool, your node will automatically claim and distribute any balance you have in your fee distributor contract. If you don't want to claim your balance at this time, you should not create a new minipool.%s\nWould you like to continue?", colorYellow, colorReset))) {
+	if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sNOTE: By creating a new minipool, your node will automatically claim and distribute any balance you have in your fee distributor contract. If you don't want to claim your balance at this time, you should not create a new minipool.%s\nWould you like to continue?", colorYellow, colorReset))) {
 		fmt.Println("Cancelled.")
 		return nil
 	}
@@ -100,15 +100,18 @@ func nodeDeposit(c *cli.Context) error {
 	// Get deposit amount
 	var amount float64
 
-	// Get deposit amount options
-	amountOptions := []string{
-		"8 ETH",
-	}
-
-	// Prompt for amount
-	selected, _ := cliutils.Select("Please choose an amount of ETH to deposit:", amountOptions)
-	switch selected {
-	case 0:
+	if c.String("amount") != "" {
+		// Parse amount
+		depositAmount, err := strconv.ParseFloat(c.String("amount"), 64)
+		if err != nil {
+			return fmt.Errorf("Invalid deposit amount '%s': %w", c.String("amount"), err)
+		}
+		amount = depositAmount
+	} else {
+		if !(c.Bool("yes") || cliutils.Confirm(fmt.Sprintf("%sNOTE: You are about to make an 8 ETH deposit.%s\nWould you like to continue?", colorYellow, colorReset))) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
 		amount = 8
 	}
 

--- a/shared/services/rocketpool/network.go
+++ b/shared/services/rocketpool/network.go
@@ -40,11 +40,14 @@ func (c *Client) RplPrice() (api.RplPriceResponse, error) {
 	if response.RplPrice == nil {
 		response.RplPrice = big.NewInt(0)
 	}
-	if response.MinPer8EthMinipoolRplStake == nil {
-		response.MinPer8EthMinipoolRplStake = big.NewInt(0)
+	if response.FivePercentBorrowedRplStake == nil {
+		response.FivePercentBorrowedRplStake = big.NewInt(0)
 	}
-	if response.MinPer16EthMinipoolRplStake == nil {
-		response.MinPer16EthMinipoolRplStake = big.NewInt(0)
+	if response.TenPercentBorrowedRplStake == nil {
+		response.TenPercentBorrowedRplStake = big.NewInt(0)
+	}
+	if response.FifteenPercentBorrowedRplStake == nil {
+		response.FifteenPercentBorrowedRplStake = big.NewInt(0)
 	}
 	return response, nil
 }

--- a/shared/types/api/network.go
+++ b/shared/types/api/network.go
@@ -16,12 +16,13 @@ type NodeFeeResponse struct {
 }
 
 type RplPriceResponse struct {
-	Status                      string   `json:"status"`
-	Error                       string   `json:"error"`
-	RplPrice                    *big.Int `json:"rplPrice"`
-	RplPriceBlock               uint64   `json:"rplPriceBlock"`
-	MinPer8EthMinipoolRplStake  *big.Int `json:"minPer8EthMinipoolRplStake"`
-	MinPer16EthMinipoolRplStake *big.Int `json:"minPer16EthMinipoolRplStake"`
+	Status                         string   `json:"status"`
+	Error                          string   `json:"error"`
+	RplPrice                       *big.Int `json:"rplPrice"`
+	RplPriceBlock                  uint64   `json:"rplPriceBlock"`
+	FivePercentBorrowedRplStake    *big.Int `json:"fivePercentBorrowedRplStake"`
+	TenPercentBorrowedRplStake     *big.Int `json:"tenPercentRplStake"`
+	FifteenPercentBorrowedRplStake *big.Int `json:"fifteenPercentRplStake"`
 }
 
 type NetworkStatsResponse struct {


### PR DESCRIPTION
Included in this PR: 


- New suggested RPL stake options in `stake-rpl`, because changing `node.per.minipool.stake.minimum` to 0 broke the old selection
```
Please choose an amount of RPL to stake:
1: 5% of borrowed ETH (276.648996 RPL) for one minipool?
2: 10% of borrowed ETH (553.297992 RPL) for one minipool?
3: 15% of borrowed ETH (829.946988 RPL) for one minipool?
```
- Reintroduced the `-y` and `-a` flags to `node deposit` for users who automate minipool deposits [(10/10 foresight)](https://discord.com/channels/405159462932971535/704214707904446535/1299259263318888458)

- `node deposit` and `create-vacant-minipool` uses a `y/n` confirmation rather than prompting for a selection:
```
// New
NOTE: You are about to make an 8 ETH deposit.
Would you like to continue? [y/n]
y

// Old
Please choose an amount of ETH to deposit:
1: 8 ETH
1
```