### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/rocketpool/watchtower/utils/utils.go
+++ b/rocketpool/watchtower/utils/utils.go
@@ -23,19 +23,13 @@ const (
 // Get the max fee for watchtower transactions
 func GetWatchtowerMaxFee(cfg *config.RocketPoolConfig) float64 {
 	setting := cfg.Smartnode.WatchtowerMaxFeeOverride.Value.(float64)
-	if setting < MinWatchtowerMaxFee {
-		return MinWatchtowerMaxFee
-	}
-	return setting
+	return max(MinWatchtowerMaxFee, setting)
 }
 
 // Get the priority fee for watchtower transactions
 func GetWatchtowerPrioFee(cfg *config.RocketPoolConfig) float64 {
 	setting := cfg.Smartnode.WatchtowerPrioFeeOverride.Value.(float64)
-	if setting < MinWatchtowerPriorityFee {
-		return MinWatchtowerPriorityFee
-	}
-	return setting
+	return max(MinWatchtowerPriorityFee, setting)
 }
 
 func FindLastBlockWithExecutionPayload(bc beacon.Client, slotNumber uint64) (beacon.BeaconBlock, error) {


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.