### PR TITLE
Use the last submission block as target if the node didn't participate in consensus

### DIFF
--- a/rocketpool/watchtower/constants.go
+++ b/rocketpool/watchtower/constants.go
@@ -1,6 +1,10 @@
 package watchtower
 
+import "time"
+
 const (
 	enableSubmissionAfterConsensus_Balances    bool = true
 	enableSubmissionAfterConsensus_RewardsTree bool = true
+
+	contextTimeout = 10 * time.Second
 )

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -7,9 +7,11 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -367,15 +369,46 @@ func (t *submitRplPrice) run(state *state.NetworkState) error {
 	lastSubmissionBlock := state.NetworkDetails.PricesBlock
 
 	referenceTimestamp := t.cfg.Smartnode.PriceBalanceSubmissionReferenceTimestamp.Value.(int64)
+
 	// Get the duration in seconds for the interval between submissions
 	submissionIntervalInSeconds := int64(state.NetworkDetails.PricesSubmissionFrequency)
 	eth2Config := state.BeaconConfig
 
-	_, nextSubmissionTime, targetBlockHeader, err := utils.FindNextSubmissionTarget(t.rp, eth2Config, t.bc, t.ec, lastSubmissionBlock, referenceTimestamp, submissionIntervalInSeconds)
-	if err != nil {
-		return err
+	var hasSubmittedPastBlock bool
+	var nextSubmissionTime time.Time
+	var targetBlockNumber uint64
+	var lastSubmissionBlockHeader *types.Header
+
+	// Check if the node has submitted prices for the latest block
+	if lastSubmissionBlock != 0 {
+		// Get the lastSubmissionBlock timestamp
+		lastSubmissionBlockHeader, err = t.rp.Client.HeaderByNumber(context.Background(), big.NewInt(int64(lastSubmissionBlock)))
+		if err != nil {
+			t.log.Printlnf("Error getting the latest submission block header: %s", err.Error())
+			return err
+		}
+		hasSubmittedPastBlock, err = t.hasSubmittedSpecificBlockPrices(nodeAccount.Address, lastSubmissionBlock, lastSubmissionBlockHeader.Time, state.NetworkDetails.RplPrice)
+		if err != nil {
+			t.log.Printlnf("Error checking if node has submitted prices for block %d: %s", lastSubmissionBlock, err.Error())
+			return err
+		}
 	}
-	targetBlockNumber := targetBlockHeader.Number.Uint64()
+
+	if !hasSubmittedPastBlock {
+		// If the node didn't participate in consensus, use the last submission block as the target block as a health check
+		t.log.Printlnf("Node has not participated on the consensus for block %d, using it as the target block.", lastSubmissionBlock)
+		targetBlockNumber = lastSubmissionBlock
+		nextSubmissionTime = time.Unix(int64(lastSubmissionBlockHeader.Time), 0)
+
+	} else {
+		// If it did participate, find the next submission target
+		var targetBlockHeader *types.Header
+		_, nextSubmissionTime, targetBlockHeader, err = utils.FindNextSubmissionTarget(t.rp, eth2Config, t.bc, t.ec, lastSubmissionBlock, referenceTimestamp, submissionIntervalInSeconds)
+		if err != nil {
+			return err
+		}
+		targetBlockNumber = targetBlockHeader.Number.Uint64()
+	}
 
 	// Check if the process is already running
 	t.lock.Lock()


### PR DESCRIPTION
This PR makes the RPL price submission work as a health check for oDAO nodes. If a node didn't participate in the previous round, they're going to use that past block as the submission target.