### PR TITLE
Update golang to 1.24.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.24.5
       - run: make NO_DOCKER=true release 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.24.5
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.24.5
           cache-dependency-path: go.work.sum
       - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ formatters:
     - goimports
 run:
   relative-path-mode: cfg
-  go: '1.21.8'
+  go: '1.24.5'
 output:
   formats:
     text:

--- a/docker/rocketpool-dockerfile
+++ b/docker/rocketpool-dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.8-bookworm AS smartnode_dependencies
+FROM --platform=$BUILDPLATFORM golang:1.24.5-bookworm AS smartnode_dependencies
 ARG BUILDPLATFORM
 
 # Install build tools

--- a/go.mod
+++ b/go.mod
@@ -161,7 +161,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/supranational/blst v0.3.11 // indirect
+	github.com/supranational/blst v0.3.15 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e // indirect
 	github.com/tklauser/go-sysconf v0.3.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rocket-pool/smartnode
 
-go 1.21.8
+go 1.24.5
 
 // Do not update until you can test that its regression on ARM is resolved
 require github.com/herumi/bls-eth-go-binary v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -777,8 +777,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
-github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.15 h1:rd9viN6tfARE5wv3KZJ9H8e1cg0jXW8syFCcsbHa76o=
+github.com/supranational/blst v0.3.15/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=

--- a/shared/services/alerting/alerting.go
+++ b/shared/services/alerting/alerting.go
@@ -218,7 +218,7 @@ const (
 func alertClientSyncComplete(cfg *config.RocketPoolConfig, client ClientKind) error {
 	alertName := fmt.Sprintf("%sClientSyncComplete", client)
 	if !isAlertingEnabled(cfg) {
-		logMessage(fmt.Sprintf("alerting is disabled, not sending %s.", alertName))
+		logMessage("alerting is disabled, not sending %s.", alertName)
 		return nil
 	}
 

--- a/shared/services/rewards/generator-v8_test.go
+++ b/shared/services/rewards/generator-v8_test.go
@@ -54,7 +54,7 @@ func newV8Test(t *testing.T, index uint64) *v8Test {
 
 func (t *v8Test) failIf(err error) {
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 }
 

--- a/shared/services/rewards/utils.go
+++ b/shared/services/rewards/utils.go
@@ -1,6 +1,7 @@
 package rewards
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -258,7 +259,7 @@ func (i *IntervalInfo) DownloadRewardsFile(cfg *config.RocketPoolConfig, isDaemo
 		errBuilder.WriteString(fmt.Sprintf("Downloading files with timeout %v failed.\n", timeout))
 	}
 
-	return fmt.Errorf(errBuilder.String())
+	return errors.New(errBuilder.String())
 
 }
 


### PR DESCRIPTION
I really want to use some new-as-of-1.22 features in the std http package, namely, the more advanced handler routing: https://go.dev/blog/routing-enhancements

Probably time we just update to latest stable.