### PR TITLE
Show delegate vote direction in pDAO proposal details and voting. 

### DIFF
--- a/rocketpool-cli/pdao/proposals.go
+++ b/rocketpool-cli/pdao/proposals.go
@@ -116,6 +116,12 @@ func getProposal(c *cli.Context, id uint64) error {
 		return err
 	}
 
+	// Get the voting delegate info
+	votingDelegateInfo, err := rp.GetCurrentVotingDelegate()
+	if err != nil {
+		return err
+	}
+
 	// Find the proposal
 	var proposal *api.PDAOProposalWithNodeVoteDirection
 
@@ -170,12 +176,21 @@ func getProposal(c *cli.Context, id uint64) error {
 	vetoQuorum := utilsMath.RoundUp(eth.WeiToEth(proposal.VetoQuorum), 2)
 	fmt.Printf("Voting power for:       %.2f / %.2f (%.2f%%)\n", votingPowerFor, votingPowerRequired, votingPowerFor/votingPowerRequired*100)
 	fmt.Printf("Voting power against:   %.2f\n", utilsMath.RoundDown(eth.WeiToEth(proposal.VotingPowerAgainst), 2))
-	fmt.Printf("   Against with veto:   %.2f / %2.f (%.2f%%)\n", votingPowerToVeto, vetoQuorum, votingPowerToVeto/vetoQuorum*100)
+	fmt.Printf("Against with veto:      %.2f / %2.f (%.2f%%)\n", votingPowerToVeto, vetoQuorum, votingPowerToVeto/vetoQuorum*100)
 	fmt.Printf("Voting power abstained: %.2f\n", utilsMath.RoundDown(eth.WeiToEth(proposal.VotingPowerAbstained), 2))
 	if proposal.NodeVoteDirection != types.VoteDirection_NoVote {
 		fmt.Printf("Node has voted:         %s\n", types.VoteDirections[proposal.NodeVoteDirection])
 	} else {
 		fmt.Printf("Node has voted:         no\n")
+	}
+
+	if votingDelegateInfo.VotingDelegate != votingDelegateInfo.AccountAddress && proposal.DelegateVoteDirection != types.VoteDirection_NoVote {
+		fmt.Printf("Delegate has voted:     %s\n", types.VoteDirections[proposal.DelegateVoteDirection])
+	} else if votingDelegateInfo.VotingDelegate != votingDelegateInfo.AccountAddress {
+		fmt.Printf("Delegate has voted:     no\n")
+	}
+	if votingDelegateInfo.VotingDelegate != votingDelegateInfo.AccountAddress {
+		fmt.Printf("Current Delegate:       %s", votingDelegateInfo.VotingDelegate.Hex())
 	}
 
 	return nil

--- a/rocketpool-cli/pdao/vote-proposal.go
+++ b/rocketpool-cli/pdao/vote-proposal.go
@@ -38,6 +38,12 @@ func voteOnProposal(c *cli.Context) error {
 		}
 	}
 
+	// Get the voting delegate
+	votingDelegateInfo, err := rp.GetCurrentVotingDelegate()
+	if err != nil {
+		return err
+	}
+
 	// Check for votable proposals
 	if len(votableProposals) == 0 {
 		fmt.Println("No proposals can be voted on.")
@@ -94,6 +100,12 @@ func voteOnProposal(c *cli.Context) error {
 		selected, _ := cliutils.Select("Please select a proposal to vote on:", options)
 		selectedProposal = votableProposals[selected]
 
+	}
+
+	// Check if delegate has voted
+	if selectedProposal.DelegateVoteDirection != types.VoteDirection_NoVote && votingDelegateInfo.VotingDelegate != votingDelegateInfo.AccountAddress {
+		fmt.Printf("Your Delegate: %s has voted: %s\n", votingDelegateInfo.VotingDelegate.Hex(), types.VoteDirections[selectedProposal.DelegateVoteDirection])
+		fmt.Println()
 	}
 
 	// Get support status

--- a/shared/types/api/pdao.go
+++ b/shared/types/api/pdao.go
@@ -12,7 +12,8 @@ import (
 
 type PDAOProposalWithNodeVoteDirection struct {
 	protocol.ProtocolDaoProposalDetails
-	NodeVoteDirection types.VoteDirection `json:"nodeVoteDirection"`
+	NodeVoteDirection     types.VoteDirection `json:"nodeVoteDirection"`
+	DelegateVoteDirection types.VoteDirection `json:"delegateVoteDirection"`
 }
 
 type PDAOProposalsResponse struct {


### PR DESCRIPTION
This PR adds a new field `DelegateVoteDirection` to the `PDAOProposalWithNodeVoteDirection`api reponse, then uses it to show the delegate vote direction when querying details for a proposal, or when voting on a proposal. 

```
:~$ rocketpool pdao proposals details 50

Proposal ID:            50
Message:                one-time spend for invoice test-delegate-vote-direction-2
...
...
Node has voted:         no
Delegate has voted:     In Favor
Current Delegate:       0xd48a411E40624A4504e48390419d01A47a50fbFE
```
```
:~$ rocketpool pdao proposals vote 

Please select a proposal to vote on:
1: proposal 50 (message: 'one-time spend for invoice test-delegate-vote-direction-2', payload: proposalTreasuryOneTimeSpend(test-delegate-vote-direction-2,0xE8325F5f4486c2FF2AC7B522Fbc9eB249d46C936,1000000000000000000), phase 1 end: 20 Feb 25 22:01 PST, vp required: 222.83, for: 103.81, against: 0.00, abstained: 0.00, veto: 0.00, proposed by: 0xE8325F5f4486c2FF2AC7B522Fbc9eB249d46C936)

Please enter a number corresponding to an option
1

Your Delegate: 0xd48a411E40624A4504e48390419d01A47a50fbFE has voted: In Favor

How would you like to vote on the proposal?
1: Abstain
2: In Favor
3: Against
4: Veto
```