### PR TITLE
V2 Saturn 0 changes + node `deposit` and `stake-rpl` updates

### DIFF
--- a/rocketpool-cli/commands/node/commands.go
+++ b/rocketpool-cli/commands/node/commands.go
@@ -240,7 +240,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 					&cli.StringFlag{
 						Name:    amountFlag,
 						Aliases: []string{"a"},
-						Usage:   "The amount of RPL to stake (also accepts 'min8' / 'max8' for 8-ETH minipools, 'min16' / 'max16' for 16-ETH minipools, or 'all' for all of your RPL)",
+						Usage:   "The amount of RPL to stake (also accepts '5', '10', or '15' for 8-ETH minipools, or 'all' for all of your RPL)",
 					},
 					cliutils.YesFlag,
 					&cli.BoolFlag{
@@ -255,10 +255,9 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 
 					// Validate flags
 					if c.String(amountFlag) != "" &&
-						c.String(amountFlag) != "min8" &&
-						c.String(amountFlag) != "max8" &&
-						c.String(amountFlag) != "min16" &&
-						c.String(amountFlag) != "max16" &&
+						c.String(amountFlag) != "5%" &&
+						c.String(amountFlag) != "10%" &&
+						c.String(amountFlag) != "15%" &&
 						c.String(amountFlag) != "all" {
 						if _, err := input.ValidatePositiveEthAmount("stake amount", c.String(amountFlag)); err != nil {
 							return err

--- a/rocketpool-cli/commands/node/deposit.go
+++ b/rocketpool-cli/commands/node/deposit.go
@@ -23,7 +23,7 @@ const (
 	maxSlippageFlag           string  = "max-slippage"
 	saltFlag                  string  = "salt"
 	defaultMaxNodeFeeSlippage float64 = 0.01 // 1% below current network fee
-	depositWarningMessage     string  = "NOTE: by creating a new minipool, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before creating a new minipool."
+	depositWarningMessage     string  = "NOTE: By creating a new minipool, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before creating a new minipool."
 )
 
 type deposit struct {

--- a/rocketpool-cli/commands/node/stake-rpl.go
+++ b/rocketpool-cli/commands/node/stake-rpl.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	swapFlag               string = "swap"
-	stakeRPLWarningMessage string = "NOTE: by staking RPL, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before staking RPL."
+	stakeRPLWarningMessage string = "NOTE: By staking RPL, your node will automatically initialize voting power to itself. If you would like to delegate your on-chain voting power, you should run the command `rocketpool pdao initialize-voting` before staking RPL."
 )
 
 func nodeStakeRpl(c *cli.Context) error {
@@ -68,8 +68,12 @@ func nodeStakeRpl(c *cli.Context) error {
 	// Get stake amount
 	var amountWei *big.Int
 	switch c.String(amountFlag) {
-	case "min8":
-		amountWei = priceResponse.Data.MinPer8EthMinipoolRplStake
+	case "5%":
+		amountWei = priceResponse.Data.FivePercentBorrowedRplStake
+	case "10%":
+		amountWei = priceResponse.Data.TenPercentBorrowedRplStake
+	case "15%":
+		amountWei = priceResponse.Data.FifteenPercentBorrowedRplStake
 	case "all":
 		amountWei = rplBalance
 	case "":
@@ -154,21 +158,29 @@ func nodeStakeRpl(c *cli.Context) error {
 
 // Prompt the user for the amount of RPL to stake
 func promptForRplAmount(priceResponse *api.NetworkRplPriceData, rplBalance *big.Int) (*big.Int, error) {
-	// Get min/max per minipool RPL stake amounts
-	minAmount8 := priceResponse.MinPer8EthMinipoolRplStake
+	// Get the RPL stake amounts for 5,10,15% borrowed ETH per LEB8
+	fivePercentBorrowedRplStake := priceResponse.FivePercentBorrowedRplStake
+	tenPercentBorrowedRplStake := priceResponse.TenPercentBorrowedRplStake
+	fifteenPercentBorrowedRplStake := priceResponse.FifteenPercentBorrowedRplStake
 
 	// Prompt for amount option
 	var amountWei *big.Int
 	amountOptions := []string{
-		fmt.Sprintf("The minimum minipool stake amount for an 8-ETH minipool (%.6f RPL)?", math.RoundUp(eth.WeiToEth(minAmount8), 6)),
+		fmt.Sprintf("5%% of borrowed ETH (%.6f RPL) for one minipool?", math.RoundUp(eth.WeiToEth(fivePercentBorrowedRplStake), 6)),
+		fmt.Sprintf("10%% of borrowed ETH (%.6f RPL) for one minipool?", math.RoundUp(eth.WeiToEth(tenPercentBorrowedRplStake), 6)),
+		fmt.Sprintf("15%% of borrowed ETH (%.6f RPL) for one minipool?", math.RoundUp(eth.WeiToEth(fifteenPercentBorrowedRplStake), 6)),
 		fmt.Sprintf("Your entire RPL balance (%.6f RPL)?", math.RoundDown(eth.WeiToEth(rplBalance), 6)),
 		"A custom amount",
 	}
 	selected, _ := utils.Select("Please choose an amount of RPL to stake:", amountOptions)
 	switch selected {
 	case 0:
-		amountWei = minAmount8
+		amountWei = fivePercentBorrowedRplStake
 	case 1:
+		amountWei = tenPercentBorrowedRplStake
+	case 2:
+		amountWei = fifteenPercentBorrowedRplStake
+	case 3:
 		amountWei = rplBalance
 	}
 

--- a/rocketpool-cli/commands/node/stake-rpl.go
+++ b/rocketpool-cli/commands/node/stake-rpl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rocket-pool/node-manager-core/eth"
@@ -12,6 +13,7 @@ import (
 	"github.com/rocket-pool/node-manager-core/utils/math"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/client"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
+	cliutils "github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils"
 	"github.com/rocket-pool/smartnode/v2/rocketpool-cli/utils/tx"
 	"github.com/rocket-pool/smartnode/v2/shared/types/api"
 )
@@ -64,30 +66,35 @@ func nodeStakeRpl(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("error getting RPL price: %w", err)
 	}
-
 	// Get stake amount
 	var amountWei *big.Int
-	switch c.String(amountFlag) {
-	case "5%":
-		amountWei = priceResponse.Data.FivePercentBorrowedRplStake
-	case "10%":
-		amountWei = priceResponse.Data.TenPercentBorrowedRplStake
-	case "15%":
-		amountWei = priceResponse.Data.FifteenPercentBorrowedRplStake
-	case "all":
+	var stakePercent float64
+
+	// Amount flag custom percentage input
+	if strings.HasSuffix(c.String("amount"), "%") {
+		_, err := fmt.Sscanf(c.String("amount"), "%f%%", &stakePercent)
+		if err != nil {
+			return fmt.Errorf("invalid percentage format '%s': %w", c.String("amount"), err)
+		}
+		amountWei = rplStakeForLEB8(eth.EthToWei(stakePercent/100), priceResponse.Data.RplPrice)
+
+	} else if c.String("amount") == "all" {
+		// Set amount to node's entire RPL balance
 		amountWei = rplBalance
-	case "":
-		amountWei, err = promptForRplAmount(priceResponse.Data, rplBalance)
+
+	} else if c.String("amount") != "" {
+		// Parse amount
+		stakeAmount, err := strconv.ParseFloat(c.String("amount"), 64)
+		if err != nil {
+			return fmt.Errorf("Invalid stake amount '%s': %w", c.String("amount"), err)
+		}
+		amountWei = eth.EthToWei(stakeAmount)
+
+	} else {
+		amountWei, err = promptForRplAmount(priceResponse.Data, rplBalance, stakePercent)
 		if err != nil {
 			return err
 		}
-	default:
-		// Parse amount
-		stakeAmount, err := strconv.ParseFloat(c.String(amountFlag), 64)
-		if err != nil {
-			return fmt.Errorf("invalid stake amount '%s': %w", c.String(amountFlag), err)
-		}
-		amountWei = eth.EthToWei(stakeAmount)
 	}
 
 	// Build the stake TX
@@ -157,11 +164,13 @@ func nodeStakeRpl(c *cli.Context) error {
 }
 
 // Prompt the user for the amount of RPL to stake
-func promptForRplAmount(priceResponse *api.NetworkRplPriceData, rplBalance *big.Int) (*big.Int, error) {
+func promptForRplAmount(priceResponse *api.NetworkRplPriceData, rplBalance *big.Int, stakePercent float64) (*big.Int, error) {
 	// Get the RPL stake amounts for 5,10,15% borrowed ETH per LEB8
-	fivePercentBorrowedRplStake := priceResponse.FivePercentBorrowedRplStake
-	tenPercentBorrowedRplStake := priceResponse.TenPercentBorrowedRplStake
-	fifteenPercentBorrowedRplStake := priceResponse.FifteenPercentBorrowedRplStake
+	fivePercentBorrowedPerMinipool := new(big.Int)
+	fivePercentBorrowedPerMinipool.SetString("50000000000000000", 10)
+	fivePercentBorrowedRplStake := rplStakeForLEB8(fivePercentBorrowedPerMinipool, priceResponse.RplPrice)
+	tenPercentBorrowedRplStake := new(big.Int).Mul(fivePercentBorrowedRplStake, big.NewInt(2))
+	fifteenPercentBorrowedRplStake := new(big.Int).Mul(fivePercentBorrowedRplStake, big.NewInt(3))
 
 	// Prompt for amount option
 	var amountWei *big.Int
@@ -184,14 +193,35 @@ func promptForRplAmount(priceResponse *api.NetworkRplPriceData, rplBalance *big.
 		amountWei = rplBalance
 	}
 
-	// Prompt for custom amount
+	// Prompt for custom amount or percentage
 	if amountWei == nil {
-		inputAmount := utils.Prompt("Please enter an amount of RPL to stake:", "^\\d+(\\.\\d+)?$", "Invalid amount")
-		stakeAmount, err := strconv.ParseFloat(inputAmount, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid stake amount '%s': %w", inputAmount, err)
+		inputAmountOrPercent := cliutils.Prompt("Please enter an amount of RPL or percentage of borrowed ETH to stake. (e.g '50' for 50 RPL or '5%' for 5% borrowed ETH as RPL):", "^(0|[1-9]\\d*)(\\.\\d+)?%?$", "Invalid amount")
+		if strings.HasSuffix(inputAmountOrPercent, "%") {
+			_, err := fmt.Sscanf(inputAmountOrPercent, "%f%%", &stakePercent)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid percentage format '%s': %w", inputAmountOrPercent, err)
+			}
+			amountWei = rplStakeForLEB8(eth.EthToWei(stakePercent/100), priceResponse.RplPrice)
+			fmt.Println(amountWei)
+		} else {
+			stakeAmount, err := strconv.ParseFloat(inputAmountOrPercent, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid stake amount '%s': %w", inputAmountOrPercent, err)
+			}
+			amountWei = eth.EthToWei(stakeAmount)
 		}
-		amountWei = eth.EthToWei(stakeAmount)
 	}
 	return amountWei, nil
+
+}
+
+func rplStakeForLEB8(borrowedPerMinipool *big.Int, rplPrice *big.Int) *big.Int {
+	percentBorrowedRplStake := big.NewInt(0)
+	percentBorrowedRplStake.Mul(eth.EthToWei(24), borrowedPerMinipool)
+	percentBorrowedRplStake.Div(percentBorrowedRplStake, rplPrice)
+	percentBorrowedRplStake.Add(percentBorrowedRplStake, big.NewInt(1))
+	amountWei := percentBorrowedRplStake
+
+	return amountWei
+
 }

--- a/rocketpool-cli/commands/node/stake-rpl.go
+++ b/rocketpool-cli/commands/node/stake-rpl.go
@@ -70,8 +70,6 @@ func nodeStakeRpl(c *cli.Context) error {
 	switch c.String(amountFlag) {
 	case "min8":
 		amountWei = priceResponse.Data.MinPer8EthMinipoolRplStake
-	case "min16":
-		amountWei = priceResponse.Data.MinPer16EthMinipoolRplStake
 	case "all":
 		amountWei = rplBalance
 	case "":
@@ -158,13 +156,11 @@ func nodeStakeRpl(c *cli.Context) error {
 func promptForRplAmount(priceResponse *api.NetworkRplPriceData, rplBalance *big.Int) (*big.Int, error) {
 	// Get min/max per minipool RPL stake amounts
 	minAmount8 := priceResponse.MinPer8EthMinipoolRplStake
-	minAmount16 := priceResponse.MinPer16EthMinipoolRplStake
 
 	// Prompt for amount option
 	var amountWei *big.Int
 	amountOptions := []string{
 		fmt.Sprintf("The minimum minipool stake amount for an 8-ETH minipool (%.6f RPL)?", math.RoundUp(eth.WeiToEth(minAmount8), 6)),
-		fmt.Sprintf("The minimum minipool stake amount for a 16-ETH minipool (%.6f RPL)?", math.RoundUp(eth.WeiToEth(minAmount16), 6)),
 		fmt.Sprintf("Your entire RPL balance (%.6f RPL)?", math.RoundDown(eth.WeiToEth(rplBalance), 6)),
 		"A custom amount",
 	}
@@ -173,8 +169,6 @@ func promptForRplAmount(priceResponse *api.NetworkRplPriceData, rplBalance *big.
 	case 0:
 		amountWei = minAmount8
 	case 1:
-		amountWei = minAmount16
-	case 2:
 		amountWei = rplBalance
 	}
 

--- a/rocketpool-cli/commands/node/status.go
+++ b/rocketpool-cli/commands/node/status.go
@@ -291,8 +291,6 @@ func getStatus(c *cli.Context) error {
 			math.RoundDown(eth.WeiToEth(status.Data.EffectiveRplStake), 6))
 		if status.Data.BorrowedCollateralRatio > 0 {
 			rplTooLow := (status.Data.RplStake.Cmp(status.Data.MinimumRplStake) < 0)
-			rplTotalStake := math.RoundDown(eth.WeiToEth(status.Data.RplStake), 6)
-			rplWithdrawalLimit := math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6)
 			if rplTooLow {
 				fmt.Printf(
 					"This is currently %s%.2f%% of its borrowed ETH%s and %.2f%% of its bonded ETH.\n",
@@ -302,34 +300,8 @@ func getStatus(c *cli.Context) error {
 					"This is currently %.2f%% of its borrowed ETH and %.2f%% of its bonded ETH.\n",
 					status.Data.BorrowedCollateralRatio*100, status.Data.BondedCollateralRatio*100)
 			}
-			fmt.Printf(
-				"It must keep at least %.6f RPL staked to claim RPL rewards (10%% of borrowed ETH).\n", math.RoundDown(eth.WeiToEth(status.Data.MinimumRplStake), 6))
-			fmt.Printf(
-				"RPIP-30 is in effect and the node will gradually earn rewards in amounts above the previous limit of %.6f RPL (150%% of bonded ETH). Read more at https://github.com/rocket-pool/RPIPs/blob/main/RPIPs/RPIP-30.md\n", math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6))
-			if rplTotalStake > rplWithdrawalLimit {
-				fmt.Printf(
-					"You can now withdraw down to %.6f RPL (%.0f%% of bonded eth)\n",
-					math.RoundDown(eth.WeiToEth(status.Data.MaximumRplStake), 6),
-					eth.WeiToEth(status.Data.MaximumStakeFraction)*100)
-			}
-			if rplTooLow {
-				fmt.Printf("%sWARNING: you are currently undercollateralized. You must stake at least %.6f more RPL in order to claim RPL rewards.%s\n", terminal.ColorRed, math.RoundUp(eth.WeiToEth(big.NewInt(0).Sub(status.Data.MinimumRplStake, status.Data.RplStake)), 6), terminal.ColorReset)
-			}
 		}
 		fmt.Println()
-
-		remainingAmount := big.NewInt(0).Sub(status.Data.EthMatchedLimit, status.Data.EthMatched)
-		remainingAmount.Sub(remainingAmount, status.Data.PendingMatchAmount)
-		remainingAmountEth := int(eth.WeiToEth(remainingAmount))
-		remainingFor8EB := remainingAmountEth / 24
-		if remainingFor8EB < 0 {
-			remainingFor8EB = 0
-		}
-		remainingFor16EB := remainingAmountEth / 16
-		if remainingFor16EB < 0 {
-			remainingFor16EB = 0
-		}
-		fmt.Printf("The node has enough RPL staked to make %d more 8-ETH minipools (or %d more 16-ETH minipools).\n\n", remainingFor8EB, remainingFor16EB)
 
 		// Minipool details
 		fmt.Printf("%s=== Minipools ===%s\n", terminal.ColorGreen, terminal.ColorReset)

--- a/rocketpool-daemon/api/network/rpl-price.go
+++ b/rocketpool-daemon/api/network/rpl-price.go
@@ -84,22 +84,9 @@ func (c *networkPriceContext) GetState(mc *batch.MultiCaller) {
 
 func (c *networkPriceContext) PrepareData(data *api.NetworkRplPriceData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	var rplPrice *big.Int
-	_24Eth := eth.EthToWei(24)
 
 	data.RplPriceBlock = c.networkMgr.PricesBlock.Formatted()
 	rplPrice = c.networkMgr.RplPrice.Raw()
-
-	// RPL stake amounts for 5,10,15% borrowed ETH per LEB8
-	fivePercentBorrowedPerMinipool := new(big.Int)
-	fivePercentBorrowedPerMinipool.SetString("50000000000000000", 10)
-
-	fivePercentBorrowedRplStake := big.NewInt(0)
-	fivePercentBorrowedRplStake.Mul(_24Eth, fivePercentBorrowedPerMinipool)
-	fivePercentBorrowedRplStake.Div(fivePercentBorrowedRplStake, rplPrice)
-	fivePercentBorrowedRplStake.Add(fivePercentBorrowedRplStake, big.NewInt(1))
-	data.FivePercentBorrowedRplStake = fivePercentBorrowedRplStake
-	data.TenPercentBorrowedRplStake = new(big.Int).Mul(fivePercentBorrowedRplStake, big.NewInt(2))
-	data.FifteenPercentBorrowedRplStake = new(big.Int).Mul(fivePercentBorrowedRplStake, big.NewInt(3))
 
 	// Update & return response
 	data.RplPrice = rplPrice

--- a/rocketpool-daemon/api/network/rpl-price.go
+++ b/rocketpool-daemon/api/network/rpl-price.go
@@ -85,26 +85,21 @@ func (c *networkPriceContext) GetState(mc *batch.MultiCaller) {
 func (c *networkPriceContext) PrepareData(data *api.NetworkRplPriceData, opts *bind.TransactOpts) (types.ResponseStatus, error) {
 	var rplPrice *big.Int
 	_24Eth := eth.EthToWei(24)
-	_16Eth := eth.EthToWei(16)
-	var minPerMinipoolStake *big.Int
 
 	data.RplPriceBlock = c.networkMgr.PricesBlock.Formatted()
 	rplPrice = c.networkMgr.RplPrice.Raw()
-	minPerMinipoolStake = c.pSettings.Node.MinimumPerMinipoolStake.Raw()
 
-	// Min for LEB8s
-	minPer8EthMinipoolRplStake := big.NewInt(0)
-	minPer8EthMinipoolRplStake.Mul(_24Eth, minPerMinipoolStake) // Min is 10% of borrowed (24 ETH)
-	minPer8EthMinipoolRplStake.Div(minPer8EthMinipoolRplStake, rplPrice)
-	minPer8EthMinipoolRplStake.Add(minPer8EthMinipoolRplStake, big.NewInt(1))
-	data.MinPer8EthMinipoolRplStake = minPer8EthMinipoolRplStake
+	// RPL stake amounts for 5,10,15% borrowed ETH per LEB8
+	fivePercentBorrowedPerMinipool := new(big.Int)
+	fivePercentBorrowedPerMinipool.SetString("50000000000000000", 10)
 
-	// Min for 16s
-	minPer16EthMinipoolRplStake := big.NewInt(0)
-	minPer16EthMinipoolRplStake.Mul(_16Eth, minPerMinipoolStake) // Min is 10% of borrowed (16 ETH)
-	minPer16EthMinipoolRplStake.Div(minPer16EthMinipoolRplStake, rplPrice)
-	minPer16EthMinipoolRplStake.Add(minPer16EthMinipoolRplStake, big.NewInt(1))
-	data.MinPer16EthMinipoolRplStake = minPer16EthMinipoolRplStake
+	fivePercentBorrowedRplStake := big.NewInt(0)
+	fivePercentBorrowedRplStake.Mul(_24Eth, fivePercentBorrowedPerMinipool)
+	fivePercentBorrowedRplStake.Div(fivePercentBorrowedRplStake, rplPrice)
+	fivePercentBorrowedRplStake.Add(fivePercentBorrowedRplStake, big.NewInt(1))
+	data.FivePercentBorrowedRplStake = fivePercentBorrowedRplStake
+	data.TenPercentBorrowedRplStake = new(big.Int).Mul(fivePercentBorrowedRplStake, big.NewInt(2))
+	data.FifteenPercentBorrowedRplStake = new(big.Int).Mul(fivePercentBorrowedRplStake, big.NewInt(3))
 
 	// Update & return response
 	data.RplPrice = rplPrice

--- a/shared/types/api/network.go
+++ b/shared/types/api/network.go
@@ -17,11 +17,8 @@ type NetworkNodeFeeData struct {
 }
 
 type NetworkRplPriceData struct {
-	RplPrice                       *big.Int `json:"rplPrice"`
-	RplPriceBlock                  uint64   `json:"rplPriceBlock"`
-	FivePercentBorrowedRplStake    *big.Int `json:"fivePercentBorrowedRplStake"`
-	TenPercentBorrowedRplStake     *big.Int `json:"tenPercentRplStake"`
-	FifteenPercentBorrowedRplStake *big.Int `json:"fifteenPercentRplStake"`
+	RplPrice      *big.Int `json:"rplPrice"`
+	RplPriceBlock uint64   `json:"rplPriceBlock"`
 }
 
 type NetworkStatsData struct {

--- a/shared/types/api/network.go
+++ b/shared/types/api/network.go
@@ -17,10 +17,11 @@ type NetworkNodeFeeData struct {
 }
 
 type NetworkRplPriceData struct {
-	RplPrice                    *big.Int `json:"rplPrice"`
-	RplPriceBlock               uint64   `json:"rplPriceBlock"`
-	MinPer8EthMinipoolRplStake  *big.Int `json:"minPer8EthMinipoolRplStake"`
-	MinPer16EthMinipoolRplStake *big.Int `json:"minPer16EthMinipoolRplStake"`
+	RplPrice                       *big.Int `json:"rplPrice"`
+	RplPriceBlock                  uint64   `json:"rplPriceBlock"`
+	FivePercentBorrowedRplStake    *big.Int `json:"fivePercentBorrowedRplStake"`
+	TenPercentBorrowedRplStake     *big.Int `json:"tenPercentRplStake"`
+	FifteenPercentBorrowedRplStake *big.Int `json:"fifteenPercentRplStake"`
 }
 
 type NetworkStatsData struct {


### PR DESCRIPTION
This PR includes changes from #681 and #694

In summary: 
- Removed 16ETH options
- Removed some `node status` text that isn't needed in Saturn 0 
- Updated messages and workflow for `node deposit` (Saturn 0 message, smoothing pool check, 8 eth deposit hardcoded, `--a` and `--y` flags still available)
- Removed stale `node stake-rpl` options now that `node.per.minipool.stake.minimum == 0`
- Replaced those options with `5,10, or 15% borrowed ETH as RPL` as well as custom percentage inputs passed within the command or as a CLI flag. 