### PR TITLE
Fix nil pointers by returning errors instead of logging

### DIFF
--- a/rocketpool/node/notify-final-balance.go
+++ b/rocketpool/node/notify-final-balance.go
@@ -194,7 +194,7 @@ func (t *notifyFinalBalance) createFinalBalanceProof(rp *rocketpool.RocketPool, 
 
 	withdrawalProof, proofSlot, stateUsed, err := services.GetWithdrawalProofForSlot(t.c, slot, validatorIndex)
 	if err != nil {
-		fmt.Printf("An error occurred: %s\n", err)
+		return fmt.Errorf("error getting withdrawal proof for validator 0x%s (index: %d): %w", validatorPubkey.String(), validatorIndex, err)
 	}
 	t.log.Printlnf("The Beacon WithdrawalSlot for validator ID %d is: %d", validatorInfo.ValidatorId, withdrawalProof.WithdrawalSlot)
 

--- a/rocketpool/watchtower/dissolve-invalid-credentials.go
+++ b/rocketpool/watchtower/dissolve-invalid-credentials.go
@@ -97,7 +97,8 @@ func (t *dissolveInvalidCredentials) dissolveInvalidCredentialValidators(state *
 			// Fetch the validator from the beacon state to compare credentials
 			validatorFromState, err := t.bc.GetValidatorStatus(types.ValidatorPubkey(validator.Pubkey), nil)
 			if err != nil {
-				t.log.Printlnf("Error fetching validator %s from beacon state: %s", validatorFromState.Index, err)
+				pubkey := types.BytesToValidatorPubkey(validator.Pubkey).String()
+				t.log.Printlnf("error getting the beacon state for validator 0x%s on megapool %s: %s", pubkey, validator.MegapoolAddress, err)
 				continue
 			}
 			if !validatorFromState.Exists {

--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -536,11 +536,11 @@ func (t *submitNetworkBalances) getMegapoolBalanceDetails(megapoolAddress common
 				// Convert the validator index to a uint64
 				validatorIndex, err := strconv.ParseUint(megapoolValidatorDetails.Index, 10, 64)
 				if err != nil {
-					fmt.Printf("An error occurred while converting the validator index to a uint64: %s\n", err)
+					return megapoolBalanceDetails, fmt.Errorf("error converting validator index %s to uint64: %w", megapoolValidatorDetails.Index, err)
 				}
 				_, _, _, withdrawal, _, err := services.FindWithdrawalBlockAndArrayPosition(searchWithdrawSlot, validatorIndex, t.bc)
 				if err != nil {
-					fmt.Printf("An error occurred while searching for the withdrawn balance: %s\n", err)
+					return megapoolBalanceDetails, fmt.Errorf("error finding withdrawal for validator %d: %w", validatorIndex, err)
 				}
 				// Track the withdrawn balance so we can discount it from the pending rewards on the contract
 				totalWithdrawnBalance.Add(totalWithdrawnBalance, eth.GweiToWei(float64(withdrawal.Amount)))


### PR DESCRIPTION
This PR resolves a handful of nil pointers caused by missing `fmt.Errorf` statements, allowing the task to gracefully exit if the beacon node goes offline. 

```
2026/02/24 21:35:57 WARNING: Primary Beacon client disconnected (Could not get beacon block data: Get "http://100.68.178.27:5052/eth/v2/beacon/blocks/2448518": dial tcp 100.68.178.27:5052: i/o timeout), using fallback...
An error occurred while searching for the withdrawn balance: no Beacon clients were ready
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x135f6ad]

goroutine 1859 [running]:
github.com/rocket-pool/smartnode/rocketpool/watchtower.(*submitNetworkBalances).getMegapoolBalanceDetails(0xc0008382a0, {0x39, 0x92, 0x10, 0xe2, 0x72, 0xd3, 0xa9, 0x61, 0x0, ...}, ...)
	/home/tpan/dev/smartnode/rocketpool/watchtower/submit-network-balances.go:543 +0x56d
github.com/rocket-pool/smartnode/rocketpool/watchtower.(*submitNetworkBalances).getNetworkBalances.func2()
	/home/tpan/dev/smartnode/rocketpool/watchtower/submit-network-balances.go:398 +0x1c8
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/home/tpan/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1647
	/home/tpan/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:78 +0x95
```

Steps to reproduce: 
1. Run the balance submissions watchtower task
2. Disconnect your beacon node while [getMegapoolBalanceDetails](https://github.com/rocket-pool/smartnode/blob/892ed0ca3c100b7c5bc84bb41a47dc7017782426/rocketpool/watchtower/submit-network-balances.go#L505) is looping over every megapool validator


A similar issue is present in a handful of other spots: 
- [dissolveInvalidCredentialValidators](https://github.com/rocket-pool/smartnode/blob/d19d72dcae682954b4e1813382296f8d5c09d820/rocketpool/watchtower/dissolve-invalid-credentials.go#L100) tries to print `validatorFromState.Index`, which doesn't exist if the `GetValidatorStatus` call fails. 
- [createFinalBalanceProof](https://github.com/rocket-pool/smartnode/blob/master/rocketpool/node/notify-final-balance.go#L197) allows the task to continue even if the `GetWithdrawalProofForSlot` call fails. 