### PR TITLE
Add cli binaries to docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,15 +116,10 @@ endif
 # Docker containers
 .PHONY: docker
 docker: ${DOCKER_DIR}
-	VERSION=${VERSION} docker bake -f docker/daemon-bake.hcl daemon
-
-.PHONY: docker-load
-docker-load: docker
-	docker import - smartnode:${VERSION}-amd64 < ${DOCKER_DIR}/smartnode:${VERSION}-amd64.tar
-	docker import - smartnode:${VERSION}-arm64 < ${DOCKER_DIR}/smartnode:${VERSION}-arm64.tar
+	VERSION=${VERSION} docker bake -f docker/daemon-bake.hcl smartnode
 
 .PHONY: docker-push
-docker-push: docker-load
+docker-push: docker
 	echo
 	echo -n "Publishing smartnode:${VERSION} containers. Continue? [yN]: " && read ans && if [ $${ans:-'N'} != 'y' ]; then exit 1; fi
 	rm -rf ~/.docker/manifests/docker.io_rocketpool_smartnode-${VERSION}
@@ -141,6 +136,11 @@ docker-latest: docker-push
 	rm -rf ~/.docker/manifests/docker.io_rocketpool_smartnode-latest
 	docker manifest create rocketpool/smartnode:latest --amend rocketpool/smartnode:${VERSION}-amd64 --amend rocketpool/smartnode:${VERSION}-arm64
 	docker manifest push --purge rocketpool/smartnode:latest
+
+.PHONY: docker-prune
+docker-prune:
+	docker system prune -af
+	docker buildx prune -af
 
 define lint-template 
 .PHONY: lint-$1

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ A [Makefile](./Makefile) is included for building, testing, and linting.
 * `make build/treegen` builds just the treegen stand-alone binary.
   * The build is done in docker, unless you run `make NO_DOCKER=true \<cmd\>`
 * `make docker` builds the rocketpool/smartnode containers for all supported architectures and saves them in build/\<version\>/docker
-* `make docker-load` builds and loads the smartnode containers.
 * `make docker-push` builds, loads, pushes, creates a multi-arch manifest, and pushes the smartnode containers and manifest.
 * `make docker-latest` does the same as docker-push, but tags latest which is also pushed.
 * `make lint` runs the linter.

--- a/docker/daemon-bake.hcl
+++ b/docker/daemon-bake.hcl
@@ -3,7 +3,7 @@ variable "VERSION" {
 }
 
 group "default" {
-  targets = ["builder", "daemon"]
+  targets = ["builder", "smartnode"]
 }
 
 target "builder" {
@@ -16,8 +16,8 @@ target "builder" {
   platforms = [ "linux/amd64" ]
 }
 
-target "daemon" {
-  name = "daemon-${arch}"
+target "smartnode" {
+  name = "smartnode-${arch}"
   dockerfile = "docker/rocketpool-dockerfile"
   args = {
     VERSION = "${VERSION}"
@@ -29,7 +29,7 @@ target "daemon" {
   matrix = {
     arch = [ "amd64", "arm64" ]
   }
-  target = "daemon"
+  target = "smartnode"
   platform = "linux/${arch}"
-  output = [{ "type": "tar", "dest": "build/${VERSION}/docker/smartnode:${VERSION}-${arch}.tar" }]
+  output = [{ "type": "docker" }]
 }

--- a/docker/rocketpool-dockerfile
+++ b/docker/rocketpool-dockerfile
@@ -34,15 +34,22 @@ COPY ./shared/ /src/shared/
 COPY ./treegen/ /src/treegen
 COPY Makefile /src/Makefile
 WORKDIR /src
-RUN --mount=type=cache,target=/root/.cache/go-build make NO_DOCKER=true build/${VERSION}/bin/rocketpool-daemon-linux-${TARGETARCH}
+RUN --mount=type=cache,target=/root/.cache/go-build make NO_DOCKER=true \
+	build/${VERSION}/bin/rocketpool-daemon-linux-${TARGETARCH} \
+	build/${VERSION}/bin/rocketpool-cli-linux-${TARGETARCH} \
+	build/${VERSION}/bin/treegen-linux-${TARGETARCH}
 
-FROM debian:bookworm-slim AS daemon
+FROM debian:bookworm-slim AS smartnode
 ARG TARGETARCH
 ARG VERSION
 
-COPY --from=build /src/build/${VERSION}/bin/rocketpool-daemon-linux-${TARGETARCH} /go/bin/rocketpool
-
 RUN apt update && apt install ca-certificates -y
 
-# Container entry point
+COPY --from=build /src/build/${VERSION}/bin/rocketpool-daemon-linux-${TARGETARCH} /go/bin/rocketpool
+COPY --from=build /src/build/${VERSION}/bin/rocketpool-cli-linux-${TARGETARCH} /go/bin/rocketpool-cli
+COPY --from=build /src/build/${VERSION}/bin/treegen-linux-${TARGETARCH} /go/bin/treegen
+
+ENV PATH="$PATH:/go/bin"
+
+# Default entry point
 ENTRYPOINT ["/go/bin/rocketpool"]


### PR DESCRIPTION
This also removes the on-disk image targets because apparently when docker bake builds those, it doesn't include metadata (like entrypoint), which makes them beyond useless.