### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/shared/services/proposals/checksum-manager.go
+++ b/shared/services/proposals/checksum-manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -138,9 +139,7 @@ func LoadFromFile[ContextType any, DataType IDataType](m *ChecksumManager[Contex
 
 	// Iterate over each file, counting backwards from the bottom
 	dataFolder := filepath.Dir(m.checksumFilename)
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
-
+	for _, line := range slices.Backward(lines) {
 		// Get the checksum from the line
 		checksumString, filename, found := strings.Cut(line, "  ")
 		if !found {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899