### PR TITLE
 chore: fix typos in comment

### DIFF
--- a/rocketpool-cli/node/deposit.go
+++ b/rocketpool-cli/node/deposit.go
@@ -78,7 +78,7 @@ func nodeDeposit(c *cli.Context) error {
 		return nil
 	}
 
-	// Post a final warning about the dynamic comission boost
+	// Post a final warning about the dynamic commission boost
 	if !smoothie.NodeRegistered {
 		if !(c.Bool("yes") || prompt.Confirm(fmt.Sprintf("%sWARNING: Your node is not opted into the smoothing pool, which means newly launched minipools will not benefit from the 5-9%% dynamic commission boost. You can join the smoothing pool using: 'rocketpool node join-smoothing-pool'.\n%sAre you sure you'd like to continue without opting into the smoothing pool?", colorRed, colorReset))) {
 			fmt.Println("Cancelled.")

--- a/rocketpool/node/reduce-bonds.go
+++ b/rocketpool/node/reduce-bonds.go
@@ -302,7 +302,7 @@ func (t *reduceBonds) forceFeeDistribution() (bool, error) {
 	return true, nil
 }
 
-// Get reduceable minipools
+// Get reducible minipools
 func (t *reduceBonds) getReduceableMinipools(nodeAddress common.Address, windowStart time.Duration, windowLength time.Duration, latestBlockTime time.Time, state *state.NetworkState, opts *bind.CallOpts) ([]*rpstate.NativeMinipoolDetails, error) {
 
 	// Filter minipools

--- a/treegen/tree-gen.go
+++ b/treegen/tree-gen.go
@@ -114,7 +114,7 @@ func GenerateTree(c *cli.Context) error {
 	logger := log.NewColorLogger(color.FgHiWhite)
 	errLogger := log.NewColorLogger(color.FgRed)
 
-	// URL acquisiton
+	// URL acquisition
 	ecUrl := c.String("ec-endpoint")
 	if ecUrl == "" {
 		return fmt.Errorf("ec-endpoint must be provided")


### PR DESCRIPTION
## Description

- Fix typos in comment:
  - `comission` → `commission`
  - `reduceable` → `reducible`
  - `acquisiton` → `acquisiton`