### PR TITLE
Feat: pull images before restart

### DIFF
--- a/rocketpool-cli/service/service.go
+++ b/rocketpool-cli/service/service.go
@@ -306,6 +306,13 @@ func configureService(c *cli.Context) error {
 				return nil
 			}
 
+			// Let's reduce potential downtime by pulling the new containers before restarting
+			fmt.Println("Pulling potential new container images...")
+			err = rp.PullComposeImages(getComposeFiles(c))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: couldn't pull new images for updated containers: %s\n", err.Error())
+			}
+
 			fmt.Println()
 			for _, container := range md.ContainersToRestart {
 				fullName := fmt.Sprintf("%s_%s", prefix, container)

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -723,6 +723,18 @@ func (c *Client) GetComposeImages(composeFiles []string) ([]string, error) {
 	return strings.Fields(string(output)), nil
 }
 
+func (c *Client) PullComposeImages(composeFiles []string) error {
+	cmd, err := c.compose(composeFiles, "pull -q")
+	if err != nil {
+		return err
+	}
+	err = c.printOutput(cmd)
+	if err != nil {
+		return fmt.Errorf("error pulling images: %w", err)
+	}
+	return nil
+}
+
 type DockerImage struct {
 	Repository string `json:"Repository"`
 	Tag        string `json:"Tag"`


### PR DESCRIPTION
This PR is the same as https://github.com/nodeset-org/hyperdrive/pull/220 but adjusted for the rpl smartnode cli:

### Description
This PR is a small optimization that will pull the new docker container images before stopping the currently running ones, resulting in less downtime than before.

### Motivation
I've been bitten by having to wait for several containers to be pulled before, which are not only causing unnecessary downtime, but can be especially painful if one gets rate-limited by dockerhub, or when there are other failure modes in the image pull scenario. (e.g. docker disk full - which is not necessarily the same as where the data volumes live)

With this change the containers won't be stopped until the new images are available, potentially preventing these issues and improving uptime.

### Changes
Old situation:
* User updates/manually updates container image to different version
* rpl asks user to restart
* user confirms, rpl stops to be restarted containers
* rpl runs compose up, causing it to start pulling containers
* containers start

New situation:
* User updates/manually updates container image to different version
* rpl asks user to restart
* user confirms, **rpl runs compose pull, causing it to pull new required container images**
* rpl stops to be restarted containers
* rpl runs compose up
* containers start

### Screenshots
Before - containers are stopped, then new ones pulled, then started
<img width="1135" height="681" alt="rpl-before" src="https://github.com/user-attachments/assets/4df9a3d1-d3d5-466d-815e-e53ea513de84" />

After - new images pulled first, then containers stopped, then started
<img width="776" height="262" alt="rpl-pulling-first" src="https://github.com/user-attachments/assets/961f6386-c370-4909-bc51-dcbb64e7553a" />
