### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/rocketpool-cli/node/claim-rewards.go
+++ b/rocketpool-cli/node/claim-rewards.go
@@ -3,6 +3,7 @@ package node
 import (
 	"fmt"
 	"math/big"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -150,13 +151,7 @@ func nodeClaimRewards(c *cli.Context) error {
 			seenIndices := map[uint64]bool{}
 
 			for _, element := range elements {
-				found := false
-				for _, validIndex := range validIndices {
-					if validIndex == element {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(validIndices, element)
 				if !found {
 					fmt.Printf("'%s' is an invalid index.\nValid indices are: %s\n", element, strings.Join(validIndices, ","))
 					allValid = false

--- a/rocketpool-cli/node/utils.go
+++ b/rocketpool-cli/node/utils.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -146,11 +147,8 @@ func promptTimezone() string {
 			isUpper := unicode.IsUpper(rune(filename[0]))                 // Must start with an upper case letter
 			if !isSymlink && isDir && isUpper {
 				isValid := true
-				for _, invalidCountry := range invalidCountries {
-					if invalidCountry == filename {
-						isValid = false
-						break
-					}
+				if slices.Contains(invalidCountries, filename) {
+					isValid = false
 				}
 				if isValid {
 					countryNames = append(countryNames, filename)
@@ -192,13 +190,7 @@ func promptTimezone() string {
 		timezone = ""
 		country = prompt.Prompt("Please enter a country / continent from the list above:", "^.+$", "Please enter a country / continent from the list above:")
 
-		exists := false
-		for _, candidate := range countryNames {
-			if candidate == country {
-				exists = true
-				break
-			}
-		}
+		exists := slices.Contains(countryNames, country)
 
 		if !exists {
 			fmt.Printf("%s is not a valid country or continent. Please see the list above for valid countries and continents.\n\n", country)
@@ -253,13 +245,7 @@ func promptTimezone() string {
 		timezone = ""
 		region = prompt.Prompt("Please enter a region from the list above:", "^.+$", "Please enter a region from the list above:")
 
-		exists := false
-		for _, candidate := range regionNames {
-			if candidate == region {
-				exists = true
-				break
-			}
-		}
+		exists := slices.Contains(regionNames, region)
 
 		if !exists {
 			fmt.Printf("%s is not a valid country or continent. Please see the list above for valid countries and continents.\n\n", region)

--- a/rocketpool-cli/odao/proposals.go
+++ b/rocketpool-cli/odao/proposals.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/rocket-pool/rocketpool-go/dao"
@@ -22,14 +23,7 @@ func filterProposalState(state string, stateFilter string) bool {
 
 	// Check comma separated list for the state
 	filterStates := strings.Split(stateFilter, ",")
-	for _, fs := range filterStates {
-		if fs == state {
-			return false
-		}
-	}
-
-	// Not found
-	return true
+	return !slices.Contains(filterStates, state)
 }
 
 func getProposals(c *cli.Context, stateFilter string) error {

--- a/rocketpool-cli/pdao/proposals.go
+++ b/rocketpool-cli/pdao/proposals.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,14 +27,7 @@ func filterProposalState(state string, stateFilter string) bool {
 
 	// Check comma separated list for the state
 	filterStates := strings.Split(stateFilter, ",")
-	for _, fs := range filterStates {
-		if fs == state {
-			return false
-		}
-	}
-
-	// Not found
-	return true
+	return !slices.Contains(filterStates, state)
 }
 
 func getProposals(c *cli.Context, stateFilter string) error {

--- a/rocketpool-cli/security/proposals.go
+++ b/rocketpool-cli/security/proposals.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/rocket-pool/rocketpool-go/dao"
@@ -22,14 +23,7 @@ func filterProposalState(state string, stateFilter string) bool {
 
 	// Check comma separated list for the state
 	filterStates := strings.Split(stateFilter, ",")
-	for _, fs := range filterStates {
-		if fs == state {
-			return false
-		}
-	}
-
-	// Not found
-	return true
+	return !slices.Contains(filterStates, state)
 }
 
 func getProposals(c *cli.Context, stateFilter string) error {

--- a/rocketpool-cli/service/config/standard-layout.go
+++ b/rocketpool-cli/service/config/standard-layout.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -181,11 +182,8 @@ func (layout *standardLayout) addFormItemsWithCommonParams(commonParams []*param
 	// Add the common params if they aren't in the unsupported list
 	for _, commonParam := range commonParams {
 		isSupported := true
-		for _, unsupportedParam := range unsupportedCommonParams {
-			if commonParam.parameter.ID == unsupportedParam {
-				isSupported = false
-				break
-			}
+		if slices.Contains(unsupportedCommonParams, commonParam.parameter.ID) {
+			isSupported = false
 		}
 
 		if isSupported {


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.