### PR TITLE
teku-v26.7.1

### DIFF
--- a/shared/services/config/rocket-pool-config.go
+++ b/shared/services/config/rocket-pool-config.go
@@ -1739,9 +1739,7 @@ func (cfg *RocketPoolConfig) Validate() []string {
 		_, errors = addAndCheckForDuplicate(portMap, cfg.Lodestar.P2pQuicPort, errors)
 	}
 	if cfg.ConsensusClient.Value.(config.ConsensusClient) == config.ConsensusClient_Teku {
-		portMap, errors = addAndCheckForDuplicate(portMap, cfg.Teku.P2pIpv6Port, errors)
 		portMap, errors = addAndCheckForDuplicate(portMap, cfg.Teku.P2pQuicPort, errors)
-		_, errors = addAndCheckForDuplicate(portMap, cfg.Teku.P2pQuicIpv6Port, errors)
 	}
 
 	return errors

--- a/shared/services/config/rocket-pool-config.go
+++ b/shared/services/config/rocket-pool-config.go
@@ -1739,7 +1739,7 @@ func (cfg *RocketPoolConfig) Validate() []string {
 		_, errors = addAndCheckForDuplicate(portMap, cfg.Lodestar.P2pQuicPort, errors)
 	}
 	if cfg.ConsensusClient.Value.(config.ConsensusClient) == config.ConsensusClient_Teku {
-		portMap, errors = addAndCheckForDuplicate(portMap, cfg.Teku.P2pQuicPort, errors)
+		_, errors = addAndCheckForDuplicate(portMap, cfg.Teku.P2pQuicPort, errors)
 	}
 
 	return errors

--- a/shared/services/config/teku-config.go
+++ b/shared/services/config/teku-config.go
@@ -7,11 +7,9 @@ import (
 )
 
 const (
-	tekuTagTest                string = "consensys/teku:26.7.0"
-	tekuTagProd                string = "consensys/teku:26.7.0"
-	defaultTekuMaxPeers        uint16 = 100
-	defaultTekuP2pIpv6Port     uint16 = 9090
-	defaultTekuP2pQuicIpv6Port uint16 = 8002
+	tekuTagTest         string = "consensys/teku:26.7.1"
+	tekuTagProd         string = "consensys/teku:26.7.1"
+	defaultTekuMaxPeers uint16 = 100
 )
 
 // Configuration for Teku
