### PR TITLE
Add the capella offset to historical summary proofs

### DIFF
--- a/rocketpool/api/debug/beacon_state.go
+++ b/rocketpool/api/debug/beacon_state.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/rocket-pool/smartnode/shared/services"
 	"github.com/rocket-pool/smartnode/shared/types/api"
+	cfgtypes "github.com/rocket-pool/smartnode/shared/types/config"
 	"github.com/rocket-pool/smartnode/shared/types/eth2"
 	"github.com/rocket-pool/smartnode/shared/types/eth2/generic"
 	hexutil "github.com/rocket-pool/smartnode/shared/utils/hex"
-	cfgtypes "github.com/rocket-pool/smartnode/shared/types/config"
 )
 
 const MAX_WITHDRAWAL_SLOT_DISTANCE = 432000 // 60 days.
+const capellaSlotMainnet uint64 = 6209536
+const capellaSlotHoodi uint64 = 0
 
 func getBeaconStateForSlot(c *cli.Context, slot uint64, validatorIndex uint64) error {
 	// Create a new response
@@ -75,7 +77,7 @@ func getWithdrawalProofForSlot(c *cli.Context, slot uint64, validatorIndex uint6
 	if err != nil {
 		return err
 	}
-	
+
 	// Get the network
 	cfg, err := services.GetConfig(c)
 	if err != nil {
@@ -166,7 +168,13 @@ func getWithdrawalProofForSlot(c *cli.Context, slot uint64, validatorIndex uint6
 			return err
 		}
 	} else {
-		stateProof, err = state.HistoricalSummaryProof(response.WithdrawalSlot, network)
+		var capellaOffset uint64
+		if network == cfgtypes.Network_Mainnet {
+			capellaOffset = capellaSlotMainnet / uint64(generic.SlotsPerHistoricalRoot)
+		} else {
+			capellaOffset = capellaSlotHoodi / uint64(generic.SlotsPerHistoricalRoot)
+		}
+		stateProof, err = state.HistoricalSummaryProof(response.WithdrawalSlot, capellaOffset)
 		if err != nil {
 			return err
 		}

--- a/shared/types/eth2/fork/electra/state_electra.go
+++ b/shared/types/eth2/fork/electra/state_electra.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	cfgtypes "github.com/rocket-pool/smartnode/shared/types/config"
 	"github.com/rocket-pool/smartnode/shared/types/eth2/generic"
 	"github.com/rocket-pool/smartnode/shared/utils/math"
 )
@@ -197,7 +196,7 @@ func (state *BeaconState) blockHeaderToStateProof(blockHeader *generic.BeaconBlo
 	return blockHeaderProof.Hashes, nil
 }
 
-func (state *BeaconState) HistoricalSummaryProof(slot uint64, network cfgtypes.Network) ([][]byte, error) {
+func (state *BeaconState) HistoricalSummaryProof(slot uint64, capellaOffset uint64) ([][]byte, error) {
 	isHistorical := slot+generic.SlotsPerHistoricalRoot <= state.Slot
 	if !isHistorical {
 		return nil, fmt.Errorf("slot %d is less than %d slots in the past from the state at slot %d, you must build a proof from the block_roots field instead", slot, generic.SlotsPerHistoricalRoot, state.Slot)

--- a/shared/types/eth2/fork/fulu/state_fulu.go
+++ b/shared/types/eth2/fork/fulu/state_fulu.go
@@ -7,14 +7,11 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	cfgtypes "github.com/rocket-pool/smartnode/shared/types/config"
 	"github.com/rocket-pool/smartnode/shared/types/eth2/generic"
 	"github.com/rocket-pool/smartnode/shared/utils/math"
 )
 
 const beaconStateChunkCeil uint64 = 64
-const capellaSlotMainnet uint64 = 6209536
-const capellaSlotHoodi uint64 = 0
 
 // Taken from https://github.com/OffchainLabs/prysm/blob/a0071826c5daf7dc3a6e76874fdaa76481a3c665/proto/prysm/v1alpha1/beacon_state.pb.go#L1955
 // Unexported fields stripped, as well as proto-related field tags. JSON and ssz-size tags are preserved, and nested types are replaced with local copies as well.
@@ -202,7 +199,7 @@ func (state *BeaconState) blockHeaderToStateProof(blockHeader *generic.BeaconBlo
 	return blockHeaderProof.Hashes, nil
 }
 
-func (state *BeaconState) HistoricalSummaryProof(slot uint64, network cfgtypes.Network) ([][]byte, error) {
+func (state *BeaconState) HistoricalSummaryProof(slot uint64, capellaOffset uint64) ([][]byte, error) {
 	isHistorical := slot+generic.SlotsPerHistoricalRoot <= state.Slot
 	if !isHistorical {
 		return nil, fmt.Errorf("slot %d is less than %d slots in the past from the state at slot %d, you must build a proof from the block_roots field instead", slot, generic.SlotsPerHistoricalRoot, state.Slot)
@@ -217,12 +214,6 @@ func (state *BeaconState) HistoricalSummaryProof(slot uint64, network cfgtypes.N
 	gid = gid*beaconStateChunkCeil + generic.BeaconStateHistoricalSummariesFieldIndex
 
 	// Navigate into the historical summaries vector.
-	var capellaOffset uint64
-	if network == cfgtypes.Network_Mainnet {
-		capellaOffset = capellaSlotMainnet / uint64(generic.SlotsPerHistoricalRoot)
-	} else {
-		capellaOffset = capellaSlotHoodi / uint64(generic.SlotsPerHistoricalRoot)
-	}
 	arrayIndex := (slot / generic.SlotsPerHistoricalRoot) - capellaOffset
 	gid = gid*2*generic.BeaconStateHistoricalSummariesMaxLength + arrayIndex
 

--- a/shared/types/eth2/types.go
+++ b/shared/types/eth2/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	cfgtypes "github.com/rocket-pool/smartnode/shared/types/config"
 	"github.com/rocket-pool/smartnode/shared/types/eth2/fork/deneb"
 	"github.com/rocket-pool/smartnode/shared/types/eth2/fork/electra"
 	"github.com/rocket-pool/smartnode/shared/types/eth2/fork/fulu"
@@ -24,7 +23,7 @@ type BeaconState interface {
 	GetSlot() uint64
 	ValidatorProof(index uint64) ([][]byte, error)
 	SlotProof(slot uint64) ([][]byte, error)
-	HistoricalSummaryProof(slot uint64, network cfgtypes.Network) ([][]byte, error)
+	HistoricalSummaryProof(slot uint64, capellaOffset uint64) ([][]byte, error)
 	HistoricalSummaryBlockRootProof(slot int) ([][]byte, error)
 	BlockRootProof(slot uint64) ([][]byte, error)
 	BlockHeaderProof() ([][]byte, error)


### PR DESCRIPTION
Bug: HistoricalSummaryProof uses absolute era index instead of physical array index
                                                                                                                                                                                                                                                  
  Summary                                                   

  HistoricalSummaryProof in state_fulu.go computes the arrayIndex into historical_summaries as slot / SlotsPerHistoricalRoot (the absolute era number), but historical_summaries is a list that starts accumulating from the Capella fork. The
  physical array index should be slot / SlotsPerHistoricalRoot - capellaSlot / SlotsPerHistoricalRoot.

  This bug is latent on Hoodi (where Capella activated at genesis, so offset = 0) but will cause proof verification failures on mainnet (where Capella activated at slot 6,209,536, giving offset = 758).

  Details

  Prover (smartnode/shared/types/eth2/fork/fulu/state_fulu.go:216):
  arrayIndex := (slot / generic.SlotsPerHistoricalRoot)
  gid = gid*2*generic.BeaconStateHistoricalSummariesMaxLength + arrayIndex

  Uses the absolute era number (e.g. 854 for a slot around 7,000,000) to navigate the historical_summaries backing tree.

  Verifier (contracts/contract/util/BeaconStateVerifier.sol:192):
  SSZ.intoList(uint248(uint256(_pastSlot) / slotsPerHistoricalRoot - historicalSummaryOffset), 24)

  Correctly subtracts historicalSummaryOffset (initialized at line 47 as slotCapella / slotsPerHistoricalRoot) to get the physical array index (e.g. 854 - 758 = 96).

  Impact

  On mainnet, the prover generates a proof for historical_summaries[854] (an empty/zeroed leaf beyond the list length), while the contract reconstructs the path using index 96. The proof and verification paths diverge, causing
  verifyWithdrawal to fail for every notifyFinalBalance call.

  Fix

  // state_fulu.go:216
  arrayIndex := (slot / generic.SlotsPerHistoricalRoot) - capellaOffset

  Where capellaOffset = capellaSlot / SlotsPerHistoricalRoot (758 on mainnet, 0 on Hoodi).

