### PR TITLE
Update vc image regex to be less dangerous

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -40,14 +40,18 @@ const (
 	dataFolderVolumeName            string = "/.rocketpool/data"
 
 	PruneFreeSpaceRequired uint64 = 50 * 1024 * 1024 * 1024
-	dockerImageRegex       string = ".*/(?P<image>.*):.*"
-	colorReset             string = "\033[0m"
-	colorBold              string = "\033[1m"
-	colorRed               string = "\033[31m"
-	colorYellow            string = "\033[33m"
-	colorGreen             string = "\033[32m"
-	colorLightBlue         string = "\033[36m"
-	clearLine              string = "\033[2K"
+
+	// Capture the entire image name, including the custom registry if present.
+	// Just ignore the version tag.
+	dockerImageRegex string = "(?P<image>.+):.*"
+
+	colorReset     string = "\033[0m"
+	colorBold      string = "\033[1m"
+	colorRed       string = "\033[31m"
+	colorYellow    string = "\033[33m"
+	colorGreen     string = "\033[32m"
+	colorLightBlue string = "\033[36m"
+	clearLine      string = "\033[2K"
 )
 
 // Install the Rocket Pool service


### PR DESCRIPTION
See here for behavioral change: https://go.dev/play/p/1IBbAthKGW-
```
Old:
sigp/lighthouse:v110 -> lighthouse
gcr.io/offchainlabs/prysm/validator:v6.0.3 -> validator

New:
sigp/lighthouse:v110 -> sigp/lighthouse
gcr.io/offchainlabs/prysm/validator:v6.0.3 -> gcr.io/offchainlabs/prysm/validator
```


Basically, when we switched to the upstream prysm containers, a NO noticed that it triggered their 15 minute cooldown. This happened because the regex went from extracting `prysm` from `rocketpool/prysm` to extracting `validator` from `gcr.io/offchainlabs/prysm/validator:v6.0.3`

This is _bad_. Semantically, everything preceding the `:` is relevant to the specific image being used, and if orgs change their tag locations, we should still sit out for 15 minutes to be safe.

