### PR TITLE
Direct users to the correct site when setting the RPL or Primary withdrawal address 

### DIFF
--- a/rocketpool-cli/node/primary-withdrawal-address.go
+++ b/rocketpool-cli/node/primary-withdrawal-address.go
@@ -129,14 +129,14 @@ func setPrimaryWithdrawalAddress(c *cli.Context, withdrawalAddressOrENS string) 
 
 	// Log & return
 	if !c.Bool("force") {
-		stakeUrl := ""
+		nodeManagerUrl := ""
 		config, _, err := rp.LoadConfig()
 		if err == nil {
-			stakeUrl = config.Smartnode.GetStakeUrl()
+			nodeManagerUrl = config.Smartnode.GetNodeManagerUrl() + "/primary-withdrawal-address"
 		}
-		if stakeUrl != "" {
+		if nodeManagerUrl != "" {
 			fmt.Printf("The node's primary withdrawal address update to %s is now pending.\n"+
-				"To confirm it, please visit the Rocket Pool website (%s).", withdrawalAddressString, stakeUrl)
+				"To confirm it, please visit the Rocket Pool website (%s).", withdrawalAddressString, nodeManagerUrl)
 		} else {
 			fmt.Printf("The node's primary withdrawal address update to %s is now pending.\n"+
 				"To confirm it, please visit the Rocket Pool website.", withdrawalAddressString)

--- a/rocketpool-cli/node/rpl-withdrawal-address.go
+++ b/rocketpool-cli/node/rpl-withdrawal-address.go
@@ -144,14 +144,14 @@ func setRPLWithdrawalAddress(c *cli.Context, withdrawalAddressOrENS string) erro
 
 	// Log & return
 	if !c.Bool("force") {
-		stakeUrl := ""
+		nodeManagerUrl := ""
 		config, _, err := rp.LoadConfig()
 		if err == nil {
-			stakeUrl = config.Smartnode.GetStakeUrl()
+			nodeManagerUrl = config.Smartnode.GetNodeManagerUrl() + "/rpl-withdrawal-address"
 		}
-		if stakeUrl != "" {
+		if nodeManagerUrl != "" {
 			fmt.Printf("The node's RPL withdrawal address update to %s is now pending.\n"+
-				"To confirm it, please visit the Rocket Pool website (%s).", withdrawalAddressString, stakeUrl)
+				"To confirm it, please visit the Rocket Pool website (%s).", withdrawalAddressString, nodeManagerUrl)
 		} else {
 			fmt.Printf("The node's RPL withdrawal address update to %s is now pending.\n"+
 				"To confirm it, please visit the Rocket Pool website.", withdrawalAddressString)

--- a/shared/services/config/smartnode-config.go
+++ b/shared/services/config/smartnode-config.go
@@ -121,8 +121,8 @@ type SmartnodeConfig struct {
 	// The URL to provide the user so they can follow pending transactions
 	txWatchUrl map[config.Network]string `yaml:"-"`
 
-	// The URL to use for staking rETH
-	stakeUrl map[config.Network]string `yaml:"-"`
+	// The URL to use for the node management interface
+	nodeManagerUrl map[config.Network]string `yaml:"-"`
 
 	// The map of networks to execution chain IDs
 	chainID map[config.Network]uint `yaml:"-"`
@@ -419,10 +419,10 @@ func NewSmartnodeConfig(cfg *RocketPoolConfig) *SmartnodeConfig {
 			config.Network_Testnet: "https://hoodi.etherscan.io/tx",
 		},
 
-		stakeUrl: map[config.Network]string{
-			config.Network_Mainnet: "https://stake.rocketpool.net",
-			config.Network_Devnet:  "https://devnet.rocketpool.net",
-			config.Network_Testnet: "https://testnet.rocketpool.net",
+		nodeManagerUrl: map[config.Network]string{
+			config.Network_Mainnet: "https://node.rocketpool.net",
+			config.Network_Devnet:  "https://devnet.node.rocketpool.net",
+			config.Network_Testnet: "https://testnet.node.rocketpool.net",
 		},
 
 		chainID: map[config.Network]uint{
@@ -651,8 +651,8 @@ func (cfg *SmartnodeConfig) GetTxWatchUrl() string {
 	return cfg.txWatchUrl[cfg.Network.Value.(config.Network)]
 }
 
-func (cfg *SmartnodeConfig) GetStakeUrl() string {
-	return cfg.stakeUrl[cfg.Network.Value.(config.Network)]
+func (cfg *SmartnodeConfig) GetNodeManagerUrl() string {
+	return cfg.nodeManagerUrl[cfg.Network.Value.(config.Network)]
 }
 
 func (cfg *SmartnodeConfig) GetChainID() uint {


### PR DESCRIPTION
Previously:
```
Waiting for the transaction to be included in a block... you may wait here for it, or press CTRL+C to exit and return to the terminal.

The node's primary withdrawal address update to <address> is now pending.
To confirm it, please visit the Rocket Pool website (https://stake.rocketpool.net).
```
Improved:
```
Waiting for the transaction to be included in a block... you may wait here for it, or press CTRL+C to exit and return to the terminal.

The node's primary withdrawal address update to <address> is now pending.
To confirm it, please visit the Rocket Pool website (https://node.rocketpool.net/primary-withdrawal-address).
```