### PR TITLE
Use hoodi gas estimator url on testnet nodes. 

### DIFF
--- a/rocketpool/node/auto-init-voting-power.go
+++ b/rocketpool/node/auto-init-voting-power.go
@@ -132,7 +132,7 @@ func (t *autoInitVotingPower) submitInitializeVotingPower() error {
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return err
 		}

--- a/rocketpool/node/defend-pdao-props.go
+++ b/rocketpool/node/defend-pdao-props.go
@@ -256,7 +256,7 @@ func (t *defendPdaoProps) defendProposal(prop defendableProposal) error {
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return err
 		}

--- a/rocketpool/node/distribute-minipools.go
+++ b/rocketpool/node/distribute-minipools.go
@@ -242,7 +242,7 @@ func (t *distributeMinipools) distributeMinipool(mpd *rpstate.NativeMinipoolDeta
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return false, err
 		}

--- a/rocketpool/node/promote-minipools.go
+++ b/rocketpool/node/promote-minipools.go
@@ -213,7 +213,7 @@ func (t *promoteMinipools) promoteMinipool(mpd *rpstate.NativeMinipoolDetails, c
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return false, err
 		}

--- a/rocketpool/node/reduce-bonds.go
+++ b/rocketpool/node/reduce-bonds.go
@@ -269,7 +269,7 @@ func (t *reduceBonds) forceFeeDistribution() (bool, error) {
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return false, err
 		}
@@ -379,7 +379,7 @@ func (t *reduceBonds) reduceBond(mpd *rpstate.NativeMinipoolDetails, windowStart
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return false, err
 		}

--- a/rocketpool/node/stake-prelaunch-minipools.go
+++ b/rocketpool/node/stake-prelaunch-minipools.go
@@ -264,7 +264,7 @@ func (t *stakePrelaunchMinipools) stakeMinipool(mpd *rpstate.NativeMinipoolDetai
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return false, err
 		}

--- a/rocketpool/node/verify-pdao-props.go
+++ b/rocketpool/node/verify-pdao-props.go
@@ -371,7 +371,7 @@ func (t *verifyPdaoProps) submitChallenge(challenge challenge) error {
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return err
 		}
@@ -427,7 +427,7 @@ func (t *verifyPdaoProps) submitDefeat(defeat defeat) error {
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return err
 		}

--- a/rocketpool/watchtower/process-penalties.go
+++ b/rocketpool/watchtower/process-penalties.go
@@ -505,7 +505,7 @@ func (t *processPenalties) submitPenalty(minipoolAddress common.Address, block *
 	// Get the max fee
 	maxFee := t.maxFee
 	if maxFee == nil || maxFee.Uint64() == 0 {
-		maxFee, err = rpgas.GetHeadlessMaxFeeWei()
+		maxFee, err = rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return err
 		}

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -1004,7 +1004,7 @@ func (t *submitRplPrice) submitArbitrumPrice(priceMessengerAddress string) error
 	if index == indexToSubmit {
 
 		// Get the current network recommended max fee
-		suggestedMaxFee, err := rpgas.GetHeadlessMaxFeeWei()
+		suggestedMaxFee, err := rpgas.GetHeadlessMaxFeeWei(t.cfg)
 		if err != nil {
 			return fmt.Errorf("error getting recommended base fee from the network for Arbitrum price submission: %w", err)
 		}

--- a/shared/services/gas/etherchain/etherchain.go
+++ b/shared/services/gas/etherchain/etherchain.go
@@ -7,9 +7,11 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-json"
+	"github.com/rocket-pool/smartnode/shared/services/config"
 )
 
 const gasNowUrl string = "https://beaconcha.in/api/v1/execution/gasnow"
+const gasNowUrlHoodi string = "https://hoodi.beaconcha.in/api/v1/execution/gasnow"
 
 // Standard response
 type gasNowResponse struct {
@@ -39,10 +41,16 @@ type GasFeeSuggestion struct {
 }
 
 // Get gas prices
-func GetGasPrices() (GasFeeSuggestion, error) {
+func GetGasPrices(cfg *config.RocketPoolConfig) (GasFeeSuggestion, error) {
+
+	// Check network
+	url := gasNowUrl
+	if cfg.Smartnode.GetChainID() != 1 {
+		url = gasNowUrlHoodi
+	}
 
 	// Send request
-	response, err := http.Get(gasNowUrl)
+	response, err := http.Get(url)
 	if err != nil {
 		return GasFeeSuggestion{}, err
 	}


### PR DESCRIPTION
The smartnode uses mainnet gas oracle endpoints on testnet nodes. In some cases, hoodi transactions can be stuck when gas on mainnet is cheaper than gas on hoodi. 


This PR includes a few fixes: 
- Use the hoodi beaconcha.in gasnow endpoint on testnet nodes
- Support for Etherscan's updated gasnow api response structure 
- Remove unused code in `etherscan.go`