### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/rocketpool-cli/megapool/exit-queue.go
+++ b/rocketpool-cli/megapool/exit-queue.go
@@ -49,8 +49,8 @@ func exitQueue(validatorId string, yes bool) error {
 			selectedValidators = validatorsInQueue
 		} else {
 			// Parse comma-separated validator IDs
-			ids := strings.Split(validatorId, ",")
-			for _, idStr := range ids {
+			ids := strings.SplitSeq(validatorId, ",")
+			for idStr := range ids {
 				idStr = strings.TrimSpace(idStr)
 				validatorId, err := strconv.ParseUint(idStr, 10, 64)
 				if err != nil {

--- a/shared/services/config/commit-boost-config.go
+++ b/shared/services/config/commit-boost-config.go
@@ -330,7 +330,7 @@ func (cfg *CommitBoostConfig) GetCustomRelays() []string {
 		return nil
 	}
 	result := []string{}
-	for _, relay := range strings.Split(customRelays, ",") {
+	for relay := range strings.SplitSeq(customRelays, ",") {
 		trimmed := strings.TrimSpace(relay)
 		if trimmed != "" {
 			result = append(result, trimmed)


### PR DESCRIPTION
Optimize code using a more modern writing style which can make the code more efficient and cleaner.

More info: https://github.com/golang/go/issues/61901