@@ -39,14 +37,8 @@ type TekuConfig struct {
 	// Custom command line flags for the BN
 	AdditionalBnFlags config.Parameter `yaml:"additionalBnFlags,omitempty"`
 
-	// The IPv6 P2P port for Teku (Teku uses a separate port for IPv6)
-	P2pIpv6Port config.Parameter `yaml:"p2pIpv6Port,omitempty"`
-
 	// The port to use for gossip traffic using the QUIC protocol
 	P2pQuicPort config.Parameter `yaml:"p2pQuicPort,omitempty"`
-
-	// The IPv6 QUIC P2P port (Teku uses a separate port for IPv6 QUIC)
-	P2pQuicIpv6Port config.Parameter `yaml:"p2pQuicIpv6Port,omitempty"`
 
 	// Custom command line flags for the VC
 	AdditionalVcFlags config.Parameter `yaml:"additionalVcFlags,omitempty"`
@@ -132,34 +124,12 @@ func NewTekuConfig(cfg *RocketPoolConfig) *TekuConfig {
 			OverwriteOnUpgrade: false,
 		},
 
-		P2pIpv6Port: config.Parameter{
-			ID:                 "p2pIpv6Port",
-			Name:               "P2P IPv6 Port",
-			Description:        "The port Teku uses for P2P communication over IPv6. Teku requires a dedicated port for IPv6 (separate from the main P2P port). Only used when IPv6 support is enabled.",
-			Type:               config.ParameterType_Uint16,
-			Default:            map[config.Network]interface{}{config.Network_All: defaultTekuP2pIpv6Port},
-			AffectsContainers:  []config.ContainerID{config.ContainerID_Eth2},
-			CanBeBlank:         false,
-			OverwriteOnUpgrade: false,
-		},
-
 		P2pQuicPort: config.Parameter{
 			ID:                 P2pQuicPortID,
 			Name:               "P2P QUIC Port",
 			Description:        "The port to use for P2P traffic using the QUIC protocol.",
 			Type:               config.ParameterType_Uint16,
 			Default:            map[config.Network]interface{}{config.Network_All: defaultP2pQuicPort},
-			AffectsContainers:  []config.ContainerID{config.ContainerID_Eth2},
-			CanBeBlank:         false,
-			OverwriteOnUpgrade: false,
-		},
-
-		P2pQuicIpv6Port: config.Parameter{
-			ID:                 "p2pQuicIpv6Port",
-			Name:               "P2P QUIC IPv6 Port",
-			Description:        "The port Teku uses for P2P QUIC traffic over IPv6. Teku requires a dedicated port for IPv6 QUIC (separate from the main QUIC port). Only used when IPv6 support is enabled.",
-			Type:               config.ParameterType_Uint16,
-			Default:            map[config.Network]interface{}{config.Network_All: defaultTekuP2pQuicIpv6Port},
 			AffectsContainers:  []config.ContainerID{config.ContainerID_Eth2},
 			CanBeBlank:         false,
 			OverwriteOnUpgrade: false,
@@ -187,9 +157,7 @@ func (cfg *TekuConfig) GetParameters() []*config.Parameter {
 		&cfg.UseSlashingProtection,
 		&cfg.ContainerTag,
 		&cfg.AdditionalBnFlags,
-		&cfg.P2pIpv6Port,
 		&cfg.P2pQuicPort,
-		&cfg.P2pQuicIpv6Port,
 		&cfg.AdditionalVcFlags,
 	}
 }

--- a/shared/services/rocketpool/assets/install/scripts/start-bn.sh
+++ b/shared/services/rocketpool/assets/install/scripts/start-bn.sh
@@ -326,12 +326,12 @@ if [ "$CC_CLIENT" = "teku" ]; then
     fi
 
     if [ "$ENABLE_IPV6" = "true" ]; then
-        CMD="$CMD --p2p-interface=0.0.0.0,:: --p2p-port-ipv6=$BN_IPV6_P2P_PORT --p2p-quic-port-ipv6=$BN_IPV6_QUIC_P2P_PORT"
+        CMD="$CMD --p2p-interface=0.0.0.0,:: --p2p-port-ipv6=$BN_P2P_PORT --p2p-quic-port-ipv6=$BN_P2P_QUIC_PORT"
         if [ ! -z "$EXTERNAL_IP6" ]; then
             if [ ! -z "$EXTERNAL_IP" ] && ! expr "$EXTERNAL_IP" : '.*:' >/dev/null; then
-                CMD="$CMD --p2p-advertised-ips $EXTERNAL_IP,$EXTERNAL_IP6 --p2p-advertised-port-ipv6=$BN_IPV6_P2P_PORT"
+                CMD="$CMD --p2p-advertised-ips $EXTERNAL_IP,$EXTERNAL_IP6"
             else
-                CMD="$CMD --p2p-advertised-ips $EXTERNAL_IP6 --p2p-advertised-port-ipv6=$BN_IPV6_P2P_PORT"
+                CMD="$CMD --p2p-advertised-ips $EXTERNAL_IP6"
             fi
         fi
     fi

--- a/shared/services/rocketpool/assets/install/templates/eth2.tmpl
+++ b/shared/services/rocketpool/assets/install/templates/eth2.tmpl
@@ -52,11 +52,10 @@ services:
       {{- end}}
       {{- end}}
       {{- if eq .ConsensusClient.String "teku"}}
-      - "{{.Teku.P2pQuicPort}}:{{.Teku.P2pQuicPort}}/udp"
       {{- if .IsIPv6Enabled}}
-      - "{{.Teku.P2pIpv6Port}}:{{.Teku.P2pIpv6Port}}/udp"
-      - "{{.Teku.P2pIpv6Port}}:{{.Teku.P2pIpv6Port}}/tcp"
-      - "{{.Teku.P2pQuicIpv6Port}}:{{.Teku.P2pQuicIpv6Port}}/udp"
+      - "[::]:{{.Teku.P2pQuicPort}}:{{.Teku.P2pQuicPort}}/udp"
+      {{- else}}
+      - "{{.Teku.P2pQuicPort}}:{{.Teku.P2pQuicPort}}/udp"
       {{- end}}
       {{- end}}
       {{- range $entry := .GetBnOpenPorts}}
@@ -107,9 +106,7 @@ services:
       {{- if eq .ConsensusClient.String "teku"}}
       - TEKU_JVM_HEAP_SIZE={{.Teku.JvmHeapSize}}
       - TEKU_ARCHIVE_MODE={{.Teku.ArchiveMode}}
-      - BN_IPV6_P2P_PORT={{.Teku.P2pIpv6Port}}
       - BN_P2P_QUIC_PORT={{.Teku.P2pQuicPort}}
-      - BN_IPV6_QUIC_P2P_PORT={{.Teku.P2pQuicIpv6Port}}
       {{- else if eq .ConsensusClient.String "prysm"}}
       - BN_RPC_PORT={{.Prysm.RpcPort}}
       - BN_P2P_QUIC_PORT={{.Prysm.P2pQuicPort}}


### PR DESCRIPTION
Teku can now bind ipv4 and ipv6 to the same port.
Defaults still use different ports so we're using the ipv6 flags to pass the same ipv4 port.