### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/bindings/minipool/minipool-contract-v2.go
+++ b/bindings/minipool/minipool-contract-v2.go
@@ -565,10 +565,7 @@ func (mp *minipool_v2) GetPrestakeEvent(intervalSize *big.Int, opts *bind.CallOp
 
 	// Backwards scan through blocks to find the event
 	for i := currentBlock; i >= fromBlock; i -= EventScanInterval {
-		from := i - EventScanInterval + 1
-		if from < fromBlock {
-			from = fromBlock
-		}
+		from := max(i-EventScanInterval+1, fromBlock)
 
 		fromBig := big.NewInt(0).SetUint64(from)
 		toBig := big.NewInt(0).SetUint64(i)

--- a/bindings/minipool/minipool-contract-v3.go
+++ b/bindings/minipool/minipool-contract-v3.go
@@ -606,10 +606,7 @@ func (mp *minipool_v3) GetPrestakeEvent(intervalSize *big.Int, opts *bind.CallOp
 
 	// Backwards scan through blocks to find the event
 	for i := currentBlock; i >= fromBlock; i -= EventScanInterval {
-		from := i - EventScanInterval + 1
-		if from < fromBlock {
-			from = fromBlock
-		}
+		from := max(i-EventScanInterval+1, fromBlock)
 
 		fromBig := big.NewInt(0).SetUint64(from)
 		toBig := big.NewInt(0).SetUint64(i)

--- a/bindings/minipool/minipool.go
+++ b/bindings/minipool/minipool.go
@@ -66,10 +66,7 @@ func loadMinipoolDetails(rp *rocketpool.RocketPool, minipoolAddresses []common.A
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolDetailsBatchSize
-		if mei > len(minipoolAddresses) {
-			mei = len(minipoolAddresses)
-		}
+		mei := min(bsi+MinipoolDetailsBatchSize, len(minipoolAddresses))
 
 		// Load details
 		var wg errgroup.Group
@@ -110,10 +107,7 @@ func GetMinipoolAddresses(rp *rocketpool.RocketPool, opts *bind.CallOpts) ([]com
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolAddressBatchSize
-		if mei > minipoolCount {
-			mei = minipoolCount
-		}
+		mei := min(bsi+MinipoolAddressBatchSize, minipoolCount)
 
 		// Load addresses
 		var wg errgroup.Group
@@ -183,10 +177,7 @@ func GetNodeMinipoolAddresses(rp *rocketpool.RocketPool, nodeAddress common.Addr
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolAddressBatchSize
-		if mei > minipoolCount {
-			mei = minipoolCount
-		}
+		mei := min(bsi+MinipoolAddressBatchSize, minipoolCount)
 
 		// Load addresses
 		var wg errgroup.Group
@@ -227,10 +218,7 @@ func GetNodeValidatingMinipoolPubkeys(rp *rocketpool.RocketPool, nodeAddress com
 
 		// Get batch start & end index
 		msi := bsi
-		mei := bsi + MinipoolAddressBatchSize
-		if mei > minipoolCount {
-			mei = minipoolCount
-		}
+		mei := min(bsi+MinipoolAddressBatchSize, minipoolCount)
 
 		// Load pubkeys
 		var wg errgroup.Group

--- a/bindings/utils/multicall/balances.go
+++ b/bindings/utils/multicall/balances.go
@@ -49,10 +49,7 @@ func (b *BalanceBatcher) GetEthBalances(addresses []common.Address, opts *bind.C
 	// Run the getters in batches
 	for i := 0; i < count; i += balanceBatchSize {
 		i := i
-		max := i + balanceBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+balanceBatchSize, count)
 
 		wg.Go(func() error {
 			subAddresses := addresses[i:max]

--- a/bindings/utils/state/minipool.go
+++ b/bindings/utils/state/minipool.go
@@ -177,10 +177,7 @@ func CalculateCompleteMinipoolShares(rp *rocketpool.RocketPool, contracts *Netwo
 	count := len(minipoolDetails)
 	for i := 0; i < count; i += minipoolCompleteShareBatchSize {
 		i := i
-		max := i + minipoolCompleteShareBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolCompleteShareBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -283,10 +280,7 @@ func getNodeMinipoolAddressesFast(rp *rocketpool.RocketPool, contracts *NetworkC
 	count := int(minipoolCount)
 	for i := 0; i < count; i += minipoolAddressBatchSize {
 		i := i
-		max := i + minipoolAddressBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolAddressBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -329,10 +323,7 @@ func getAllMinipoolAddressesFast(rp *rocketpool.RocketPool, contracts *NetworkCo
 	count := int(minipoolCount)
 	for i := 0; i < count; i += minipoolAddressBatchSize {
 		i := i
-		max := i + minipoolAddressBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolAddressBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -369,10 +360,7 @@ func getMinipoolVersionsFast(rp *rocketpool.RocketPool, contracts *NetworkContra
 	versions := make([]uint8, count)
 	for i := 0; i < count; i += minipoolVersionBatchSize {
 		i := i
-		max := i + minipoolVersionBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolVersionBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -426,10 +414,7 @@ func getBulkMinipoolDetails(rp *rocketpool.RocketPool, contracts *NetworkContrac
 	count := len(addresses)
 	for i := 0; i < count; i += minipoolBatchSize {
 		i := i
-		max := i + minipoolBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -464,10 +449,7 @@ func getBulkMinipoolDetails(rp *rocketpool.RocketPool, contracts *NetworkContrac
 	wg2.SetLimit(threadLimit)
 	for i := 0; i < count; i += minipoolBatchSize {
 		i := i
-		max := i + minipoolBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolBatchSize, count)
 
 		wg2.Go(func() error {
 			var err error

--- a/bindings/utils/state/network.go
+++ b/bindings/utils/state/network.go
@@ -202,10 +202,7 @@ func GetTotalEffectiveRplStake(rp *rocketpool.RocketPool, contracts *NetworkCont
 	// Run the getters in batches
 	for i := 0; i < count; i += networkEffectiveStakeBatchSize {
 		i := i
-		max := i + networkEffectiveStakeBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+networkEffectiveStakeBatchSize, count)
 
 		wg.Go(func() error {
 			var err error

--- a/bindings/utils/state/node.go
+++ b/bindings/utils/state/node.go
@@ -147,10 +147,7 @@ func GetAllNativeNodeDetails(rp *rocketpool.RocketPool, contracts *NetworkContra
 	// Run the getters in batches
 	for i := 0; i < count; i += legacyNodeBatchSize {
 		i := i
-		max := i + legacyNodeBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+legacyNodeBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -295,10 +292,7 @@ func getNodeAddressesFast(rp *rocketpool.RocketPool, contracts *NetworkContracts
 	count := int(nodeCount)
 	for i := 0; i < count; i += nodeAddressBatchSize {
 		i := i
-		max := i + nodeAddressBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+nodeAddressBatchSize, count)
 
 		wg.Go(func() error {
 			var err error

--- a/bindings/utils/state/odao.go
+++ b/bindings/utils/state/odao.go
@@ -86,10 +86,7 @@ func getOdaoAddresses(rp *rocketpool.RocketPool, contracts *NetworkContracts, op
 	count := int(memberCount)
 	for i := 0; i < count; i += minipoolAddressBatchSize {
 		i := i
-		max := i + oDaoAddressBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+oDaoAddressBatchSize, count)
 
 		wg.Go(func() error {
 			var err error
@@ -125,10 +122,7 @@ func getOracleDaoDetails(rp *rocketpool.RocketPool, contracts *NetworkContracts,
 	count := len(addresses)
 	for i := 0; i < count; i += minipoolBatchSize {
 		i := i
-		max := i + minipoolBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+minipoolBatchSize, count)
 
 		wg.Go(func() error {
 			var err error

--- a/bindings/utils/state/pdao.go
+++ b/bindings/utils/state/pdao.go
@@ -101,10 +101,7 @@ func getProposalDetails(rp *rocketpool.RocketPool, contracts *NetworkContracts, 
 	count := len(propDetailsRaw)
 	for i := 0; i < count; i += pDaoPropDetailsBatchSize {
 		i := i
-		max := i + pDaoPropDetailsBatchSize
-		if max > count {
-			max = count
-		}
+		max := min(i+pDaoPropDetailsBatchSize, count)
 
 		wg.Go(func() error {
 			var err error


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
