### PR TITLE
erigon-v3.6.0

### DIFF
--- a/shared/services/config/erigon-params.go
+++ b/shared/services/config/erigon-params.go
@@ -8,8 +8,8 @@ import (
 
 // Constants
 const (
-	erigonTagProd            string = "erigontech/erigon:v3.5.5"
-	erigonTagTest            string = "erigontech/erigon:v3.5.5"
+	erigonTagProd            string = "erigontech/erigon:v3.6.0"
+	erigonTagTest            string = "erigontech/erigon:v3.6.0"
 	erigonEventLogInterval   int    = 1000
 	erigonStopSignal         string = "SIGINT"
 	defaultErigonTorrentPort uint16 = 42069

--- a/shared/services/rocketpool/assets/install/scripts/start-ec.sh
+++ b/shared/services/rocketpool/assets/install/scripts/start-ec.sh
@@ -561,7 +561,7 @@ if [ "$CLIENT" = "erigon" ]; then
     fi
 
     if [ "$EC_PRUNING_MODE" = "fullNode" ]; then
-        CMD="$CMD --prune.mode=blocks"
+        CMD="$CMD --prune.mode=blocks --prune.include-receipts --prune.receipts.distance=keep-all"
     fi
 
     if [ "$EC_PRUNING_MODE" = "historyExpiry" ]; then


### PR DESCRIPTION
v3.6 is dropping receipts by default so a full node needs to use new flags to keep them.