### PR TITLE
Use prysm containers directly

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -406,7 +406,7 @@ func updateConfigParamFromCliArg(c *cli.Context, sectionName string, param *cfgt
 func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName string) error {
 
 	// Stop all of the containers
-	fmt.Print("Stopping containers... ")
+	fmt.Println("Stopping containers... ")
 	err := rp.PauseService(getComposeFiles(c))
 	if err != nil {
 		return fmt.Errorf("error stopping service: %w", err)
@@ -414,7 +414,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 	fmt.Println("done")
 
 	// Restart the API container
-	fmt.Print("Starting API container... ")
+	fmt.Println("Starting API container... ")
 	output, err := rp.StartContainer(apiContainerName)
 	if err != nil {
 		return fmt.Errorf("error starting API container: %w", err)
@@ -425,7 +425,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 	fmt.Println("done")
 
 	// Get the path of the user's data folder
-	fmt.Print("Retrieving data folder path... ")
+	fmt.Println("Retrieving data folder path... ")
 	volumePath, err := rp.GetClientVolumeSource(apiContainerName, dataFolderVolumeName)
 	if err != nil {
 		return fmt.Errorf("error getting data folder path: %w", err)
@@ -433,7 +433,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 	fmt.Printf("done, data folder = %s\n", volumePath)
 
 	// Delete the data folder
-	fmt.Print("Removing data folder... ")
+	fmt.Println("Removing data folder... ")
 	_, err = rp.TerminateDataFolder()
 	if err != nil {
 		return err
@@ -441,7 +441,7 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 	fmt.Println("done")
 
 	// Terminate the current setup
-	fmt.Print("Removing old installation... ")
+	fmt.Println("Removing old installation... ")
 	err = rp.StopService(getComposeFiles(c))
 	if err != nil {
 		return fmt.Errorf("error terminating old installation: %w", err)
@@ -449,14 +449,14 @@ func changeNetworks(c *cli.Context, rp *rocketpool.Client, apiContainerName stri
 	fmt.Println("done")
 
 	// Create new validator folder
-	fmt.Print("Recreating data folder... ")
+	fmt.Println("Recreating data folder... ")
 	err = os.MkdirAll(filepath.Join(volumePath, "validators"), 0775)
 	if err != nil {
 		return fmt.Errorf("error recreating data folder: %w", err)
 	}
 
 	// Start the service
-	fmt.Print("Starting Rocket Pool... ")
+	fmt.Println("Starting Rocket Pool... ")
 	err = rp.StartService(getComposeFiles(c))
 	if err != nil {
 		return fmt.Errorf("error starting service: %w", err)

--- a/shared/services/config/rocket-pool-config.go
+++ b/shared/services/config/rocket-pool-config.go
@@ -925,6 +925,14 @@ func (cfg *RocketPoolConfig) ConsensusClientApiUrl() (string, error) {
 	return cCfg.(config.ExternalConsensusConfig).GetApiUrl(), nil
 }
 
+func stripScheme(url string) string {
+	idx := strings.Index(url, "://")
+	if idx != -1 {
+		url = url[idx+3:]
+	}
+	return url
+}
+
 // Used by text/template to format validator.yml
 func (cfg *RocketPoolConfig) ConsensusClientRpcUrl() (string, error) {
 	// Check if Rescue Node is in-use
@@ -947,8 +955,8 @@ func (cfg *RocketPoolConfig) ConsensusClientRpcUrl() (string, error) {
 		return fmt.Sprintf("%s:%d", Eth2ContainerName, cfg.Prysm.RpcPort.Value), nil
 	}
 
-	// Use the external RPC endpoint
-	return cfg.ExternalPrysm.JsonRpcUrl.Value.(string), nil
+	// Use the external RPC endpoint, but strip any scheme
+	return stripScheme(cfg.ExternalPrysm.JsonRpcUrl.Value.(string)), nil
 }
 
 // Used by text/template to format validator.yml
@@ -976,7 +984,7 @@ func (cfg *RocketPoolConfig) FallbackCcRpcUrl() string {
 		return ""
 	}
 
-	return cfg.FallbackPrysm.JsonRpcUrl.Value.(string)
+	return stripScheme(cfg.FallbackPrysm.JsonRpcUrl.Value.(string))
 }
 
 // Used by text/template to format validator.yml

--- a/shared/services/rocketpool/assets/install/scripts/download-genesis.sh
+++ b/shared/services/rocketpool/assets/install/scripts/download-genesis.sh
@@ -6,7 +6,7 @@ if [ "$NETWORK" = "testnet" ]; then
     echo "Prysm is configured to use Hoodi, genesis state required."
     if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
         echo "Downloading from Github..."
-        wget https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
+        wget https://github.com/eth-clients/hoodi/raw/refs/heads/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
         echo "Download complete."
     else
         echo "Genesis state already downloaded, continuing."
@@ -15,7 +15,7 @@ elif [ "$NETWORK" = "devnet" ]; then
     echo "Prysm is configured to use Hoodi, genesis state required."
     if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
         echo "Downloading from Github..."
-        wget https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
+        wget https://github.com/eth-clients/hoodi/raw/refs/heads/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
         echo "Download complete."
     else
         echo "Genesis state already downloaded, continuing."

--- a/shared/services/rocketpool/assets/install/scripts/download-genesis.sh
+++ b/shared/services/rocketpool/assets/install/scripts/download-genesis.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# Grab the Testnet genesis state if needed
+if [ "$NETWORK" = "testnet" ]; then
+    echo "Prysm is configured to use Hoodi, genesis state required."
+    if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
+        echo "Downloading from Github..."
+        wget https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
+        echo "Download complete."
+    else
+        echo "Genesis state already downloaded, continuing."
+    fi
+elif [ "$NETWORK" = "devnet" ]; then
+    echo "Prysm is configured to use Hoodi, genesis state required."
+    if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
+        echo "Downloading from Github..."
+        wget https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
+        echo "Download complete."
+    else
+        echo "Genesis state already downloaded, continuing."
+    fi
+else
+    echo "Genesis download not required for $NETWORK"
+fi

--- a/shared/services/rocketpool/assets/install/scripts/start-bn.sh
+++ b/shared/services/rocketpool/assets/install/scripts/start-bn.sh
@@ -210,27 +210,6 @@ fi
 # Prysm startup
 if [ "$CC_CLIENT" = "prysm" ]; then
 
-    # Grab the Testnet genesis state if needed
-    if [ "$NETWORK" = "testnet" ]; then
-        echo "Prysm is configured to use Hoodi, genesis state required."
-        if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
-            echo "Downloading from Github..."
-            wget https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
-            echo "Download complete."
-        else
-            echo "Genesis state already downloaded, continuing."
-        fi
-    elif [ "$NETWORK" = "devnet" ]; then
-        echo "Prysm is configured to use Hoodi, genesis state required."
-        if [ ! -f "/ethclient/hoodi-genesis.ssz" ]; then
-            echo "Downloading from Github..."
-            wget https://github.com/eth-clients/hoodi/blob/main/metadata/genesis.ssz -O /ethclient/hoodi-genesis.ssz
-            echo "Download complete."
-        else
-            echo "Genesis state already downloaded, continuing."
-        fi
-    fi
-
     CMD="$PERF_PREFIX /app/cmd/beacon-chain/beacon-chain \
         --accept-terms-of-use \
         $PRYSM_NETWORK \

--- a/shared/services/rocketpool/assets/install/scripts/start-vc.sh
+++ b/shared/services/rocketpool/assets/install/scripts/start-vc.sh
@@ -168,12 +168,6 @@ if [ "$CC_CLIENT" = "prysm" ]; then
     # Make the Prysm dir
     mkdir -p /validators/prysm-non-hd/
 
-    # Get rid of the protocol prefix
-    CC_RPC_ENDPOINT=$(echo $CC_RPC_ENDPOINT | sed -E 's/.*\:\/\/(.*)/\1/')
-    if [ ! -z "$FALLBACK_CC_RPC_ENDPOINT" ]; then
-        FALLBACK_CC_RPC_ENDPOINT=$(echo $FALLBACK_CC_RPC_ENDPOINT | sed -E 's/.*\:\/\/(.*)/\1/')
-    fi
-
     # Set up the CC + fallback string
     CC_URL_STRING=$CC_RPC_ENDPOINT
     if [ ! -z "$FALLBACK_CC_RPC_ENDPOINT" ]; then

--- a/shared/services/rocketpool/assets/install/templates/eth2.tmpl
+++ b/shared/services/rocketpool/assets/install/templates/eth2.tmpl
@@ -5,6 +5,21 @@
 # See https://docs.docker.com/compose/extends/#adding-and-overriding-configuration
 # for more information on overriding specific parameters of docker-compose files.
 
+{{define "GENESIS_DL"}}
+  eth2_genesis_downloader:
+    image: curlimages/curl:8.13.0
+    user: root
+    container_name: {{.Smartnode.ProjectName}}_genesis_downloader
+    volumes:
+      - eth2clientdata:/ethclient
+      - {{.RocketPoolDirectory}}/scripts:/setup:ro
+    network_mode: host
+    environment:
+      - NETWORK={{.Smartnode.Network}}
+    entrypoint: sh
+    command: "/setup/download-genesis.sh"
+{{end}}
+
 services:
   eth2:
     image: {{.GetBeaconContainerTag}}
@@ -72,11 +87,6 @@ services:
       {{- else if eq .ConsensusClient.String "lighthouse"}}
       - BN_P2P_QUIC_PORT={{.Lighthouse.P2pQuicPort}}
       {{- end}}
-    {{- if eq .ConsensusClient.String "prysm"}}
-    entrypoint: bash
-    {{- else}}
-    entrypoint: sh
-    {{- end}}
     command: "/setup/start-bn.sh"
     cap_drop:
       - all
@@ -84,6 +94,16 @@ services:
       - dac_override
     security_opt:
       - no-new-privileges
+    {{- if ne .ConsensusClient.String "prysm"}}
+    entrypoint: sh
+    {{- else}}
+    {{- /* prysm has bash but not sh and may need us to download genesis for testnets */}}
+    entrypoint: bash
+    depends_on:
+      eth2_genesis_downloader:
+        condition: service_completed_successfully
+    {{- template "GENESIS_DL" . }}
+    {{- end}}
 networks:
   net:
 volumes:

--- a/shared/services/rocketpool/assets/install/templates/eth2.tmpl
+++ b/shared/services/rocketpool/assets/install/templates/eth2.tmpl
@@ -7,18 +7,7 @@
 
 services:
   eth2:
-    {{- if eq .ConsensusClient.String "prysm"}}
-    image: localhost/{{.GetBeaconContainerTag}}
-    pull_policy: never
-    build:
-      dockerfile_inline: |
-        FROM {{.GetBeaconContainerTag}} as upstream
-        FROM debian:bookworm-slim
-        RUN apt update && apt install -y wget ca-certificates && rm -rf /var/lib/apt/lists/*
-        COPY --from=upstream /app/cmd/beacon-chain/beacon-chain /app/cmd/beacon-chain/beacon-chain
-    {{- else}}
     image: {{.GetBeaconContainerTag}}
-    {{- end}}
     user: root
     container_name: {{.Smartnode.ProjectName}}_eth2
     restart: unless-stopped
@@ -83,7 +72,11 @@ services:
       {{- else if eq .ConsensusClient.String "lighthouse"}}
       - BN_P2P_QUIC_PORT={{.Lighthouse.P2pQuicPort}}
       {{- end}}
+    {{- if eq .ConsensusClient.String "prysm"}}
+    entrypoint: bash
+    {{- else}}
     entrypoint: sh
+    {{- end}}
     command: "/setup/start-bn.sh"
     cap_drop:
       - all

--- a/shared/services/rocketpool/assets/install/templates/validator.tmpl
+++ b/shared/services/rocketpool/assets/install/templates/validator.tmpl
@@ -7,18 +7,7 @@
 
 services:
   validator:
-    {{- if eq .ConsensusClient.String "prysm"}}
-    image: localhost/{{.GetVCContainerTag}}
-    pull_policy: never
-    build:
-      dockerfile_inline: |
-        FROM {{.GetVCContainerTag}} as upstream
-        FROM debian:bookworm-slim
-        RUN apt update && apt install -y wget ca-certificates && rm -rf /var/lib/apt/lists/*
-        COPY --from=upstream /app/cmd/validator/validator /app/cmd/validator/validator
-    {{- else}}
     image: {{.GetVCContainerTag}}
-    {{- end}}
     user: root
     container_name: {{.Smartnode.ProjectName}}_validator
     restart: unless-stopped
@@ -56,7 +45,11 @@ services:
       {{- if eq .ConsensusClient.String "teku"}}
       - TEKU_USE_SLASHING_PROTECTION={{.Teku.UseSlashingProtection}}
       {{- end}}
+    {{- if eq .ConsensusClient.String "prysm"}}
+    entrypoint: bash
+    {{- else}}
     entrypoint: sh
+    {{- end}}
     command: "/setup/start-vc.sh"
     cap_drop:
       - all


### PR DESCRIPTION
It turns out we don't need to build containers at all.

The last dependencies were:
1) prysm has /bin/bash but not /bin/sh available
2) we used `sed` in start-vc.sh to strip the scheme from the RPC URIs, if one is errantly provided.
3) we download genesis with wget for testnets

1 is easily fixed with templating around the entrypoint argument in docker-compose
2 is fixed by stripping the scheme in rocketpool-cli instead.
3 is fixed by using a new curlimages container to conditionally download genesis

This pr also fixes a broken hoodi genesis url