### PR TITLE
Fix nil pointer when saving rewards artifacts on non-trusted nodes

### DIFF
--- a/shared/services/rewards/files.go
+++ b/shared/services/rewards/files.go
@@ -276,5 +276,9 @@ func saveArtifactsImpl(smartnode *config.SmartnodeConfig, treeResult *GenerateTr
 		}
 
 	}
+
+	if primaryCid == nil {
+		return cid.Cid{}, out, nil
+	}
 	return *primaryCid, out, nil
 }


### PR DESCRIPTION
As of [v1.16.0](https://github.com/rocket-pool/smartnode/releases/tag/v1.16.0), the [CID is no longer used in rewards submissions](https://github.com/rocket-pool/smartnode/commit/53740e106cd86c0c8196610ec7cf9c502b97ba54) due to occasional inconsistency in how the field is produced. 

When rewards artifacts are written to disk, non-trusted nodes are [not required to save the CID or a compressed version of the results](https://github.com/rocket-pool/smartnode/blob/a9c7d2cf4dad9379388813d9d32cb50736edb154/shared/services/rewards/files.go#L245).

As a result, non-trusted nodes saving rewards artifacts without a CID hit this segfault because `primaryCID` is not assigned.
```
2025/09/11 15:04:25 [Interval 1 Tree] Your Merkle tree's root of 0xdff8efdc96433619450aaa1b4a442791555583b366d361c46b1aec0d9831eecf matches the canonical root! You will be able to use this file for claiming rewards.
2025/09/11 15:04:25 [Interval 1 Tree] Saving JSON files...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xdf7b3c]

goroutine 42 [running]:
github.com/rocket-pool/smartnode/shared/services/rewards.saveArtifactsImpl(0xc00061bb08, 0xc000a63ef0, 0x0, 0x1)
	/home/tpan/dev/smartnode/shared/services/rewards/files.go:279 +0x87c
github.com/rocket-pool/smartnode/shared/services/rewards.saveRewardsArtifacts(0xc00061bb08, 0xc000a63ef0, 0x0)
	/home/tpan/dev/smartnode/shared/services/rewards/files.go:176 +0x67
github.com/rocket-pool/smartnode/shared/services/rewards.(*treeGeneratorImpl_v9_v10).saveFiles(0xc000912330?, 0x1769fd2?, 0x42?, 0xf0?)
	/home/tpan/dev/smartnode/shared/services/rewards/generator-impl-v9-v10.go:1316 +0x1b
github.com/rocket-pool/smartnode/shared/services/rewards.(*TreeGenerator).SaveFiles(...)
	/home/tpan/dev/smartnode/shared/services/rewards/generator.go:263
github.com/rocket-pool/smartnode/rocketpool/watchtower.(*generateRewardsTree).generateRewardsTreeImpl(_, _, _, {_, _}, {0xc0006a5c20, 0xc0006a5e00, 0xc0006a5e20, {0xdf, 0xf8, ...}, ...}, ...)
	/home/tpan/dev/smartnode/rocketpool/watchtower/generate-rewards-tree.go:271 +0xa6e
github.com/rocket-pool/smartnode/rocketpool/watchtower.(*generateRewardsTree).generateRewardsTree(0xc000904180, 0x1)
	/home/tpan/dev/smartnode/rocketpool/watchtower/generate-rewards-tree.go:228 +0x122b
created by github.com/rocket-pool/smartnode/rocketpool/watchtower.(*generateRewardsTree).run in goroutine 98
	/home/tpan/dev/smartnode/rocketpool/watchtower/generate-rewards-tree.go:125 +0x685
```

This PR resolves the issue by returning an empty `cid.Cid{}` when `primaryCID == nil`.