### PR TITLE
fix: restore correct metric for Smoothing Pool Balance panel (v1.4.0 regression)

### DIFF
--- a/shared/services/rocketpool/assets/install/dashboards/Rocket Pool Dashboard v1.4.0.json
+++ b/shared/services/rocketpool/assets/install/dashboards/Rocket Pool Dashboard v1.4.0.json
@@ -3042,7 +3042,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "rocketpool_demand_deposit_pool_balance",
+          "expr": "rocketpool_smoothing_pool_eth_balance",
           "interval": "",
           "legendFormat": "",
           "range": true,


### PR DESCRIPTION
## Summary

Panel 250 ("Smoothing Pool Balance") in `Rocket Pool Dashboard v1.4.0.json` was accidentally using `rocketpool_demand_deposit_pool_balance` — the **deposit pool** metric — instead of `rocketpool_smoothing_pool_eth_balance`.

This was correct in v1.3.3 and regressed in v1.4.0.

**Before (v1.4.0):**
```
"expr": "rocketpool_demand_deposit_pool_balance"
```

**After (this fix):**
```
"expr": "rocketpool_smoothing_pool_eth_balance"
```

## Context

- Panel 160 ("Staking Pool Balance") correctly uses `rocketpool_demand_deposit_pool_balance` for the deposit pool — no change needed there.
- The `rocketpool_smoothing_pool_eth_balance` metric is exposed by the smartnode exporter via `smoothing-pool-collector.go`.
- With the regression, the Smoothing Pool Balance panel silently displayed deposit pool balance instead, making the two panels show identical data.