### PR TITLE
Fix alertEnabled_ClientSyncStatusBeacon duplicated key issue

### DIFF
--- a/rocketpool-cli/service/config/settings-alerting.go
+++ b/rocketpool-cli/service/config/settings-alerting.go
@@ -32,6 +32,7 @@ var alertingParametersDockerMode map[string]interface{} = map[string]interface{}
 	"pushoverToken":                            nil,
 	"pushoverUserKey":                          nil,
 	"alertEnabled_ClientSyncStatusBeacon":      nil,
+	"alertEnabled_ClientSyncStatusExecution":   nil,
 	"alertEnabled_UpcomingSyncCommittee":       nil,
 	"alertEnabled_ActiveSyncCommittee":         nil,
 	"alertEnabled_UpcomingProposal":            nil,

--- a/shared/services/config/alertmanager-config.go
+++ b/shared/services/config/alertmanager-config.go
@@ -60,7 +60,7 @@ type AlertmanagerConfig struct {
 
 	// Alerts configured in prometheus rule configuration file:
 	AlertEnabled_ClientSyncStatusBeacon    config.Parameter `yaml:"alertEnabled_ClientSyncStatusBeacon,omitempty"`
-	AlertEnabled_ClientSyncStatusExecution config.Parameter `yaml:"alertEnabled_ClientSyncStatusBeacon,omitempty"`
+	AlertEnabled_ClientSyncStatusExecution config.Parameter `yaml:"alertEnabled_ClientSyncStatusExecution,omitempty"`
 	AlertEnabled_UpcomingSyncCommittee     config.Parameter `yaml:"alertEnabled_UpcomingSyncCommittee,omitempty"`
 	AlertEnabled_ActiveSyncCommittee       config.Parameter `yaml:"alertEnabled_ActiveSyncCommittee,omitempty"`
 	AlertEnabled_UpcomingProposal          config.Parameter `yaml:"alertEnabled_UpcomingProposal,omitempty"`


### PR DESCRIPTION
This pull request aims to fix the issue described below.

Steps to reproduce:
1. `make build/rocketpool-cli`
2. `cp build/rocketpool-cli ~/bin/rocketpool`
3. `rocketpool service install -d`
4. `rocketpool service config`
5. `rocketpool service get-config-yaml`

Expected result:
- YAML showing the current configuration schema is generated

Actual result:

Error is raised
```
panic: Duplicated key 'alertEnabled_ClientSyncStatusBeacon' in struct config.AlertmanagerConfig [recovered]
	panic: Duplicated key 'alertEnabled_ClientSyncStatusBeacon' in struct config.AlertmanagerConfig

goroutine 1 [running]:
gopkg.in/yaml%2ev2.handleErr(0xc0003a0498)
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:249 +0x68
panic({0xf5b540?, 0xc0003d3010?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
gopkg.in/yaml%2ev2.(*encoder).structv(0xc0007a42c8, {0x0, 0x0}, {0x1093660?, 0xc000794008?, 0x4?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:211 +0xf7
gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0007a42c8, {0x0, 0x0}, {0x1093660?, 0xc000794008?, 0x1ba1f40?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:160 +0xa19
gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0007a42c8, {0x0, 0x0}, {0xfde240?, 0xc0006bc770?, 0x32?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:154 +0x81f
gopkg.in/yaml%2ev2.(*encoder).structv.func1()
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:226 +0x1f4
gopkg.in/yaml%2ev2.(*encoder).mappingv(0xc0007a42c8, {0x0?, 0x0}, 0xc00072a0e0)
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:256 +0x14a
gopkg.in/yaml%2ev2.(*encoder).structv(0xc0007a42c8, {0x0, 0x0}, {0x10a4580?, 0xc0006bbb08?, 0x33?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:213 +0xe5
gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0007a42c8, {0x0, 0x0}, {0x10a4580?, 0xc0006bbb08?, 0x1bf1960?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:160 +0xa19
gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0007a42c8, {0x0, 0x0}, {0x1098880?, 0xc0006bbb08?, 0x41a17d?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:154 +0x81f
gopkg.in/yaml%2ev2.(*encoder).marshalDoc(0xc0007a42c8, {0x0, 0x0}, {0x1098880?, 0xc0006bbb08?, 0xc00072a4b0?})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:93 +0xcb
gopkg.in/yaml%2ev2.Marshal({0x1098880, 0xc0006bbb08})
	/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:203 +0x32a
github.com/rocket-pool/smartnode/rocketpool-cli/service.getConfigYaml(0xc00046a760?)
	/src/rocketpool-cli/service/service.go:1413 +0x2c
github.com/rocket-pool/smartnode/rocketpool-cli/service.RegisterCommands.func15(0xc00019adc0)
	/src/rocketpool-cli/service/commands.go:458 +0x2f
github.com/urfave/cli.HandleAction({0xf2a2e0?, 0x12564c8?}, 0xf?)
	/go/pkg/mod/github.com/urfave/cli@v1.22.12/app.go:524 +0x70
github.com/urfave/cli.Command.Run({{0x10bbcc0, 0xf}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x111b8ac, 0x71}, {0x10d9ea0, ...}, ...}, ...)
	/go/pkg/mod/github.com/urfave/cli@v1.22.12/command.go:175 +0x676
github.com/urfave/cli.(*App).RunAsSubcommand(0xc000485340, 0xc00019ab00)
	/go/pkg/mod/github.com/urfave/cli@v1.22.12/app.go:405 +0xddb
github.com/urfave/cli.Command.startApp({{0x10b06eb, 0x7}, {0x0, 0x0}, {0xc00068f560, 0x1, 0x1}, {0x10cb3b5, 0x1a}, {0x0, ...}, ...}, ...)
	/go/pkg/mod/github.com/urfave/cli@v1.22.12/command.go:380 +0xb18
github.com/urfave/cli.Command.Run({{0x10b06eb, 0x7}, {0x0, 0x0}, {0xc00068f560, 0x1, 0x1}, {0x10cb3b5, 0x1a}, {0x0, ...}, ...}, ...)
	/go/pkg/mod/github.com/urfave/cli@v1.22.12/command.go:103 +0x7a7
github.com/urfave/cli.(*App).Run(0xc000485180, {0xc000032270, 0x3, 0x3})
	/go/pkg/mod/github.com/urfave/cli@v1.22.12/app.go:277 +0xb1b
main.main()
	/src/rocketpool-cli/rocketpool-cli.go:128 +0xd9b
```
