### PR TITLE
Masquerade bugfix + Allow masquerade in the node/watchtower loops. 

### DIFF
--- a/rocketpool-cli/wallet/commands.go
+++ b/rocketpool-cli/wallet/commands.go
@@ -292,6 +292,11 @@ func RegisterCommands(app *cli.Command, name string, aliases []string) {
 						Aliases: []string{"a"},
 						Usage:   "Specify an address you'd like you masquerade as",
 					},
+					&cli.BoolFlag{
+						Name:    "observe",
+						Aliases: []string{"o"},
+						Usage:   "Apply masquerade to the node and watchtower loops (requires daemon restart)",
+					},
 				},
 
 				Action: func(ctx context.Context, c *cli.Command) error {
@@ -303,7 +308,7 @@ func RegisterCommands(app *cli.Command, name string, aliases []string) {
 					}
 
 					// Run
-					return masquerade(c.String("address"), c.Bool("yes"))
+					return masquerade(c.String("address"), c.Bool("yes"), c.Bool("observe"))
 
 				},
 			},

--- a/rocketpool-cli/wallet/masquerade.go
+++ b/rocketpool-cli/wallet/masquerade.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rocket-pool/smartnode/shared/utils/cli/prompt"
 )
 
-func masquerade(addressFlag string, yes bool) error {
+func masquerade(addressFlag string, yes bool, observe bool) error {
 	// Get RP client
 	rp := rocketpool.NewClient()
 	defer rp.Close()
@@ -34,12 +34,15 @@ func masquerade(addressFlag string, yes bool) error {
 	}
 
 	// Call API
-	_, err = rp.Masquerade(address)
+	_, err = rp.Masquerade(address, observe)
 	if err != nil {
 		return fmt.Errorf("error running masquerade: %w", err)
 	}
 
 	fmt.Printf("Your node is now masquerading as address %s.\n", color.LightBlue(address.Hex()))
+	if observe {
+		fmt.Println("Restart the daemon for the node and watchtower loops to pick up the masquerade address.")
+	}
 
 	return nil
 }

--- a/rocketpool-cli/wallet/masquerade.go
+++ b/rocketpool-cli/wallet/masquerade.go
@@ -28,9 +28,21 @@ func masquerade(addressFlag string, yes bool, observe bool) error {
 	}
 
 	// Prompt for confirmation
-	if !yes && !prompt.Confirm("Are you sure you want to masquerade as %s?", color.LightBlue(address.Hex())) {
-		fmt.Println("Cancelled.")
-		return nil
+	if observe {
+		fmt.Println(color.Yellow("Observe mode is enabled. Please read the following carefully:"))
+		fmt.Println(" - The node and watchtower will use the masquerade address instead of your real node address.")
+		fmt.Println(" - Your fee recipient will remain set to your real node wallet address")
+		fmt.Println(" - Run `rocketpool wallet end-masquerade` and restart the node/watchtower daemons when you have finished observing.")
+		fmt.Println()
+		if !yes && !prompt.Confirm("I understand the above. Enable observe mode for %s?", color.LightBlue(address.Hex())) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	} else {
+		if !yes && !prompt.Confirm("Are you sure you want to masquerade as %s?", color.LightBlue(address.Hex())) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
 	}
 
 	// Call API
@@ -41,7 +53,7 @@ func masquerade(addressFlag string, yes bool, observe bool) error {
 
 	fmt.Printf("Your node is now masquerading as address %s.\n", color.LightBlue(address.Hex()))
 	if observe {
-		fmt.Println("Restart the daemon for the node and watchtower loops to pick up the masquerade address.")
+		fmt.Println("Restart the node and watchtower daemons to observe as the masquerade address.")
 	}
 
 	return nil

--- a/rocketpool-cli/wallet/status.go
+++ b/rocketpool-cli/wallet/status.go
@@ -39,11 +39,22 @@ func getStatus() error {
 	if status.IsMasquerading {
 		if status.NodeAddress != emptyAddress {
 			fmt.Printf("The node wallet is initialized, but you are currently masquerading as %s\n", color.LightBlue(status.AccountAddress.Hex()))
-			fmt.Printf("Wallet Address: %s\n", status.NodeAddress)
+			fmt.Printf("Wallet Address: %s\n", color.LightBlue(status.NodeAddress.Hex()))
 			color.YellowPrintln("Due to this mismatch, the node cannot submit transactions. Use the command 'rocketpool wallet end-masquerade' to end masquerading and restore your wallet address.")
 		} else {
 			fmt.Printf("The node wallet has not been initialized, but you are currently masquerading as %s\n", color.LightBlue(status.AccountAddress.Hex()))
 			color.YellowPrintln("The node cannot submit transactions. Use the command 'rocketpool wallet end-masquerade' to end masquerading.")
+		}
+		if status.IsObserve {
+			fmt.Println()
+			fmt.Printf("The node is in %s, observing address %s.\n", color.Yellow("observe mode"), color.LightBlue(status.AccountAddress.Hex()))
+			if status.NodeAddress != emptyAddress {
+				fmt.Printf("Wallet Address (fee recipient): %s\n", color.LightBlue(status.NodeAddress.Hex()))
+			}
+			fmt.Println(" - The node and watchtower loops are using the masquerade address.")
+			fmt.Println(" - Transactions will not be submitted.")
+			fmt.Println(" - Your fee recipient remains set to your real node wallet address")
+			color.YellowPrintln("Run 'rocketpool wallet end-masquerade' and restart the node/watchtower daemons when you have finished observing.")
 		}
 	} else {
 		// Not Masquerading
@@ -56,7 +67,6 @@ func getStatus() error {
 		}
 	}
 
-	fmt.Println()
 	return nil
 
 }

--- a/rocketpool/api/wallet/masquerade.go
+++ b/rocketpool/api/wallet/masquerade.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rocket-pool/smartnode/shared/types/api"
 )
 
-func masquerade(c *cli.Command, address common.Address) (*api.MasqueradeResponse, error) {
+func masquerade(c *cli.Command, address common.Address, observe bool) (*api.MasqueradeResponse, error) {
 
 	// Get services
 	w, err := services.GetWallet(c)
@@ -18,9 +18,8 @@ func masquerade(c *cli.Command, address common.Address) (*api.MasqueradeResponse
 		return nil, err
 	}
 
-	err = w.MasqueradeAsAddress(address)
-	if err != nil {
-		return nil, fmt.Errorf("Error masquerading as address %s", address.Hex())
+	if err := w.MasqueradeAsAddress(address, observe); err != nil {
+		return nil, fmt.Errorf("error masquerading as address %s: %w", address.Hex(), err)
 	}
 
 	response := api.MasqueradeResponse{}

--- a/rocketpool/api/wallet/masquerade.go
+++ b/rocketpool/api/wallet/masquerade.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v3"
 
+	"github.com/rocket-pool/smartnode/bindings/dao/trustednode"
 	"github.com/rocket-pool/smartnode/shared/services"
 	"github.com/rocket-pool/smartnode/shared/types/api"
 )
@@ -16,6 +17,28 @@ func masquerade(c *cli.Command, address common.Address, observe bool) (*api.Masq
 	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
+	}
+
+	if observe {
+		hdw, err := services.GetHdWallet(c)
+		if err != nil {
+			return nil, err
+		}
+		rp, err := services.GetRocketPool(c)
+		if err != nil {
+			return nil, err
+		}
+		nodeAccount, err := hdw.GetNodeAccount()
+		if err != nil {
+			return nil, err
+		}
+		isMember, err := trustednode.GetMemberExists(rp, nodeAccount.Address, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error checking Oracle DAO membership: %w", err)
+		}
+		if isMember {
+			return nil, fmt.Errorf("Observe mode is not available for Oracle DAO nodes: oDAO duties would stop running while observing")
+		}
 	}
 
 	if err := w.MasqueradeAsAddress(address, observe); err != nil {

--- a/rocketpool/api/wallet/routes.go
+++ b/rocketpool/api/wallet/routes.go
@@ -79,7 +79,8 @@ func RegisterRoutes(mux *http.ServeMux, c *cli.Command) {
 
 	mux.HandleFunc("/api/wallet/masquerade", func(w http.ResponseWriter, r *http.Request) {
 		address := common.HexToAddress(r.FormValue("address"))
-		resp, err := masquerade(c, address)
+		observe := r.FormValue("observe") == "true"
+		resp, err := masquerade(c, address, observe)
 		apiutils.WriteResponse(w, resp, err)
 	})
 

--- a/rocketpool/api/wallet/status.go
+++ b/rocketpool/api/wallet/status.go
@@ -4,12 +4,17 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/types/api"
 )
 
 func getStatus(c *cli.Command) (*api.WalletStatusResponse, error) {
 
 	// Get services
+	cfg, err := services.GetConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	pm, err := services.GetPasswordManager(c)
 	if err != nil {
 		return nil, err
@@ -24,6 +29,7 @@ func getStatus(c *cli.Command) (*api.WalletStatusResponse, error) {
 
 	// Get wallet type
 	response.IsMasquerading = w.IsNodeMasquerading()
+	response.IsObserve = wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath())
 
 	// Get wallet status
 	if response.IsMasquerading {

--- a/rocketpool/node/defend-pdao-props.go
+++ b/rocketpool/node/defend-pdao-props.go
@@ -54,7 +54,7 @@ func newDefendPdaoProps(c *cli.Command, logger log.ColorLogger) (*defendPdaoProp
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/node/distribute-minipools.go
+++ b/rocketpool/node/distribute-minipools.go
@@ -52,7 +52,7 @@ func newDistributeMinipools(c *cli.Command, logger log.ColorLogger) (*distribute
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/node/download-reward-trees.go
+++ b/rocketpool/node/download-reward-trees.go
@@ -38,7 +38,7 @@ func newDownloadRewardsTrees(c *cli.Command, logger log.ColorLogger) (*downloadR
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/node/manage-fee-recipient.go
+++ b/rocketpool/node/manage-fee-recipient.go
@@ -23,13 +23,14 @@ import (
 
 // Manage fee recipient task
 type manageFeeRecipient struct {
-	c   *cli.Command
-	log log.ColorLogger
-	cfg *config.RocketPoolConfig
-	w   wallet.Wallet
-	rp  *rocketpool.RocketPool
-	d   *client.Client
-	bc  beacon.Client
+	c            *cli.Command
+	log          log.ColorLogger
+	cfg          *config.RocketPoolConfig
+	w            wallet.Wallet
+	rp           *rocketpool.RocketPool
+	d            *client.Client
+	bc           beacon.Client
+	stateManager *state.NetworkStateManager
 }
 
 // Create manage fee recipient task
@@ -58,7 +59,7 @@ func newManageFeeRecipient(c *cli.Command, logger log.ColorLogger) (*manageFeeRe
 	}
 
 	// Return task
-	return &manageFeeRecipient{
+	task := &manageFeeRecipient{
 		c:   c,
 		log: logger,
 		cfg: cfg,
@@ -66,7 +67,9 @@ func newManageFeeRecipient(c *cli.Command, logger log.ColorLogger) (*manageFeeRe
 		rp:  rp,
 		d:   d,
 		bc:  bc,
-	}, nil
+	}
+	task.stateManager = state.NewNetworkStateManager(rp, cfg.Smartnode.GetStateManagerContracts(), bc, &task.log)
+	return task, nil
 
 }
 
@@ -85,6 +88,20 @@ func (m *manageFeeRecipient) run(state *state.NetworkState) error {
 	nodeAccount, err := m.w.GetNodeAccount()
 	if err != nil {
 		return err
+	}
+
+	// Fee recipient is always managed for the real node (HD wallet on disk), not the masquerade
+	// address. In observe mode, the global state is keyed for the masquerade address,
+	// so fetch a dedicated state for the real node.
+	am := wallet.NewAddressManager(m.cfg.Smartnode.GetNodeAddressPath())
+	masqAddress, masqErr := am.LoadAddress()
+	if masqErr == nil && am.IsObserve() {
+		m.log.Printlnf("Node is masquerading as %s; fee recipient management always targets the real node (%s) stored on disk.", masqAddress.Hex(), nodeAccount.Address.Hex())
+		var stateErr error
+		state, stateErr = m.stateManager.GetHeadStateForNode(nodeAccount.Address)
+		if stateErr != nil {
+			return fmt.Errorf("error getting network state for real node %s: %w", nodeAccount.Address.Hex(), stateErr)
+		}
 	}
 
 	// Get the fee recipient info for the node

--- a/rocketpool/node/metrics-exporter.go
+++ b/rocketpool/node/metrics-exporter.go
@@ -25,7 +25,7 @@ func runMetricsServer(ctx context.Context, c *cli.Command, logger log.ColorLogge
 	if err != nil {
 		return err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return err
 	}

--- a/rocketpool/node/node.go
+++ b/rocketpool/node/node.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rocket-pool/smartnode/shared/services/alerting"
 	"github.com/rocket-pool/smartnode/shared/services/connectivity"
 	"github.com/rocket-pool/smartnode/shared/services/state"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/services/wallet/keystore/lighthouse"
 	"github.com/rocket-pool/smartnode/shared/services/wallet/keystore/nimbus"
 	"github.com/rocket-pool/smartnode/shared/services/wallet/keystore/prysm"
@@ -148,7 +149,12 @@ func run(c *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	w, err := services.GetHdWallet(c)
+	var w wallet.Wallet
+	if wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath()) {
+		w, err = services.GetWallet(c)
+	} else {
+		w, err = services.GetHdWallet(c)
+	}
 	if err != nil {
 		return err
 	}

--- a/rocketpool/node/node.go
+++ b/rocketpool/node/node.go
@@ -149,8 +149,9 @@ func run(c *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	isObserveMode := wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath())
 	var w wallet.Wallet
-	if wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath()) {
+	if isObserveMode {
 		w, err = services.GetWallet(c)
 	} else {
 		w, err = services.GetHdWallet(c)
@@ -173,6 +174,13 @@ func run(c *cli.Command) error {
 	nodeAccount, err := w.GetNodeAccount()
 	if err != nil {
 		return fmt.Errorf("error getting node account: %w", err)
+	}
+
+	if isObserveMode {
+		red := color.New(color.FgHiRed).SprintFunc()
+		fmt.Println(red("Node daemon is observing address " + nodeAccount.Address.Hex() + "."))
+		fmt.Println(red("Transactions will not be submitted. Fee recipient management targets your real node address."))
+		fmt.Println(red("Run `rocketpool wallet end-masquerade` and restart the node/watchtower daemons when you have finished observing."))
 	}
 
 	// Initialize loggers

--- a/rocketpool/node/provision-express-tickets.go
+++ b/rocketpool/node/provision-express-tickets.go
@@ -43,7 +43,7 @@ func newProvisionExpressTickets(c *cli.Command, logger log.ColorLogger) (*provis
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/node/set-latest-delegate.go
+++ b/rocketpool/node/set-latest-delegate.go
@@ -50,7 +50,7 @@ func newSetUseLatestDelegate(c *cli.Command, logger log.ColorLogger) (*setUseLat
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/node/verify-pdao-props.go
+++ b/rocketpool/node/verify-pdao-props.go
@@ -88,7 +88,7 @@ func newVerifyPdaoProps(c *cli.Command, logger log.ColorLogger) (*verifyPdaoProp
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/check-solo-migrations.go
+++ b/rocketpool/watchtower/check-solo-migrations.go
@@ -55,7 +55,7 @@ func newCheckSoloMigrations(c *cli.Command, logger log.ColorLogger, errorLogger 
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/dissolve-timed-out-minipools.go
+++ b/rocketpool/watchtower/dissolve-timed-out-minipools.go
@@ -43,7 +43,7 @@ func newDissolveTimedOutMinipools(c *cli.Command, logger log.ColorLogger) (*diss
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/finalize-pdao-proposals.go
+++ b/rocketpool/watchtower/finalize-pdao-proposals.go
@@ -37,7 +37,7 @@ func newFinalizePdaoProposals(c *cli.Command, logger log.ColorLogger) (*finalize
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/respond-challenges.go
+++ b/rocketpool/watchtower/respond-challenges.go
@@ -36,7 +36,7 @@ func newRespondChallenges(c *cli.Command, logger log.ColorLogger, m *state.Netwo
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -158,7 +158,7 @@ func newSubmitNetworkBalances(c *cli.Command, logger log.ColorLogger, errorLogge
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/submit-rewards-tree-stateless.go
+++ b/rocketpool/watchtower/submit-rewards-tree-stateless.go
@@ -59,7 +59,7 @@ func newSubmitRewardsTree_Stateless(c *cli.Command, logger log.ColorLogger, erro
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/submit-rpl-price.go
+++ b/rocketpool/watchtower/submit-rpl-price.go
@@ -304,7 +304,7 @@ func newSubmitRplPrice(c *cli.Command, logger log.ColorLogger, errorLogger log.C
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/submit-scrub-minipools.go
+++ b/rocketpool/watchtower/submit-scrub-minipools.go
@@ -92,7 +92,7 @@ func newSubmitScrubMinipools(c *cli.Command, logger log.ColorLogger, errorLogger
 	if err != nil {
 		return nil, err
 	}
-	w, err := services.GetHdWallet(c)
+	w, err := services.GetWallet(c)
 	if err != nil {
 		return nil, err
 	}

--- a/rocketpool/watchtower/watchtower.go
+++ b/rocketpool/watchtower/watchtower.go
@@ -21,9 +21,9 @@ import (
 	"github.com/rocket-pool/smartnode/bindings/utils"
 	"github.com/rocket-pool/smartnode/rocketpool/watchtower/collectors"
 	"github.com/rocket-pool/smartnode/shared/services"
-	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/services/beacon"
 	"github.com/rocket-pool/smartnode/shared/services/state"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/utils/log"
 )
 

--- a/rocketpool/watchtower/watchtower.go
+++ b/rocketpool/watchtower/watchtower.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rocket-pool/smartnode/bindings/utils"
 	"github.com/rocket-pool/smartnode/rocketpool/watchtower/collectors"
 	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/services/beacon"
 	"github.com/rocket-pool/smartnode/shared/services/state"
 	"github.com/rocket-pool/smartnode/shared/utils/log"
@@ -120,7 +121,12 @@ func run(c *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	w, err := services.GetHdWallet(c)
+	var w wallet.Wallet
+	if wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath()) {
+		w, err = services.GetWallet(c)
+	} else {
+		w, err = services.GetHdWallet(c)
+	}
 	if err != nil {
 		return err
 	}

--- a/rocketpool/watchtower/watchtower.go
+++ b/rocketpool/watchtower/watchtower.go
@@ -121,8 +121,9 @@ func run(c *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	isObserveMode := wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath())
 	var w wallet.Wallet
-	if wallet.CheckObserveMode(cfg.Smartnode.GetNodeAddressPath()) {
+	if isObserveMode {
 		w, err = services.GetWallet(c)
 	} else {
 		w, err = services.GetHdWallet(c)
@@ -165,6 +166,13 @@ func run(c *cli.Command) error {
 	nodeAccount, err := w.GetNodeAccount()
 	if err != nil {
 		return fmt.Errorf("error getting node account: %w", err)
+	}
+
+	if isObserveMode {
+		red := color.New(color.FgHiRed).SprintFunc()
+		fmt.Println(red("Watchtower daemon is observing address " + nodeAccount.Address.Hex() + "."))
+		fmt.Println(red("Transactions will not be submitted."))
+		fmt.Println(red("Run `rocketpool wallet end-masquerade` and restart the node/watchtower daemons when you have finished observing."))
 	}
 
 	// Initialize tasks

--- a/shared/services/rocketpool/wallet.go
+++ b/shared/services/rocketpool/wallet.go
@@ -221,8 +221,12 @@ func (c *Client) ExportWallet() (api.ExportWalletResponse, error) {
 }
 
 // Set the node address to an arbitrary address
-func (c *Client) Masquerade(address common.Address) (api.MasqueradeResponse, error) {
-	responseBytes, err := c.callHTTPAPI("POST", "/api/wallet/masquerade", url.Values{"address": {address.Hex()}})
+func (c *Client) Masquerade(address common.Address, observe bool) (api.MasqueradeResponse, error) {
+	observeStr := "false"
+	if observe {
+		observeStr = "true"
+	}
+	responseBytes, err := c.callHTTPAPI("POST", "/api/wallet/masquerade", url.Values{"address": {address.Hex()}, "observe": {observeStr}})
 	if err != nil {
 		return api.MasqueradeResponse{}, fmt.Errorf("Could not masquerade wallet: %w", err)
 	}

--- a/shared/services/services.go
+++ b/shared/services/services.go
@@ -276,50 +276,55 @@ func getAddressManager(cfg *config.RocketPoolConfig) *wallet.AddressManager {
 }
 
 func getWallet(c *cli.Command, cfg *config.RocketPoolConfig, pm *passwords.PasswordManager, am *wallet.AddressManager, ignoreMasquerade bool) (wallet.Wallet, error) {
-	var err error
-	initNodeWallet.Do(func() {
-		var maxFee *big.Int
-		maxFeeFloat := c.Root().Float64("maxFee")
-		if maxFeeFloat == 0 {
-			maxFeeFloat = cfg.Smartnode.ManualMaxFee.Value.(float64)
-		}
-		if maxFeeFloat != 0 {
-			maxFee = eth.GweiToWei(maxFeeFloat)
-		}
+	var maxFee *big.Int
+	maxFeeFloat := c.Root().Float64("maxFee")
+	if maxFeeFloat == 0 {
+		maxFeeFloat = cfg.Smartnode.ManualMaxFee.Value.(float64)
+	}
+	if maxFeeFloat != 0 {
+		maxFee = eth.GweiToWei(maxFeeFloat)
+	}
 
-		var maxPriorityFee *big.Int
-		maxPriorityFeeFloat := c.Root().Float64("maxPrioFee")
-		if maxPriorityFeeFloat == 0 {
-			maxPriorityFeeFloat = cfg.Smartnode.PriorityFee.Value.(float64)
-		}
-		if maxPriorityFeeFloat != 0 {
-			maxPriorityFee = eth.GweiToWei(maxPriorityFeeFloat)
-		}
+	var maxPriorityFee *big.Int
+	maxPriorityFeeFloat := c.Root().Float64("maxPrioFee")
+	if maxPriorityFeeFloat == 0 {
+		maxPriorityFeeFloat = cfg.Smartnode.PriorityFee.Value.(float64)
+	}
+	if maxPriorityFeeFloat != 0 {
+		maxPriorityFee = eth.GweiToWei(maxPriorityFeeFloat)
+	}
 
-		chainId := cfg.Smartnode.GetChainID()
+	chainId := cfg.Smartnode.GetChainID()
+	keychainPath := os.ExpandEnv(cfg.Smartnode.GetValidatorKeychainPath())
 
-		if ignoreMasquerade {
+	if ignoreMasquerade {
+		// Node/watchtower path: cached once for the daemon lifetime, always real HD-derived address.
+		var err error
+		initNodeWallet.Do(func() {
 			nodeWallet, err = wallet.NewHdWallet(os.ExpandEnv(cfg.Smartnode.GetWalletPath()), chainId, maxFee, maxPriorityFee, 0, pm, am)
-		} else {
-			nodeWallet, err = wallet.NewWallet(os.ExpandEnv(cfg.Smartnode.GetNodeAddressPath()), os.ExpandEnv(cfg.Smartnode.GetWalletPath()), chainId, maxFee, maxPriorityFee, 0, pm, am)
-		}
-		if err != nil {
-			return
-		}
+			if err != nil {
+				return
+			}
+			nodeWallet.AddKeystore("lighthouse", lhkeystore.NewKeystore(keychainPath, pm))
+			nodeWallet.AddKeystore("lodestar", lokeystore.NewKeystore(keychainPath, pm))
+			nodeWallet.AddKeystore("nimbus", nmkeystore.NewKeystore(keychainPath, pm))
+			nodeWallet.AddKeystore("prysm", prkeystore.NewKeystore(keychainPath, pm))
+			nodeWallet.AddKeystore("teku", tkkeystore.NewKeystore(keychainPath, pm))
+		})
+		return nodeWallet, err
+	}
 
-		// Keystores
-		lighthouseKeystore := lhkeystore.NewKeystore(os.ExpandEnv(cfg.Smartnode.GetValidatorKeychainPath()), pm)
-		lodestarKeystore := lokeystore.NewKeystore(os.ExpandEnv(cfg.Smartnode.GetValidatorKeychainPath()), pm)
-		nimbusKeystore := nmkeystore.NewKeystore(os.ExpandEnv(cfg.Smartnode.GetValidatorKeychainPath()), pm)
-		prysmKeystore := prkeystore.NewKeystore(os.ExpandEnv(cfg.Smartnode.GetValidatorKeychainPath()), pm)
-		tekuKeystore := tkkeystore.NewKeystore(os.ExpandEnv(cfg.Smartnode.GetValidatorKeychainPath()), pm)
-		nodeWallet.AddKeystore("lighthouse", lighthouseKeystore)
-		nodeWallet.AddKeystore("lodestar", lodestarKeystore)
-		nodeWallet.AddKeystore("nimbus", nimbusKeystore)
-		nodeWallet.AddKeystore("prysm", prysmKeystore)
-		nodeWallet.AddKeystore("teku", tekuKeystore)
-	})
-	return nodeWallet, err
+	// CLI path: fresh call so masquerade state is always current.
+	w, err := wallet.NewWallet(os.ExpandEnv(cfg.Smartnode.GetNodeAddressPath()), os.ExpandEnv(cfg.Smartnode.GetWalletPath()), chainId, maxFee, maxPriorityFee, 0, pm, am)
+	if err != nil {
+		return nil, err
+	}
+	w.AddKeystore("lighthouse", lhkeystore.NewKeystore(keychainPath, pm))
+	w.AddKeystore("lodestar", lokeystore.NewKeystore(keychainPath, pm))
+	w.AddKeystore("nimbus", nmkeystore.NewKeystore(keychainPath, pm))
+	w.AddKeystore("prysm", prkeystore.NewKeystore(keychainPath, pm))
+	w.AddKeystore("teku", tkkeystore.NewKeystore(keychainPath, pm))
+	return w, nil
 }
 
 func getEthClient(c *cli.Command, cfg *config.RocketPoolConfig) (*ExecutionClientManager, error) {

--- a/shared/services/wallet/address-manager.go
+++ b/shared/services/wallet/address-manager.go
@@ -7,16 +7,23 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/goccy/go-json"
 )
 
 const (
 	addressFileMode fs.FileMode = 0664
 )
 
+type addressFile struct {
+	Address string `json:"address"`
+	Observe bool   `json:"observe"`
+}
+
 // Simple class to wrap the node's address file
 type AddressManager struct {
 	path    string
 	address common.Address
+	observe bool
 }
 
 // Creates a new address manager
@@ -26,9 +33,11 @@ func NewAddressManager(path string) *AddressManager {
 	}
 }
 
-// Gets the address saved on disk. Returns false if the address file doesn't exist.
+// Gets the address saved on disk. Returns empty address if the address file doesn't exist.
+// Also loads the observe flag as a side effect; check IsObserve() after calling.
 func (m *AddressManager) LoadAddress() (common.Address, error) {
 	m.address = common.Address{}
+	m.observe = false
 
 	_, err := os.Stat(m.path)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -41,7 +50,15 @@ func (m *AddressManager) LoadAddress() (common.Address, error) {
 	if err != nil {
 		return common.Address{}, fmt.Errorf("error loading address file [%s]: %w", m.path, err)
 	}
-	m.address = common.HexToAddress(string(bytes))
+
+	var af addressFile
+	if err := json.Unmarshal(bytes, &af); err != nil {
+		// backward compat: plain hex address written by older versions
+		m.address = common.HexToAddress(string(bytes))
+	} else {
+		m.address = common.HexToAddress(af.Address)
+		m.observe = af.Observe
+	}
 	return m.address, nil
 }
 
@@ -50,12 +67,21 @@ func (m *AddressManager) GetAddress() common.Address {
 	return m.address
 }
 
-// Sets the node address and saves it to disk
-func (m *AddressManager) SetAndSaveAddress(newAddress common.Address) error {
+// Get the cached observe flag
+func (m *AddressManager) IsObserve() bool {
+	return m.observe
+}
+
+// Sets the node address and observe flag, and saves both to disk
+func (m *AddressManager) SetAndSaveAddress(newAddress common.Address, observe bool) error {
 	m.address = newAddress
-	bytes := []byte(newAddress.Hex())
-	err := os.WriteFile(m.path, bytes, addressFileMode)
+	m.observe = observe
+	af := addressFile{Address: newAddress.Hex(), Observe: observe}
+	bytes, err := json.Marshal(af)
 	if err != nil {
+		return fmt.Errorf("error encoding address file: %w", err)
+	}
+	if err := os.WriteFile(m.path, bytes, addressFileMode); err != nil {
 		return fmt.Errorf("error writing address file [%s] to disk: %w", m.path, err)
 	}
 	return nil
@@ -68,5 +94,16 @@ func (m *AddressManager) DeleteAddressFile() error {
 		return fmt.Errorf("error deleting address file [%s]: %w", m.path, err)
 	}
 	m.address = common.Address{}
+	m.observe = false
 	return nil
+}
+
+// CheckObserveMode reads the address file at path and returns true if observe mode is active.
+// Returns false if the file doesn't exist, can't be read, or observe is not set.
+func CheckObserveMode(path string) bool {
+	am := NewAddressManager(path)
+	if _, err := am.LoadAddress(); err != nil {
+		return false
+	}
+	return am.IsObserve()
 }

--- a/shared/services/wallet/masquerade-wallet.go
+++ b/shared/services/wallet/masquerade-wallet.go
@@ -76,8 +76,8 @@ func (w *masqueradeWallet) GetAddress() (common.Address, error) {
 }
 
 // Change the node's effective address to a different one. Node and watchtower tasks will continue to run normally using the loaded wallet.
-func (w *masqueradeWallet) MasqueradeAsAddress(newAddress common.Address) error {
-	return w.am.SetAndSaveAddress(newAddress)
+func (w *masqueradeWallet) MasqueradeAsAddress(newAddress common.Address, observe bool) error {
+	return w.am.SetAndSaveAddress(newAddress, observe)
 }
 
 // End a masquerade, restoring your node's effective address back to your wallet address if one is loaded

--- a/shared/services/wallet/wallet.go
+++ b/shared/services/wallet/wallet.go
@@ -63,7 +63,7 @@ type Wallet interface {
 	String() (string, error)
 	TestRecoverValidatorKey(pubkey rptypes.ValidatorPubkey, startIndex uint) (uint, error)
 	TestRecovery(derivationPath string, walletIndex uint, mnemonic string) error
-	MasqueradeAsAddress(address common.Address) error
+	MasqueradeAsAddress(address common.Address, observe bool) error
 	EndMasquerade() error
 	GetAddress() (common.Address, error)
 	IsNodeMasquerading() bool
@@ -202,8 +202,8 @@ func (w *hdWallet) GetAddress() (common.Address, error) {
 }
 
 // Change the node's effective address to a different one. Node and watchtower tasks will continue to run normally using the loaded wallet.
-func (w *hdWallet) MasqueradeAsAddress(newAddress common.Address) error {
-	return w.am.SetAndSaveAddress(newAddress)
+func (w *hdWallet) MasqueradeAsAddress(newAddress common.Address, observe bool) error {
+	return w.am.SetAndSaveAddress(newAddress, observe)
 }
 
 // End a masquerade, restoring your node's effective address back to your wallet address if one is loaded

--- a/shared/types/api/wallet.go
+++ b/shared/types/api/wallet.go
@@ -29,6 +29,7 @@ type WalletStatusResponse struct {
 	// NodeAddress always represents the address drived from the wallet stored on disk
 	NodeAddress    common.Address `json:"nodeAddress"`
 	IsMasquerading bool           `json:"isMasquerading"`
+	IsObserve      bool           `json:"isObserve"`
 }
 
 type SetPasswordResponse struct {

--- a/shared/utils/rp/fee-recipient.go
+++ b/shared/utils/rp/fee-recipient.go
@@ -33,6 +33,9 @@ func GetFeeRecipientInfo(rp *rocketpool.RocketPool, bc beacon.Client, nodeAddres
 	}
 
 	mpd := state.NodeDetailsByAddress[nodeAddress]
+	if mpd == nil {
+		return nil, fmt.Errorf("node %s not found in network state", nodeAddress.Hex())
+	}
 
 	// Get info
 	info.SmoothingPoolAddress = state.NetworkDetails.SmoothingPoolAddress


### PR DESCRIPTION
- Masquerade broke when we switched to a long-standing HTTP API process. The real node address is cached once and returned by the API every time the CLI called `GetWallet`. Previously `rocketpool_api` (now deprecated) would make a fresh read of masquerade address from disk every time the CLI called it. This PR resolves the issue by ensuring `GetWallet` returns the correct masquerade state and address when called from the CLI. 

- Added flag `--observe` to the `wallet masquerade` command. When this flag is passed, the node/watchtower loop will use the masqueraded address for all tasks except for `manageFeeRecipient`. Transactions cannot be submitted and oDAO nodes are blocked from using the flag. 