### PR TITLE
Remove invocations to nethermind prune starter container, preferring docker-based curl

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -33,7 +33,6 @@ const (
 	ValidatorContainerSuffix        string = "_validator"
 	BeaconContainerSuffix           string = "_eth2"
 	ExecutionContainerSuffix        string = "_eth1"
-	PruneStarterContainerSuffix     string = "_nm_prune_starter"
 	NodeContainerSuffix             string = "_node"
 	ApiContainerSuffix              string = "_api"
 	WatchtowerContainerSuffix       string = "_watchtower"
@@ -1012,8 +1011,6 @@ func pruneExecutionClient(c *cli.Context) error {
 	// Get the execution container name
 	executionContainerName := prefix + ExecutionContainerSuffix
 
-	pruneStarterContainerName := prefix + PruneStarterContainerSuffix
-
 	// Check for enough free space
 	volumePath, err := rp.GetClientVolumeSource(executionContainerName, clientDataVolumeName)
 	if err != nil {
@@ -1046,7 +1043,7 @@ func pruneExecutionClient(c *cli.Context) error {
 
 	if selectedEc == cfgtypes.ExecutionClient_Nethermind {
 		// Restarting NM is not needed anymore
-		err = rp.RunNethermindPruneStarter(executionContainerName, pruneStarterContainerName)
+		err = rp.RunNethermindPruneStarter(executionContainerName)
 		if err != nil {
 			return fmt.Errorf("Error starting Nethermind prune starter: %w", err)
 		}


### PR DESCRIPTION
Use curlimages/curl to begin nethermind prunes instead of a bespoke container.