### PR TITLE
V1 Exclude finalized minipools in `delegate-upgrade` unless `include-finalized` flag is used. 

### DIFF
--- a/rocketpool-cli/minipool/commands.go
+++ b/rocketpool-cli/minipool/commands.go
@@ -403,6 +403,10 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 						Name:  "minipool, m",
 						Usage: "The minipool/s to upgrade (address or 'all')",
 					},
+					cli.BoolFlag{
+						Name:  "include-finalized, f",
+						Usage: "Include finailized minipools in the list (default is to hide them).",
+					},
 				},
 				Action: func(c *cli.Context) error {
 

--- a/rocketpool-cli/minipool/delegate.go
+++ b/rocketpool-cli/minipool/delegate.go
@@ -33,10 +33,14 @@ func delegateUpgradeMinipools(c *cli.Context) error {
 		return err
 	}
 
+	includeFinalized := c.Bool("include-finalized")
+
 	minipools := []api.MinipoolDetails{}
 	for _, mp := range status.Minipools {
 		if mp.Delegate != latestDelegateResponse.Address && !mp.UseLatestDelegate {
-			minipools = append(minipools, mp)
+			if includeFinalized || !mp.Finalised {
+				minipools = append(minipools, mp)
+			}
 		}
 	}
 


### PR DESCRIPTION
Added a flag ` "include-finalized, f"` flag to `minipool delegate-upgrade` because finalized minipools shouldn't be included by default. 
