### PR TITLE
Fix balance check

### DIFF
--- a/rocketpool/api/node/deposit.go
+++ b/rocketpool/api/node/deposit.go
@@ -93,7 +93,7 @@ func canNodeDeposit(c *cli.Context, amountWei *big.Int, minNodeFee float64, salt
 
 	// Check credit balance
 	wg1.Go(func() error {
-		ethBalanceWei, err := node.GetNodeUsableCreditAndBalance(rp, nodeAccount.Address, nil)
+		ethBalanceWei, err := node.GetNodeCreditAndBalance(rp, nodeAccount.Address, nil)
 		if err == nil {
 			response.CreditBalance = ethBalanceWei
 		}


### PR DESCRIPTION
Using `NodeCreditAndBalance` instead of `NodeUsableCreditAndBalance` since we only need 1 ETH on the DP for minipool creation when using credits.