### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/bindings/rocketpool/rocketpool.go
+++ b/bindings/rocketpool/rocketpool.go
@@ -123,7 +123,6 @@ func (rp *RocketPool) GetAddresses(opts *bind.CallOpts, contractNames ...string)
 
 	// Load addresses
 	for ci, contractName := range contractNames {
-		ci, contractName := ci, contractName
 		wg.Go(func() error {
 			address, err := rp.GetAddress(contractName, opts)
 			if err == nil {
@@ -189,7 +188,6 @@ func (rp *RocketPool) GetABIs(opts *bind.CallOpts, contractNames ...string) ([]*
 
 	// Load ABIs
 	for ci, contractName := range contractNames {
-		ci, contractName := ci, contractName
 		wg.Go(func() error {
 			abi, err := rp.GetABI(contractName, opts)
 			if err == nil {
@@ -271,7 +269,6 @@ func (rp *RocketPool) GetContracts(opts *bind.CallOpts, contractNames ...string)
 
 	// Load contracts
 	for ci, contractName := range contractNames {
-		ci, contractName := ci, contractName
 		wg.Go(func() error {
 			contract, err := rp.GetContract(contractName, opts)
 			if err == nil {

--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -286,7 +286,6 @@ func (m *NetworkStateManager) createNetworkState(slotNumber uint64) (*NetworkSta
 		var wg errgroup.Group
 		// Iterate the maps and query megapool details
 		for megapoolAddress := range megapoolAddressMap {
-			megapoolAddress := megapoolAddress
 			wg.Go(func() error {
 
 				// Load the megapool
@@ -562,8 +561,6 @@ func (s *NetworkState) CalculateNodeWeights() (map[common.Address]*big.Int, *big
 	var wg errgroup.Group
 	wg.SetLimit(threadLimit)
 	for i, node := range s.NodeDetails {
-		i := i
-		node := node
 		wg.Go(func() error {
 			eligibleBorrowedEth := s.GetEligibleBorrowedEth(&node)
 
@@ -661,8 +658,6 @@ func (s *NetworkState) CalculateTrueEffectiveStakes(scaleByParticipation bool, a
 	var wg errgroup.Group
 	wg.SetLimit(threadLimit)
 	for i, node := range s.NodeDetails {
-		i := i
-		node := node
 		wg.Go(func() error {
 			eligibleBorrowedEth := big.NewInt(0)
 			eligibleBondedEth := big.NewInt(0)

--- a/shared/utils/rp/node.go
+++ b/shared/utils/rp/node.go
@@ -137,8 +137,6 @@ func CheckCollateral(saturnDeployed bool, rp *rocketpool.RocketPool, nodeAddress
 	}
 
 	for i, address := range addresses {
-		i := i
-		address := address
 		wg.Go(func() error {
 			reduceBondTime, err := minipool.GetReduceBondTime(rp, address, opts)
 			if err != nil {


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore