### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/shared/utils/cli/prompt/prompt_unix.go
+++ b/shared/utils/cli/prompt/prompt_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package prompt
 

--- a/shared/utils/cli/prompt/prompt_windows.go
+++ b/shared/utils/cli/prompt/prompt_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package prompt
 

--- a/shared/utils/term/term_unix.go
+++ b/shared/utils/term/term_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package term
 

--- a/shared/utils/term/term_windows.go
+++ b/shared/utils/term/term_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package term
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild
