### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/rocketpool-cli/pdao/kick-sc.go
+++ b/rocketpool-cli/pdao/kick-sc.go
@@ -159,13 +159,13 @@ func proposeSecurityCouncilKick(c *cli.Context) error {
 		}
 
 		// Create the kick string
-		var kickString string
+		var kickString strings.Builder
 		for i, address := range addresses {
-			kickString += fmt.Sprintf("\t- %s (%s)\n", ids[i], address.Hex())
+			kickString.WriteString(fmt.Sprintf("\t- %s (%s)\n", ids[i], address.Hex()))
 		}
 
 		// Prompt for confirmation
-		if !(c.Bool("yes") || prompt.Confirm(fmt.Sprintf("Are you sure you want to propose kicking these members from the security council?\n%s", kickString))) {
+		if !(c.Bool("yes") || prompt.Confirm(fmt.Sprintf("Are you sure you want to propose kicking these members from the security council?\n%s", kickString.String()))) {
 			fmt.Println("Cancelled.")
 			return nil
 		}

--- a/shared/services/rocketpool/client.go
+++ b/shared/services/rocketpool/client.go
@@ -1282,23 +1282,23 @@ func (c *Client) callAPIWithEnvVars(envVars map[string]string, args string, othe
 	// Create the command to run
 	var cmd string
 	if c.daemonPath == "" {
-		envArgs := ""
+		var envArgs strings.Builder
 		for key, value := range envVars {
 			os.Setenv(key, shellescape.Quote(value))
-			envArgs += fmt.Sprintf("-e %s ", key)
+			envArgs.WriteString(fmt.Sprintf("-e %s ", key))
 		}
 		containerName, err := c.getAPIContainerName()
 		if err != nil {
 			return []byte{}, err
 		}
-		cmd = fmt.Sprintf("docker exec %s %s %s %s %s %s %s api %s", envArgs, shellescape.Quote(containerName), shellescape.Quote(APIBinPath), ignoreSyncCheckFlag, forceFallbackECFlag, c.getGasOpts(), c.getCustomNonce(), args)
+		cmd = fmt.Sprintf("docker exec %s %s %s %s %s %s %s api %s", envArgs.String(), shellescape.Quote(containerName), shellescape.Quote(APIBinPath), ignoreSyncCheckFlag, forceFallbackECFlag, c.getGasOpts(), c.getCustomNonce(), args)
 	} else {
-		envArgs := ""
+		var envArgs strings.Builder
 		for key, value := range envVars {
-			envArgs += fmt.Sprintf("%s=%s ", key, shellescape.Quote(value))
+			envArgs.WriteString(fmt.Sprintf("%s=%s ", key, shellescape.Quote(value)))
 		}
 		cmd = fmt.Sprintf("%s %s --settings %s %s %s %s %s api %s",
-			envArgs,
+			envArgs.String(),
 			c.daemonPath,
 			shellescape.Quote(fmt.Sprintf("%s/%s", c.configPath, SettingsFile)),
 			ignoreSyncCheckFlag,

--- a/shared/utils/cli/prompt/prompt.go
+++ b/shared/utils/cli/prompt/prompt.go
@@ -52,9 +52,10 @@ func ConfirmWithIAgree(initialPrompt string) bool {
 func Select(initialPrompt string, options []string) (int, string) {
 
 	// Get prompt
-	prompt := initialPrompt
+	var prompt strings.Builder
+	prompt.WriteString(initialPrompt)
 	for i, option := range options {
-		prompt += fmt.Sprintf("\n%d: %s", (i + 1), option)
+		prompt.WriteString(fmt.Sprintf("\n%d: %s", (i + 1), option))
 	}
 
 	// Get expected response format
@@ -65,7 +66,7 @@ func Select(initialPrompt string, options []string) (int, string) {
 	expectedFormat := fmt.Sprintf("^(%s)$", strings.Join(optionNumbers, "|"))
 
 	// Prompt user
-	response := Prompt(prompt, expectedFormat, "Please enter a number corresponding to an option")
+	response := Prompt(prompt.String(), expectedFormat, "Please enter a number corresponding to an option")
 
 	// Get selected option
 	index, _ := strconv.Atoi(response)


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)