### PR TITLE
Don't require synced clients when skipping validator key recovery

### DIFF
--- a/rocketpool-cli/wallet/commands.go
+++ b/rocketpool-cli/wallet/commands.go
@@ -146,7 +146,7 @@ func RegisterCommands(app *cli.Command, name string, aliases []string) {
 						c.String("address"),
 						c.Bool("skip-validator-key-recovery"),
 						c.String("derivation-path"),
-						c.Uint("wallet-index"),
+						uint(c.Uint64("wallet-index")),
 						c.Bool("yes"),
 					)
 
@@ -236,7 +236,7 @@ func RegisterCommands(app *cli.Command, name string, aliases []string) {
 						c.String("address"),
 						c.Bool("skip-validator-key-recovery"),
 						c.String("derivation-path"),
-						c.Uint("wallet-index"),
+						uint(c.Uint64("wallet-index")),
 						c.Bool("yes"),
 					)
 

--- a/rocketpool-cli/wallet/recover.go
+++ b/rocketpool-cli/wallet/recover.go
@@ -14,10 +14,15 @@ import (
 
 func recoverWallet(password, mnemonic, addressFlag string, skipValidatorKeyRecovery bool, derivationPath string, walletIndex uint, yes bool) error {
 
-	// Get RP client
-	rp, ready, err := rocketpool.NewClient().WithStatus()
-	if err != nil {
-		return err
+	// Only check client status when recovering validator keys
+	rp := rocketpool.NewClient()
+	ready := false
+	if !skipValidatorKeyRecovery {
+		var err error
+		rp, ready, err = rp.WithStatus()
+		if err != nil {
+			return err
+		}
 	}
 	defer rp.Close()
 

--- a/rocketpool-cli/wallet/test.go
+++ b/rocketpool-cli/wallet/test.go
@@ -13,10 +13,15 @@ import (
 
 func testRecovery(mnemonic, addressFlag string, skipValidatorKeyRecovery bool, derivationPath string, walletIndex uint, yes bool) error {
 
-	// Get RP client
-	rp, ready, err := rocketpool.NewClient().WithStatus()
-	if err != nil {
-		return err
+	// Only check client status when testing validator key recovery
+	rp := rocketpool.NewClient()
+	ready := false
+	if !skipValidatorKeyRecovery {
+		var err error
+		rp, ready, err = rp.WithStatus()
+		if err != nil {
+			return err
+		}
 	}
 	defer rp.Close()
 

--- a/rocketpool/api/wallet/recover.go
+++ b/rocketpool/api/wallet/recover.go
@@ -41,7 +41,9 @@ func recoverWalletWithParams(c *cli.Command, mnemonic string, skipValidatorKeyRe
 	if err != nil {
 		return nil, err
 	}
+	// Chain clients are only needed to discover and filter validator pubkeys
 	var rp *rocketpool.RocketPool
+	var bc beacon.Client
 	if !skipValidatorKeyRecovery {
 		if err := services.RequireRocketStorage(c); err != nil {
 			return nil, err
@@ -50,10 +52,10 @@ func recoverWalletWithParams(c *cli.Command, mnemonic string, skipValidatorKeyRe
 		if err != nil {
 			return nil, err
 		}
-	}
-	bc, err := services.GetBeaconClient(c)
-	if err != nil {
-		return nil, err
+		bc, err = services.GetBeaconClient(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Response
@@ -111,7 +113,9 @@ func searchAndRecoverWalletWithParams(c *cli.Command, mnemonic string, address c
 	if err != nil {
 		return nil, err
 	}
+	// Chain clients are only needed to discover and filter validator pubkeys
 	var rp *rocketpool.RocketPool
+	var bc beacon.Client
 	if !skipValidatorKeyRecovery {
 		if err := services.RequireRocketStorage(c); err != nil {
 			return nil, err
@@ -120,10 +124,10 @@ func searchAndRecoverWalletWithParams(c *cli.Command, mnemonic string, address c
 		if err != nil {
 			return nil, err
 		}
-	}
-	bc, err := services.GetBeaconClient(c)
-	if err != nil {
-		return nil, err
+		bc, err = services.GetBeaconClient(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Response

--- a/rocketpool/api/wallet/test.go
+++ b/rocketpool/api/wallet/test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rocket-pool/smartnode/bindings/rocketpool"
 
 	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
 	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/types/api"
 )
@@ -20,7 +21,9 @@ func testRecoverWalletWithParams(c *cli.Command, mnemonic string, skipValidatorK
 	if err != nil {
 		return nil, err
 	}
+	// Chain clients are only needed to discover and filter validator pubkeys
 	var rp *rocketpool.RocketPool
+	var bc beacon.Client
 	if !skipValidatorKeyRecovery {
 		if err := services.RequireRocketStorage(c); err != nil {
 			return nil, err
@@ -29,11 +32,10 @@ func testRecoverWalletWithParams(c *cli.Command, mnemonic string, skipValidatorK
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	bc, err := services.GetBeaconClient(c)
-	if err != nil {
-		return nil, err
+		bc, err = services.GetBeaconClient(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create a blank wallet
@@ -88,7 +90,9 @@ func testSearchAndRecoverWalletWithParams(c *cli.Command, mnemonic string, addre
 	if err != nil {
 		return nil, err
 	}
+	// Chain clients are only needed to discover and filter validator pubkeys
 	var rp *rocketpool.RocketPool
+	var bc beacon.Client
 	if !skipValidatorKeyRecovery {
 		if err := services.RequireRocketStorage(c); err != nil {
 			return nil, err
@@ -97,11 +101,10 @@ func testSearchAndRecoverWalletWithParams(c *cli.Command, mnemonic string, addre
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	bc, err := services.GetBeaconClient(c)
-	if err != nil {
-		return nil, err
+		bc, err = services.GetBeaconClient(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create a blank wallet


### PR DESCRIPTION
We don't need synced clients if not recovering validator keys. 
This PR also fixes an issue with the wallet-index param.