### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/shared/services/alerting/alerting.go
+++ b/shared/services/alerting/alerting.go
@@ -3,6 +3,7 @@ package alerting
 import (
 	"fmt"
 	"log"
+	"maps"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -313,9 +314,7 @@ func createAlert(uniqueName string, summary string, description string, severity
 		EndsAt: endsAt,
 	}
 
-	for k, v := range extraLabels {
-		alert.Labels[k] = v
-	}
+	maps.Copy(alert.Labels, extraLabels)
 	return alert
 }
 


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.