### PR TITLE
V1 Edit snapshot query to exclude pre-signalling proposals

### DIFF
--- a/rocketpool/api/pdao/status.go
+++ b/rocketpool/api/pdao/status.go
@@ -223,6 +223,7 @@ func GetSnapshotVotedProposals(apiDomain string, space string, nodeAddress commo
 		  where: {
 			space: "%s",
 			voter_in: ["%s", "%s"],
+			created_gte: 1727694646
 		  },
 		  orderBy: "created",
 		  orderDirection: desc
@@ -264,7 +265,7 @@ func GetSnapshotProposals(apiDomain string, space string, state string) (*api.Sn
 		stateFilter = fmt.Sprintf(`, state: "%s"`, state)
 	}
 	query := fmt.Sprintf(`query Proposals {
-	proposals(where: {space: "%s"%s}, orderBy: "created", orderDirection: desc) {
+	proposals(where: {space: "%s"%s, start_gte: 1727694646}, orderBy: "created", orderDirection: desc) {
 	    id
 	    title
 	    choices

--- a/rocketpool/node/metrics-exporter.go
+++ b/rocketpool/node/metrics-exporter.go
@@ -89,7 +89,7 @@ func runMetricsServer(c *cli.Context, logger log.ColorLogger, stateLocker *colle
 			// Set signallingAddress to blank address instead of erroring out of the task loop.
 			signallingAddress = common.Address{}
 		}
-		snapshotCollector := collectors.NewSnapshotCollector(rp, cfg, ec, bc, nodeAccount.Address, signallingAddress)
+		snapshotCollector := collectors.NewSnapshotCollector(rp, cfg, ec, bc, reg, nodeAccount.Address, signallingAddress)
 		registry.MustRegister(snapshotCollector)
 
 	}


### PR DESCRIPTION
Minor change that should have been included in #708: 

Edited `GetSnapshotProposals` and `GetSnapshotVotedProposals` query to exclude proposals before the latest [rocketpool-node-operator-delegate-v8](https://snapshot.org/#/strategy/rocketpool-node-operator-delegate-v8) strategy. This corrects `pdao status` as well as this pane in grafana: 
![image](https://github.com/user-attachments/assets/4f418c4c-b4e3-41bd-ac9d-7db2b2014e4d)


