### PR TITLE
Deprecate service stats

### DIFF
--- a/rocketpool-cli/service/commands.go
+++ b/rocketpool-cli/service/commands.go
@@ -338,17 +338,12 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:      "stats",
 				Aliases:   []string{"a"},
-				Usage:     "View the Rocket Pool service stats",
+				Usage:     "(DEPRECATED) No longer supported. Use 'docker stats -a' instead",
 				UsageText: "rocketpool service stats",
 				Action: func(c *cli.Context) error {
 
-					// Validate args
-					if err := cliutils.ValidateArgCount(c, 0); err != nil {
-						return err
-					}
-
 					// Run command
-					return serviceStats(c)
+					return serviceStats()
 
 				},
 			},

--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -1040,15 +1040,9 @@ func serviceLogs(c *cli.Context, aliasedNames ...string) error {
 }
 
 // View the Rocket Pool service stats
-func serviceStats(c *cli.Context) error {
-
-	// Get RP client
-	rp := rocketpool.NewClientFromCtx(c)
-	defer rp.Close()
-
-	// Print service stats
-	return rp.PrintServiceStats(getComposeFiles(c))
-
+func serviceStats() error {
+	fmt.Println("No longer supported - please run 'docker stats -a' instead.")
+	return nil
 }
 
 // View the Rocket Pool service compose config

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -523,25 +523,6 @@ func (c *Client) PrintServiceLogs(composeFiles []string, tail string, serviceNam
 	return c.printOutput(cmd)
 }
 
-// Print the Rocket Pool service stats
-func (c *Client) PrintServiceStats(composeFiles []string) error {
-
-	// Get service container IDs
-	cmd, err := c.compose(composeFiles, "ps -q")
-	if err != nil {
-		return err
-	}
-	containers, err := c.readOutput(cmd)
-	if err != nil {
-		return err
-	}
-	containerIds := strings.Split(strings.TrimSpace(string(containers)), "\n")
-
-	// Print stats
-	return c.printOutput(fmt.Sprintf("docker stats %s", strings.Join(containerIds, " ")))
-
-}
-
 // Print the Rocket Pool service compose config
 func (c *Client) PrintServiceCompose(composeFiles []string) error {
 	cmd, err := c.compose(composeFiles, "config")


### PR DESCRIPTION
Pulling over a change previously made to V2: https://github.com/rocket-pool/smartnode/pull/667