### PR TITLE
Embed git metadata into docker images

### DIFF
--- a/docker/daemon-bake.hcl
+++ b/docker/daemon-bake.hcl
@@ -2,6 +2,14 @@ variable "VERSION" {
   default = "$VERSION"
 }
 
+variable "GIT_BRANCH" {
+  default = "$GIT_BRANCH"
+}
+
+variable "GIT_COMMIT" {
+  default = "$GIT_COMMIT"
+}
+
 group "default" {
   targets = ["builder", "smartnode"]
 }
@@ -21,6 +29,11 @@ target "smartnode" {
   args = {
     BUILDPLATFORM = "linux/amd64"
     VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.ref.name" = "${GIT_BRANCH}"
+    "org.opencontainers.image.revision" = "${GIT_COMMIT}"
+    "org.opencontainers.image.source" = "https://github.com/rocket-pool/smartnode"
   }
   tags = [
     "rocketpool/smartnode:${VERSION}",


### PR DESCRIPTION
It's not possible to identify the source code for a build by checking the docker image tag: https://hub.docker.com/r/rocketpool/smartnode/tags

This PR embeds a link to the smartnode repo, branch name, and commit hash using Docker object labels. 
Labels are up to code with [OCI annotations spec](https://specs.opencontainers.org/image-spec/annotations/).

Labels are visible via `docker inspect`

`docker inspect rocketpool/smartnode:v1.18.0-dev4 | jq '.[0].Config.Labels'` 
```
{
  "org.opencontainers.image.ref.name": "image-metadata",
  "org.opencontainers.image.revision": "2ac540ba971e91d7fb3d72dcdd691a5b800e768a",
  "org.opencontainers.image.source": "https://github.com/rocket-pool/smartnode"
}
```

Builds using uncommitted changes display the most recent commit alongside this suffix: `-with-uncommitted-changes`
```
{
  "org.opencontainers.image.revision": "7f56060f7d653b5fd0d5741933def0a1bfe46f20-with-uncommitted-changes",
}
``` 