### PR TITLE
Fix Teku metric for number of peers

### DIFF
--- a/shared/services/rocketpool/assets/install/dashboards/Rocket Pool Dashboard v1.3.3.json
+++ b/shared/services/rocketpool/assets/install/dashboards/Rocket Pool Dashboard v1.3.3.json
@@ -1743,7 +1743,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(sync_peers_per_status{job=\"eth2\", sync_status=~\"Synced|Advanced\"}) OR # Lighthouse\nlodestar_peers_sync_count{job=\"eth2\"} OR # Lodestar\nnbc_peers{job=\"eth2\"} OR # Nimbus\np2p_peer_count{job=\"eth2\", state=\"Connected\"} OR # Prysm\nbeacon_peer_count{job=\"eth2\"} # Teku",
+          "expr": "sum(sync_peers_per_status{job=\"eth2\", sync_status=~\"Synced|Advanced\"}) OR # Lighthouse\nlodestar_peers_sync_count{job=\"eth2\"} OR # Lodestar\nnbc_peers{job=\"eth2\"} OR # Nimbus\np2p_peer_count{job=\"eth2\", state=\"Connected\"} OR # Prysm\nsum(beacon_peer_count{job=\"eth2\"}) # Teku",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -1830,7 +1830,7 @@
         {
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(sync_peers_per_status{job=\"eth2\", sync_status=~\"Synced|Advanced\"}) OR # Lighthouse\nlodestar_peers_sync_count{job=\"eth2\"} OR # Lodestar\nnbc_peers{job=\"eth2\"} OR # Nimbus\np2p_peer_count{job=\"eth2\", state=\"Connected\"} OR # Prysm\nbeacon_peer_count{job=\"eth2\"} # Teku",
+          "expr": "sum(sync_peers_per_status{job=\"eth2\", sync_status=~\"Synced|Advanced\"}) OR # Lighthouse\nlodestar_peers_sync_count{job=\"eth2\"} OR # Lodestar\nnbc_peers{job=\"eth2\"} OR # Nimbus\np2p_peer_count{job=\"eth2\", state=\"Connected\"} OR # Prysm\nsum(beacon_peer_count{job=\"eth2\"}) # Teku",
           "interval": "",
           "legendFormat": "BN",
           "range": true,


### PR DESCRIPTION
Latest teku release 25.11.1 has improved the beacon_peer_count gauge metric with an extra label for the connection direction (inbound or outbound). Reference: https://github.com/Consensys/teku/releases/tag/25.11.1

This is just a small fix to aggregate both directions into a single peer count to keep the RP dashboard working as expected.