### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/bindings/dao/protocol/verify.go
+++ b/bindings/dao/protocol/verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"time"
 
@@ -290,13 +291,7 @@ func GetRootSubmittedEvents(rp *rocketpool.RocketPool, proposalIDs []uint64, int
 	if verifierAddresses == nil {
 		verifierAddresses = []common.Address{currentAddress}
 	} else {
-		found := false
-		for _, address := range verifierAddresses {
-			if address == currentAddress {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(verifierAddresses, currentAddress)
 		if !found {
 			verifierAddresses = append(verifierAddresses, currentAddress)
 		}
@@ -374,13 +369,7 @@ func GetChallengeSubmittedEvents(rp *rocketpool.RocketPool, proposalIDs []uint64
 	if verifierAddresses == nil {
 		verifierAddresses = []common.Address{currentAddress}
 	} else {
-		found := false
-		for _, address := range verifierAddresses {
-			if address == currentAddress {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(verifierAddresses, currentAddress)
 		if !found {
 			verifierAddresses = append(verifierAddresses, currentAddress)
 		}

--- a/bindings/rewards/rewards.go
+++ b/bindings/rewards/rewards.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"time"
 
@@ -259,13 +260,7 @@ func GetRewardsEvent(rp *rocketpool.RocketPool, index uint64, rocketRewardsPoolA
 	if rocketRewardsPoolAddresses == nil {
 		rocketRewardsPoolAddresses = []common.Address{currentAddress}
 	} else {
-		found := false
-		for _, address := range rocketRewardsPoolAddresses {
-			if address == currentAddress {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(rocketRewardsPoolAddresses, currentAddress)
 		if !found {
 			rocketRewardsPoolAddresses = append(rocketRewardsPoolAddresses, currentAddress)
 		}

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -788,12 +789,7 @@ type DockerContainer struct {
 
 func (c *DockerContainer) HasVolume(volume string) bool {
 	mounts := strings.Split(c.Mounts, ",")
-	for _, mount := range mounts {
-		if mount == volume {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(mounts, volume)
 }
 
 // Returns all Docker containers on the system with the given prefix


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.