### PR TITLE
Hardcode pre-merge receipt for mainnet interval 0 

### DIFF
--- a/bindings/rewards/rewards.go
+++ b/bindings/rewards/rewards.go
@@ -1,6 +1,7 @@
 package rewards
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"sync"
@@ -230,6 +231,42 @@ func SubmitRewardSnapshot(rp *rocketpool.RocketPool, submission RewardSubmission
 
 // Get the event info for a rewards snapshot using the Atlas getter
 func GetRewardsEvent(rp *rocketpool.RocketPool, index uint64, rocketRewardsPoolAddresses []common.Address, opts *bind.CallOpts) (bool, RewardsEvent, error) {
+
+	// Check if ec is synced to mainnet
+	chainID, err := rp.Client.ChainID(context.Background())
+	if err != nil {
+		return false, RewardsEvent{}, fmt.Errorf("Error getting chainID: %w", err)
+	}
+	isMainnet := chainID.Cmp(big.NewInt(1)) == 0
+
+	// Return hardcoded RewardsEvent for index 0, the only pre-merge interval on mainnet
+	if index == 0 && isMainnet {
+		treasuryRPL := new(big.Int)
+		treasuryRPL.SetString("10633670478560109530497", 10)
+		trustedNodeRPL := new(big.Int)
+		trustedNodeRPL.SetString("10633670478560109529794", 10)
+		nodeRPL := new(big.Int)
+		nodeRPL.SetString("49623795566613844471758", 10)
+
+		eventDataInterval_0 := RewardsEvent{
+			Index:             big.NewInt(0),
+			ExecutionBlock:    big.NewInt(15451078),
+			ConsensusBlock:    big.NewInt(4598879),
+			IntervalsPassed:   big.NewInt(1),
+			TreasuryRPL:       treasuryRPL,
+			TrustedNodeRPL:    []*big.Int{trustedNodeRPL},
+			NodeRPL:           []*big.Int{nodeRPL},
+			NodeETH:           []*big.Int{big.NewInt(0)},
+			UserETH:           big.NewInt(0),
+			MerkleRoot:        common.HexToHash("0xb839fa0f5842bf3c8f19091361889fb0f1cb399d64b8da476d372b7de7a93463"),
+			MerkleTreeCID:     "bafybeidrck3sz24acv32h56xdb7ruarxq52oci32del7moxqtief3do73y",
+			IntervalStartTime: time.Unix(1659591339, 0),
+			IntervalEndTime:   time.Unix(1662010539, 0),
+			SubmissionTime:    time.Unix(1662011717, 0),
+		}
+		return true, eventDataInterval_0, nil
+	}
+
 	// Get contracts
 	rocketRewardsPool, err := getRocketRewardsPool(rp, opts)
 	if err != nil {

--- a/bindings/rocketpool/ec-interface.go
+++ b/bindings/rocketpool/ec-interface.go
@@ -102,4 +102,7 @@ type ExecutionClient interface {
 	// SyncProgress retrieves the current progress of the sync algorithm. If there's
 	// no sync currently running, it returns nil.
 	SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error)
+
+	// ChainID retrieves the current chain ID
+	ChainID(ctx context.Context) (*big.Int, error)
 }

--- a/shared/services/ec-manager.go
+++ b/shared/services/ec-manager.go
@@ -328,6 +328,17 @@ func (p *ExecutionClientManager) SyncProgress(ctx context.Context) (*ethereum.Sy
 	return result.(*ethereum.SyncProgress), err
 }
 
+// BlockNumber returns the most recent block number
+func (p *ExecutionClientManager) ChainID(ctx context.Context) (*big.Int, error) {
+	result, err := p.runFunction(func(client *ethclient.Client) (interface{}, error) {
+		return client.ChainID(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*big.Int), err
+}
+
 /// ==================
 /// Internal functions
 /// ==================


### PR DESCRIPTION
- Extend `ec-interface` and `ec-manager` to support grabbing the `chainID`
- Clients are expiring pre-merge receipts, so return a hardcoded `RewardsEvent` for interval 0, the only pre-merge interval on mainnet. 

[Interval 0 snapshot](https://etherscan.io/tx/0x563c8906756e66b73b535a0b869c096180a32fafc46130362dd48c3c7fa3cb95)