### PR TITLE
Fix megapool validator maps

### DIFF
--- a/rocketpool-cli/megapool/stake.go
+++ b/rocketpool-cli/megapool/stake.go
@@ -18,7 +18,7 @@ func getStakableValidator() (uint64, bool, error) {
 	}
 	defer rp.Close()
 	// Get Megapool status
-	status, err := rp.MegapoolStatus(false)
+	status, err := rp.MegapoolStatus(true)
 	if err != nil {
 		return 0, false, err
 	}

--- a/rocketpool/node/collectors/node-collector.go
+++ b/rocketpool/node/collectors/node-collector.go
@@ -638,7 +638,7 @@ func (collector *NodeCollector) Collect(channel chan<- prometheus.Metric) {
 		currentEpoch := state.BeaconConfig.SlotToEpoch(state.BeaconSlotNumber)
 		totalEffectiveBeaconBalance := big.NewInt(0)
 		for _, pubkey := range megapoolPubkeys {
-			info, infoExists := state.MegapoolValidatorInfo[pubkey]
+			info, infoExists := state.GetMegapoolValidatorInfo(megapoolAddress, pubkey)
 			if !infoExists {
 				continue
 			}

--- a/rocketpool/node/notify-final-balance.go
+++ b/rocketpool/node/notify-final-balance.go
@@ -139,7 +139,7 @@ func (t *notifyFinalBalance) run(state *state.NetworkState) error {
 		validatorDetails, exists := state.MegapoolValidatorDetails[pubkey]
 		if !exists {
 			// Skip validators that haven't been staked
-			info, infoExists := state.MegapoolValidatorInfo[pubkey]
+			info, infoExists := state.GetMegapoolValidatorInfo(megapoolAddress, pubkey)
 			if infoExists && !info.ValidatorInfo.Staked {
 				continue
 			}
@@ -147,7 +147,7 @@ func (t *notifyFinalBalance) run(state *state.NetworkState) error {
 			continue
 		}
 
-		validatorInfo, exists := state.MegapoolValidatorInfo[pubkey]
+		validatorInfo, exists := state.GetMegapoolValidatorInfo(megapoolAddress, pubkey)
 		if !exists {
 			// Log
 			t.log.Printlnf("Validator %s not found in the megapool validator info map", pubkey.String())

--- a/rocketpool/node/notify-validator-exit.go
+++ b/rocketpool/node/notify-validator-exit.go
@@ -143,7 +143,7 @@ func (t *notifyValidatorExit) run(state *state.NetworkState) error {
 		validatorDetails, exists := state.MegapoolValidatorDetails[pubkey]
 		if !exists {
 			// Skip validators that haven't been staked
-			info, infoExists := state.MegapoolValidatorInfo[pubkey]
+			info, infoExists := state.GetMegapoolValidatorInfo(megapoolAddress, pubkey)
 			if infoExists && !info.ValidatorInfo.Staked {
 				continue
 			}
@@ -151,7 +151,7 @@ func (t *notifyValidatorExit) run(state *state.NetworkState) error {
 			continue
 		}
 
-		validatorInfo, exists := state.MegapoolValidatorInfo[pubkey]
+		validatorInfo, exists := state.GetMegapoolValidatorInfo(megapoolAddress, pubkey)
 		if !exists {
 			// Log
 			t.log.Printlnf("Validator %s not found in the megapool validator info map", pubkey.String())

--- a/rocketpool/watchtower/submit-network-balances-state_test.go
+++ b/rocketpool/watchtower/submit-network-balances-state_test.go
@@ -1,6 +1,7 @@
 package watchtower
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 	"time"
@@ -8,7 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/rocket-pool/smartnode/bindings/megapool"
+	rptypes "github.com/rocket-pool/smartnode/bindings/types"
+	rpstate "github.com/rocket-pool/smartnode/bindings/utils/state"
 	log "github.com/rocket-pool/smartnode/shared/logger"
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
 	"github.com/rocket-pool/smartnode/shared/services/config"
 	"github.com/rocket-pool/smartnode/shared/services/state"
 )
@@ -174,4 +178,84 @@ func TestGetNetworkBalancesFromState(t *testing.T) {
 	t.Logf("  RETHSupply:              %s", balances.RETHSupply)
 	t.Logf("  NodeCreditBalance:       %s", balances.NodeCreditBalance)
 	t.Logf("  RewardCalc calls:        %d", len(rewardCalc.calls))
+}
+
+// TestMegapoolBalanceWithDuplicatePubkey verifies that a staked validator's
+// beacon balance is still counted when another megapool holds a validator
+func TestMegapoolBalanceWithDuplicatePubkey(t *testing.T) {
+	megapoolAddrA := common.HexToAddress("0xAA00000000000000000000000000000000000000")
+	megapoolAddrB := common.HexToAddress("0xBB00000000000000000000000000000000000000")
+	var pubkey rptypes.ValidatorPubkey
+	pubkey[0] = 0xDD
+
+	oneEth := big.NewInt(1e18)
+	reducedBond := new(big.Int).Mul(big.NewInt(4), oneEth)
+
+	ns := &state.NetworkState{
+		BeaconSlotNumber: 32000,
+		BeaconConfig: beacon.Eth2Config{
+			SlotsPerEpoch: 32,
+		},
+		NetworkDetails: &rpstate.NetworkDetails{
+			ReducedBond: reducedBond,
+		},
+		MegapoolValidatorDetails: state.ValidatorDetailsMap{
+			pubkey: {Pubkey: pubkey, Index: "4", Exists: true, Balance: 32000000000, ActivationEpoch: 0, ExitEpoch: ^uint64(0)},
+		},
+		MegapoolValidatorGlobalIndex: []megapool.ValidatorInfoFromGlobalIndex{
+			{
+				Pubkey:          pubkey[:],
+				MegapoolAddress: megapoolAddrA,
+				ValidatorId:     1,
+				ValidatorInfo: megapool.ValidatorInfo{
+					Staked: true,
+				},
+			},
+			{
+				// A validator in a different megapool reusing the same pubkey,
+				// dequeued immediately (all status flags false)
+				Pubkey:          pubkey[:],
+				MegapoolAddress: megapoolAddrB,
+				ValidatorId:     0,
+				ValidatorInfo:   megapool.ValidatorInfo{},
+			},
+		},
+	}
+
+	// Round-trip through JSON to build MegapoolToPubkeysMap and
+	// MegapoolValidatorInfo the same way createNetworkState does
+	data, err := json.Marshal(ns)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var restored state.NetworkState
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	megapoolDetails := rpstate.NativeMegapoolDetails{
+		Address:        megapoolAddrA,
+		Deployed:       true,
+		UserCapital:    new(big.Int).Mul(big.NewInt(24), oneEth),
+		NodeBond:       new(big.Int).Mul(big.NewInt(8), oneEth),
+		EthBalance:     big.NewInt(0),
+		PendingRewards: big.NewInt(0),
+	}
+
+	task := &submitNetworkBalances{}
+	details, err := task.getMegapoolBalanceDetails(megapoolAddrA, &restored, megapoolDetails, &stubRewardSplitCalculator{})
+	if err != nil {
+		t.Fatalf("getMegapoolBalanceDetails: %v", err)
+	}
+
+	// The staked validator's 32 ETH beacon balance must be counted
+	expectedTotal := new(big.Int).Mul(big.NewInt(32), oneEth)
+	if details.BeaconBalanceTotal.Cmp(expectedTotal) != 0 {
+		t.Errorf("BeaconBalanceTotal: got %s, want %s (staked validator's balance dropped due to duplicate pubkey)", details.BeaconBalanceTotal, expectedTotal)
+	}
+
+	expectedStaking := new(big.Int).Sub(expectedTotal, reducedBond)
+	if details.StakingBalance.Cmp(expectedStaking) != 0 {
+		t.Errorf("StakingBalance: got %s, want %s", details.StakingBalance, expectedStaking)
+	}
 }

--- a/rocketpool/watchtower/submit-network-balances.go
+++ b/rocketpool/watchtower/submit-network-balances.go
@@ -576,7 +576,10 @@ func (t *submitNetworkBalances) getMegapoolBalanceDetails(megapoolAddress common
 	for _, megapoolValidatorKey := range megapoolValidators {
 		// Grab the validator details from the pubkey
 		megapoolValidatorDetails := state.MegapoolValidatorDetails[megapoolValidatorKey]
-		megapoolValidatorInfo := state.MegapoolValidatorInfo[megapoolValidatorKey]
+		megapoolValidatorInfo, exists := state.GetMegapoolValidatorInfo(megapoolAddress, megapoolValidatorKey)
+		if !exists {
+			continue
+		}
 
 		// If the validator was dissolved, exited, or in queue, ignore the beacon balance
 		if megapoolValidatorInfo.ValidatorInfo.Dissolved || megapoolValidatorInfo.ValidatorInfo.Exited || megapoolValidatorInfo.ValidatorInfo.InQueue {

--- a/shared/services/rewards/generator-impl-v11.go
+++ b/shared/services/rewards/generator-impl-v11.go
@@ -1636,8 +1636,14 @@ func (r *treeGeneratorImpl_v11) getSmoothingPoolNodeDetails() error {
 							continue
 						}
 
-						nativeValidatorInfo, exists := r.networkState.MegapoolValidatorInfo[validator]
+						nativeValidatorInfo, exists := r.networkState.GetMegapoolValidatorInfo(megapoolAddress, validator)
 						if !exists {
+							continue
+						}
+
+						// Skip validators that never reached the beacon chain via this megapool
+						vi := nativeValidatorInfo.ValidatorInfo
+						if !(vi.Staked || vi.InPrestake || vi.Exiting || vi.Exited) {
 							continue
 						}
 

--- a/shared/services/rewards/generator-impl-v11.go
+++ b/shared/services/rewards/generator-impl-v11.go
@@ -1643,7 +1643,7 @@ func (r *treeGeneratorImpl_v11) getSmoothingPoolNodeDetails() error {
 
 						// Skip validators that never reached the beacon chain via this megapool
 						vi := nativeValidatorInfo.ValidatorInfo
-						if !(vi.Staked || vi.InPrestake || vi.Exiting || vi.Exited) {
+						if !vi.Staked && !vi.InPrestake && !vi.Exiting && !vi.Exited {
 							continue
 						}
 

--- a/shared/services/rewards/test/mock.go
+++ b/shared/services/rewards/test/mock.go
@@ -686,7 +686,7 @@ func (h *MockHistory) GetEndNetworkState() *state.NetworkState {
 
 		MegapoolValidatorGlobalIndex: []megapool.ValidatorInfoFromGlobalIndex{},
 		MegapoolToPubkeysMap:         make(map[common.Address][]types.ValidatorPubkey),
-		MegapoolValidatorInfo:        make(map[types.ValidatorPubkey]*megapool.ValidatorInfoFromGlobalIndex),
+		MegapoolValidatorInfo:        make(map[state.MegapoolValidatorKey]*megapool.ValidatorInfoFromGlobalIndex),
 		MegapoolDetails:              make(map[common.Address]rpstate.NativeMegapoolDetails),
 		MegapoolValidatorDetails:     make(state.ValidatorDetailsMap),
 	}
@@ -878,7 +878,7 @@ func (h *MockHistory) GetEndNetworkState() *state.NetworkState {
 				}
 				out.MegapoolValidatorGlobalIndex = append(out.MegapoolValidatorGlobalIndex, vifgi)
 				out.MegapoolToPubkeysMap[node.MegapoolAddress()] = append(out.MegapoolToPubkeysMap[node.MegapoolAddress()], pubkey)
-				out.MegapoolValidatorInfo[pubkey] = &vifgi
+				out.MegapoolValidatorInfo[state.MegapoolValidatorKey{MegapoolAddress: node.MegapoolAddress(), Pubkey: pubkey}] = &vifgi
 				out.MegapoolValidatorDetails[pubkey] = beacon.ValidatorStatus{
 					Pubkey:                     pubkey,
 					Index:                      idx,

--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -34,6 +34,12 @@ var _13_Eth = big.NewInt(0).Mul(big.NewInt(13), oneEth)
 
 type ValidatorDetailsMap map[types.ValidatorPubkey]beacon.ValidatorStatus
 
+// MegapoolValidatorKey uniquely identifies a megapool validator.
+type MegapoolValidatorKey struct {
+	MegapoolAddress common.Address
+	Pubkey          types.ValidatorPubkey
+}
+
 func (vdm ValidatorDetailsMap) MarshalJSON() ([]byte, error) {
 	// Marshal as a slice of ValidatorStatus
 	out := make([]beacon.ValidatorStatus, 0, len(vdm))
@@ -102,7 +108,7 @@ type NetworkState struct {
 	MinipoolValidatorDetails ValidatorDetailsMap `json:"validator_details"`
 	MegapoolValidatorDetails ValidatorDetailsMap `json:"megapool_validator_details"`
 
-	MegapoolValidatorInfo map[types.ValidatorPubkey]*megapool.ValidatorInfoFromGlobalIndex `json:"-"`
+	MegapoolValidatorInfo map[MegapoolValidatorKey]*megapool.ValidatorInfoFromGlobalIndex `json:"-"`
 
 	// Oracle DAO details
 	OracleDaoMemberDetails []rpstate.OracleDaoMemberDetails `json:"oracle_dao_member_details"`
@@ -166,8 +172,17 @@ func (s *NetworkState) UnmarshalJSON(data []byte) error {
 	}
 
 	// Rebuild MegapoolToPubkeysMap and MegapoolValidatorInfo from MegapoolValidatorGlobalIndex
+	s.rebuildMegapoolValidatorMaps()
+
+	return nil
+}
+
+// Rebuilds MegapoolToPubkeysMap and MegapoolValidatorInfo from MegapoolValidatorGlobalIndex
+func (s *NetworkState) rebuildMegapoolValidatorMaps() []types.ValidatorPubkey {
 	s.MegapoolToPubkeysMap = make(map[common.Address][]types.ValidatorPubkey)
-	s.MegapoolValidatorInfo = make(map[types.ValidatorPubkey]*megapool.ValidatorInfoFromGlobalIndex)
+	s.MegapoolValidatorInfo = make(map[MegapoolValidatorKey]*megapool.ValidatorInfoFromGlobalIndex)
+	pubkeys := make([]types.ValidatorPubkey, 0, len(s.MegapoolValidatorGlobalIndex))
+	seen := make(map[types.ValidatorPubkey]bool, len(s.MegapoolValidatorGlobalIndex))
 	for i := range s.MegapoolValidatorGlobalIndex {
 		validator := &s.MegapoolValidatorGlobalIndex[i]
 		if len(validator.Pubkey) > 0 {
@@ -175,11 +190,20 @@ func (s *NetworkState) UnmarshalJSON(data []byte) error {
 			s.MegapoolToPubkeysMap[validator.MegapoolAddress] = append(
 				s.MegapoolToPubkeysMap[validator.MegapoolAddress], pubkey,
 			)
-			s.MegapoolValidatorInfo[pubkey] = validator
+			s.MegapoolValidatorInfo[MegapoolValidatorKey{MegapoolAddress: validator.MegapoolAddress, Pubkey: pubkey}] = validator
+			if !seen[pubkey] {
+				seen[pubkey] = true
+				pubkeys = append(pubkeys, pubkey)
+			}
 		}
 	}
+	return pubkeys
+}
 
-	return nil
+// Returns the validator info for the given megapool and pubkey.
+func (s *NetworkState) GetMegapoolValidatorInfo(megapoolAddress common.Address, pubkey types.ValidatorPubkey) (*megapool.ValidatorInfoFromGlobalIndex, bool) {
+	info, exists := s.MegapoolValidatorInfo[MegapoolValidatorKey{MegapoolAddress: megapoolAddress, Pubkey: pubkey}]
+	return info, exists
 }
 
 // Creates a snapshot of the Rocket Pool network state, on both the Execution and Consensus layers.
@@ -308,23 +332,10 @@ func (m *NetworkStateManager) createNetworkState(slotNumber uint64, nodeAddresse
 	currentStep++
 	m.logLine("%d/%d - Retrieved megapool validator global index (%s so far)", currentStep, steps, time.Since(start))
 
-	megapoolValidatorPubkeys := make([]types.ValidatorPubkey, 0, len(state.MegapoolValidatorGlobalIndex))
-	megapoolAddressMap := make(map[common.Address][]types.ValidatorPubkey)
-	megapoolValidatorInfo := make(map[types.ValidatorPubkey]*megapool.ValidatorInfoFromGlobalIndex)
-	for i := range state.MegapoolValidatorGlobalIndex {
-		validator := &state.MegapoolValidatorGlobalIndex[i]
-		if len(validator.Pubkey) > 0 {
-			pubkey := types.ValidatorPubkey(validator.Pubkey)
-			megapoolAddressMap[validator.MegapoolAddress] = append(megapoolAddressMap[validator.MegapoolAddress], pubkey)
-			megapoolValidatorPubkeys = append(megapoolValidatorPubkeys, pubkey)
-			megapoolValidatorInfo[pubkey] = validator
-		}
-	}
-	state.MegapoolToPubkeysMap = megapoolAddressMap
-	state.MegapoolValidatorInfo = megapoolValidatorInfo
+	megapoolValidatorPubkeys := state.rebuildMegapoolValidatorMaps()
 
-	megapoolAddresses := make([]common.Address, 0, len(megapoolAddressMap))
-	for addr := range megapoolAddressMap {
+	megapoolAddresses := make([]common.Address, 0, len(state.MegapoolToPubkeysMap))
+	for addr := range state.MegapoolToPubkeysMap {
 		megapoolAddresses = append(megapoolAddresses, addr)
 	}
 
@@ -579,8 +590,8 @@ func (s *NetworkState) GetMegapoolEligibleBorrowedEth(node *rpstate.NativeNodeDe
 
 	// Iterate over the validators
 	for _, validator := range s.MegapoolToPubkeysMap[node.MegapoolAddress] {
-		megapoolValidatorInfo := s.MegapoolValidatorInfo[validator]
-		if !megapoolValidatorInfo.ValidatorInfo.InPrestake {
+		megapoolValidatorInfo, exists := s.GetMegapoolValidatorInfo(node.MegapoolAddress, validator)
+		if !exists || !megapoolValidatorInfo.ValidatorInfo.InPrestake {
 			continue
 		}
 

--- a/shared/services/state/network-state_test.go
+++ b/shared/services/state/network-state_test.go
@@ -227,8 +227,8 @@ func buildTestState() *NetworkState {
 		megapoolAddrA: {megapoolPubkey},
 	}
 
-	megapoolValidatorInfo := map[types.ValidatorPubkey]*megapool.ValidatorInfoFromGlobalIndex{
-		megapoolPubkey: &megapoolValidatorGlobalIndex[0],
+	megapoolValidatorInfo := map[MegapoolValidatorKey]*megapool.ValidatorInfoFromGlobalIndex{
+		{MegapoolAddress: megapoolAddrA, Pubkey: megapoolPubkey}: &megapoolValidatorGlobalIndex[0],
 	}
 
 	megapoolDetails := map[common.Address]rpstate.NativeMegapoolDetails{
@@ -500,4 +500,85 @@ func TestUnmarshalDuplicateMinipoolErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for duplicate minipool address, got nil")
 	}
+}
+
+func TestDuplicatePubkeyAcrossMegapools(t *testing.T) {
+	megapoolAddrA := common.HexToAddress("0xAA00000000000000000000000000000000000000")
+	megapoolAddrB := common.HexToAddress("0xBB00000000000000000000000000000000000000")
+	pubkey := newTestPubkey(0xDD)
+
+	state := &NetworkState{
+		MinipoolValidatorDetails: ValidatorDetailsMap{},
+		MegapoolValidatorDetails: ValidatorDetailsMap{},
+		MegapoolValidatorGlobalIndex: []megapool.ValidatorInfoFromGlobalIndex{
+			{
+				Pubkey:          pubkey[:],
+				MegapoolAddress: megapoolAddrA,
+				ValidatorId:     1,
+				ValidatorInfo: megapool.ValidatorInfo{
+					Staked: true,
+				},
+			},
+			{
+				// A validator in a different megapool reusing the same pubkey,
+				// dequeued immediately (all status flags false)
+				Pubkey:          pubkey[:],
+				MegapoolAddress: megapoolAddrB,
+				ValidatorId:     0,
+				ValidatorInfo:   megapool.ValidatorInfo{},
+			},
+		},
+	}
+
+	checkState := func(t *testing.T, s *NetworkState) {
+		t.Helper()
+
+		if len(s.MegapoolValidatorInfo) != 2 {
+			t.Errorf("MegapoolValidatorInfo count: got %d, want 2", len(s.MegapoolValidatorInfo))
+		}
+
+		infoA, exists := s.GetMegapoolValidatorInfo(megapoolAddrA, pubkey)
+		if !exists {
+			t.Fatal("validator info for megapool A not found")
+		}
+		if !infoA.ValidatorInfo.Staked {
+			t.Error("megapool A validator lost Staked=true (overwritten by the duplicate pubkey)")
+		}
+		if infoA.ValidatorId != 1 {
+			t.Errorf("megapool A ValidatorId: got %d, want 1", infoA.ValidatorId)
+		}
+
+		infoB, exists := s.GetMegapoolValidatorInfo(megapoolAddrB, pubkey)
+		if !exists {
+			t.Fatal("validator info for megapool B not found")
+		}
+		if infoB.ValidatorInfo.Staked {
+			t.Error("megapool B validator should not be staked")
+		}
+
+		if len(s.MegapoolToPubkeysMap[megapoolAddrA]) != 1 {
+			t.Errorf("MegapoolToPubkeysMap[A] count: got %d, want 1", len(s.MegapoolToPubkeysMap[megapoolAddrA]))
+		}
+		if len(s.MegapoolToPubkeysMap[megapoolAddrB]) != 1 {
+			t.Errorf("MegapoolToPubkeysMap[B] count: got %d, want 1", len(s.MegapoolToPubkeysMap[megapoolAddrB]))
+		}
+	}
+
+	// The rebuild helper is used by both createNetworkState and UnmarshalJSON
+	pubkeys := state.rebuildMegapoolValidatorMaps()
+	if len(pubkeys) != 1 {
+		t.Errorf("deduplicated pubkey list: got %d entries, want 1", len(pubkeys))
+	}
+	checkState(t, state)
+
+	// Round-trip through JSON to exercise the UnmarshalJSON rebuild path
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var restored NetworkState
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	checkState(t, &restored)
 }

--- a/shared/services/state/static_provider_test.go
+++ b/shared/services/state/static_provider_test.go
@@ -183,7 +183,7 @@ func TestStaticProviderMegapoolToPubkeysMap(t *testing.T) {
 	// Every pubkey in the map must have a corresponding MegapoolValidatorInfo entry
 	for addr, pubkeys := range ns.MegapoolToPubkeysMap {
 		for _, pk := range pubkeys {
-			if _, ok := ns.MegapoolValidatorInfo[pk]; !ok {
+			if _, ok := ns.GetMegapoolValidatorInfo(addr, pk); !ok {
 				t.Errorf("pubkey from MegapoolToPubkeysMap[%s] not found in MegapoolValidatorInfo", addr.Hex())
 			}
 		}
@@ -222,7 +222,7 @@ func TestStaticProviderMegapoolValidatorInfo(t *testing.T) {
 	}
 
 	// Every entry in MegapoolValidatorInfo must point back into MegapoolValidatorGlobalIndex
-	for pk, info := range ns.MegapoolValidatorInfo {
+	for key, info := range ns.MegapoolValidatorInfo {
 		found := false
 		for i := range ns.MegapoolValidatorGlobalIndex {
 			candidate := &ns.MegapoolValidatorGlobalIndex[i]
@@ -232,7 +232,7 @@ func TestStaticProviderMegapoolValidatorInfo(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("MegapoolValidatorInfo[%x] does not point into MegapoolValidatorGlobalIndex", pk[:4])
+			t.Errorf("MegapoolValidatorInfo[%s/%x] does not point into MegapoolValidatorGlobalIndex", key.MegapoolAddress.Hex(), key.Pubkey[:4])
 		}
 	}
 }


### PR DESCRIPTION
Fixes a bug where megapool validator info was keyed by pubkey alone even though pubkeys are only unique per megapool. MegapoolValidatorInfo is now keyed by {megapool address, pubkey} with all consumers updated.