### PR TITLE
Update outdated PBSS message in service.go

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -986,7 +986,7 @@ func pruneExecutionClient(c *cli.Context) error {
 
 	if selectedEc == cfgtypes.ExecutionClient_Geth || selectedEc == cfgtypes.ExecutionClient_Besu {
 		if selectedEc == cfgtypes.ExecutionClient_Geth {
-			fmt.Printf("%sGeth has a new feature that renders pruning obsolete. Consider enabling PBSS in the Execution Client settings in `rocketpool service config` and resyncing with `rocketpool service resync-eth1` instead of pruning.%s\n", colorYellow, colorReset)
+			fmt.Printf("%sGeth has a new feature that renders pruning obsolete. However, as this is a new feature you may have to resync with `rocketpool service resync-eth1` before this takes effect.%s\n", colorYellow, colorReset)
 		}
 		fmt.Println("This will shut down your main execution client and prune its database, freeing up disk space.")
 		if cfg.UseFallbackClients.Value == false {


### PR DESCRIPTION
PBSS is no longer an option in the service config, and looking through the Discord there are a couple of messages with users confused by this output.
https://discord.com/channels/405159462932971535/468923220607762485/1281917595767013475
https://discord.com/channels/405159462932971535/468923220607762485/1295712655495004223

This wording should be more clear, I'm not completely privy to all the options and definitely open to suggestions on phrasing this more clearly so users know exactly what to do when running out of space with Geth as their client.