### PR TITLE
Fix grammar and typos in comments

### DIFF
--- a/bindings/tokens/rpl-fixed.go
+++ b/bindings/tokens/rpl-fixed.go
@@ -68,7 +68,7 @@ func EstimateApproveFixedSupplyRPLGas(rp *rocketpool.RocketPool, spender common.
 	return estimateApproveGas(rocketTokenFixedSupplyRPL, "fixed-supply RPL", spender, amount, opts)
 }
 
-// Approve an fixed-supply RPL spender
+// Approve a fixed-supply RPL spender
 func ApproveFixedSupplyRPL(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
 	rocketTokenFixedSupplyRPL, err := getRocketTokenRPLFixedSupply(rp, nil)
 	if err != nil {

--- a/rocketpool/api/node/deposit.go
+++ b/rocketpool/api/node/deposit.go
@@ -206,7 +206,7 @@ func canNodeDeposit(c *cli.Context, amountWei *big.Int, minNodeFee float64, salt
 			return nil, err
 		}
 
-		// calculte the withdrawal credentials (in case megapool is not deployed)
+		// calculate the withdrawal credentials (in case megapool is not deployed)
 		withdrawalCredentials = services.CalculateMegapoolWithdrawalCredentials(megapoolAddress)
 
 	}

--- a/rocketpool/api/pdao/commands.go
+++ b/rocketpool/api/pdao/commands.go
@@ -857,7 +857,7 @@ func RegisterSubcommands(command *cli.Command, name string, aliases []string) {
 			},
 			{
 				Name:      "defeat-proposal",
-				Usage:     "Defeat a proposal if it still has an challenge after voting has started",
+				Usage:     "Defeat a proposal if it still has a challenge after voting has started",
 				UsageText: "rocketpool api pdao defeat-proposal proposal-id challenged-index",
 				Action: func(c *cli.Context) error {
 

--- a/rocketpool/watchtower/challenge-exit.go
+++ b/rocketpool/watchtower/challenge-exit.go
@@ -114,7 +114,7 @@ func (t *challengeValidatorsExiting) challengeValidatorsExiting(state *state.Net
 			validatorFromState := state.MegapoolValidatorDetails[types.ValidatorPubkey(validator.Pubkey)]
 
 			if validatorFromState.WithdrawableEpoch-notifyThresholdInEpochs <= currentEpoch {
-				t.log.Printlnf("Validator %d has an withdrawable epoch %d which is past the notify threshold... Challenging", validator.ValidatorInfo.ValidatorIndex, validatorFromState.WithdrawableEpoch)
+				t.log.Printlnf("Validator %d has a withdrawable epoch %d which is past the notify threshold... Challenging", validator.ValidatorInfo.ValidatorIndex, validatorFromState.WithdrawableEpoch)
 				batched++
 				challengeMegapoolAddressToIds[validator.MegapoolAddress] = append(challengeMegapoolAddressToIds[validator.MegapoolAddress], validator.ValidatorId)
 			}

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -270,7 +270,7 @@ func (c *Client) IsFirstRun() (bool, error) {
 	return rp.IsFirstRun(expandedPath), nil
 }
 
-// Load the Prometheus template, do an template variable substitution, and save it
+// Load the Prometheus template, do a template variable substitution, and save it
 func (c *Client) UpdatePrometheusConfiguration(config *config.RocketPoolConfig) error {
 	prometheusTemplatePath, err := homedir.Expand(fmt.Sprintf("%s/%s", c.configPath, PrometheusConfigTemplate))
 	if err != nil {


### PR DESCRIPTION
Fixed a few typos and grammar issues in comments:

- Corrected "an" → "a" before consonant sounds (fixed-supply, challenge, template,withdrawable)
- Fixed "calculte" → "calculate" spelling error

