### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -482,8 +482,6 @@ func (s *NetworkState) CalculateNodeWeights() (map[common.Address]*big.Int, *big
 	var wg errgroup.Group
 	wg.SetLimit(threadLimit)
 	for i, node := range s.NodeDetails {
-		i := i
-		node := node
 		wg.Go(func() error {
 			eligibleBorrowedEth := s.GetEligibleBorrowedEth(&node)
 
@@ -581,8 +579,6 @@ func (s *NetworkState) CalculateTrueEffectiveStakes(scaleByParticipation bool, a
 	var wg errgroup.Group
 	wg.SetLimit(threadLimit)
 	for i, node := range s.NodeDetails {
-		i := i
-		node := node
 		wg.Go(func() error {
 			eligibleBorrowedEth := big.NewInt(0)
 			eligibleBondedEth := big.NewInt(0)

--- a/shared/utils/rp/node.go
+++ b/shared/utils/rp/node.go
@@ -123,8 +123,6 @@ func CheckCollateral(rp *rocketpool.RocketPool, nodeAddress common.Address, opts
 		return nil
 	})
 	for i, address := range addresses {
-		i := i
-		address := address
 		wg.Go(func() error {
 			reduceBondTime, err := minipool.GetReduceBondTime(rp, address, opts)
 			if err != nil {


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.