### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/rocketpool-cli/node/status.go
+++ b/rocketpool-cli/node/status.go
@@ -347,14 +347,8 @@ func getStatus(c *cli.Context) error {
 			remainingAmount := big.NewInt(0).Sub(status.EthMatchedLimit, status.EthMatched)
 			remainingAmount.Sub(remainingAmount, status.PendingMatchAmount)
 			remainingAmountEth := int(eth.WeiToEth(remainingAmount))
-			remainingFor8EB := remainingAmountEth / 24
-			if remainingFor8EB < 0 {
-				remainingFor8EB = 0
-			}
-			remainingFor16EB := remainingAmountEth / 16
-			if remainingFor16EB < 0 {
-				remainingFor16EB = 0
-			}
+			remainingFor8EB := max(remainingAmountEth/24, 0)
+			remainingFor16EB := max(remainingAmountEth/16, 0)
 			fmt.Printf("The node has enough RPL staked to make %d more 8-ETH minipools (or %d more 16-ETH minipools).\n\n", remainingFor8EB, remainingFor16EB)
 		}
 

--- a/rocketpool-cli/service/config/directional-modal.go
+++ b/rocketpool-cli/service/config/directional-modal.go
@@ -255,10 +255,7 @@ func (m *DirectionalModal) Draw(screen tcell.Screen) {
 	}
 	buttonsWidth -= 2
 	screenWidth, screenHeight := screen.Size()
-	width := screenWidth / 3
-	if width < buttonsWidth {
-		width = buttonsWidth
-	}
+	width := max(screenWidth/3, buttonsWidth)
 	// width is now without the box border.
 
 	// Reset the text and find out how wide it is.

--- a/rocketpool-cli/service/config/dropdown.go
+++ b/rocketpool-cli/service/config/dropdown.go
@@ -333,10 +333,7 @@ func (d *DropDown) Draw(screen tcell.Screen) {
 
 	// Draw label.
 	if d.labelWidth > 0 {
-		labelWidth := d.labelWidth
-		if labelWidth > rightLimit-x {
-			labelWidth = rightLimit - x
-		}
+		labelWidth := min(d.labelWidth, rightLimit-x)
 		tview.Print(screen, d.label, x, y, labelWidth, tview.AlignLeft, d.labelColor)
 		x += labelWidth
 	} else {
@@ -414,10 +411,7 @@ func (d *DropDown) Draw(screen tcell.Screen) {
 		lheight := len(d.options)
 		_, sheight := screen.Size()
 		if ly+lheight >= sheight && ly-2 > lheight-ly {
-			ly = y - lheight
-			if ly < 0 {
-				ly = 0
-			}
+			ly = max(y-lheight, 0)
 		}
 		if ly+lheight >= sheight {
 			lheight = sheight - ly

--- a/rocketpool-cli/service/config/pseudomodal.go
+++ b/rocketpool-cli/service/config/pseudomodal.go
@@ -257,10 +257,7 @@ func (m *Pseudomodal) Draw(screen tcell.Screen) {
 	}
 	buttonsWidth -= 2
 	screenWidth, screenHeight := screen.Size()
-	width := screenWidth / 3
-	if width < buttonsWidth {
-		width = buttonsWidth
-	}
+	width := max(screenWidth/3, buttonsWidth)
 	// width is now without the box border.
 
 	// Reset the text and find out how wide it is.

--- a/shared/services/proposals/voting-tree.go
+++ b/shared/services/proposals/voting-tree.go
@@ -154,10 +154,9 @@ func (t *VotingTree) generatePollard(virtualRootIndex uint64) (*types.VotingTree
 	rootNode := t.Nodes[index-1] // 0-indexed
 
 	rootLevel := uint64(math.Floor(math.Log2(float64(index)))) // The level of the root node
-	absoluteDepth := rootLevel + t.DepthPerRound               // The actual level in the tree that this pollard must come from
-	if absoluteDepth > t.Depth {
-		absoluteDepth = t.Depth // Clamp it to the level of the leaf nodes
-	}
+	// The actual level in the tree that this pollard must come from
+	// Clamp it to the level of the leaf nodes
+	absoluteDepth := min(rootLevel+t.DepthPerRound, t.Depth)
 	relativeDepth := absoluteDepth - rootLevel // How far the pollard level is below the root node level
 	//fmt.Printf("[Pollard Gen] Root level = %d, absolute depth = %d, relative depth = %d\n", rootLevel, absoluteDepth, relativeDepth)
 

--- a/shared/services/rewards/generator-impl-v8.go
+++ b/shared/services/rewards/generator-impl-v8.go
@@ -1035,10 +1035,7 @@ func (r *treeGeneratorImpl_v8) getSmoothingPoolNodeDetails() error {
 
 		// Get batch start & end index
 		iterationStartIndex := batchStartIndex
-		iterationEndIndex := batchStartIndex + SmoothingPoolDetailsBatchSize
-		if iterationEndIndex > nodeCount {
-			iterationEndIndex = nodeCount
-		}
+		iterationEndIndex := min(batchStartIndex+SmoothingPoolDetailsBatchSize, nodeCount)
 
 		// Load details
 		var wg errgroup.Group

--- a/shared/services/rewards/generator-impl-v9-v10.go
+++ b/shared/services/rewards/generator-impl-v9-v10.go
@@ -1139,10 +1139,7 @@ func (r *treeGeneratorImpl_v9_v10) getSmoothingPoolNodeDetails() error {
 
 		// Get batch start & end index
 		iterationStartIndex := batchStartIndex
-		iterationEndIndex := batchStartIndex + SmoothingPoolDetailsBatchSize
-		if iterationEndIndex > nodeCount {
-			iterationEndIndex = nodeCount
-		}
+		iterationEndIndex := min(batchStartIndex+SmoothingPoolDetailsBatchSize, nodeCount)
 
 		// Load details
 		var wg errgroup.Group

--- a/shared/utils/eth2/eth2.go
+++ b/shared/utils/eth2/eth2.go
@@ -47,10 +47,7 @@ func GetBeaconBalances(rp *rocketpool.RocketPool, bc beacon.Client, addresses []
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolBalanceDetailsBatchSize
-		if mei > len(addresses) {
-			mei = len(addresses)
-		}
+		mei := min(bsi+MinipoolBalanceDetailsBatchSize, len(addresses))
 
 		// Load details
 		var wg errgroup.Group
@@ -85,10 +82,7 @@ func GetBeaconBalancesFromState(rp *rocketpool.RocketPool, mpds []*rpstate.Nativ
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolBalanceDetailsBatchSize
-		if mei > len(mpds) {
-			mei = len(mpds)
-		}
+		mei := min(bsi+MinipoolBalanceDetailsBatchSize, len(mpds))
 
 		// Load details
 		var wg errgroup.Group

--- a/shared/utils/rp/minipools.go
+++ b/shared/utils/rp/minipools.go
@@ -25,10 +25,7 @@ func GetMinipoolValidators(rp *rocketpool.RocketPool, bc beacon.Client, addresse
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolPubkeyBatchSize
-		if mei > len(addresses) {
-			mei = len(addresses)
-		}
+		mei := min(bsi+MinipoolPubkeyBatchSize, len(addresses))
 
 		// Load details
 		var wg errgroup.Group


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.