### PR TITLE
fix(grafana): use container name for prometheus datasource URL

### DIFF
--- a/shared/services/rocketpool/assets/install/grafana-prometheus-datasource.yml
+++ b/shared/services/rocketpool/assets/install/grafana-prometheus-datasource.yml
@@ -9,7 +9,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://prometheus:9091
+    url: http://rocketpool_prometheus:9091
     basicAuth: false
     isDefault: true
     version: 1

--- a/shared/services/rocketpool/assets/install/templates/grafana-prometheus-datasource.tmpl
+++ b/shared/services/rocketpool/assets/install/templates/grafana-prometheus-datasource.tmpl
@@ -9,7 +9,7 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://prometheus:9091
+    url: http://rocketpool_prometheus:9091
     basicAuth: false
     isDefault: true
     version: 1


### PR DESCRIPTION
## Summary

- Updates Grafana datasource URL from `http://prometheus:9091` to `http://rocketpool_prometheus:9091`
- Fixes DNS resolution failures where Grafana cannot reach Prometheus

## Problem

Docker Compose service name DNS resolution can fail in multi-file compose setups, particularly with Docker Compose v5. The service name `prometheus` is not registered as a DNS alias, but the container name `rocketpool_prometheus` always resolves correctly.

Observed error in Grafana logs:
```
dial tcp: lookup prometheus on 127.0.0.11:53: no such host
```

## Solution

Use the explicit container name instead of relying on service name DNS aliasing.

## Notes

- Users with non-default `ProjectName` settings may need to adjust their datasource config manually
- An alternative fix would be to add explicit network aliases in the prometheus compose template

## Test Plan

- [ ] Verify Grafana can reach Prometheus after fresh install
- [ ] Verify existing installations work after upgrade