### PR TITLE
shared/types/eth2: use b.Loop in streaming benchmarks

### DIFF
--- a/shared/types/eth2/streaming_test.go
+++ b/shared/types/eth2/streaming_test.go
@@ -64,7 +64,7 @@ func TestDecodeSSZSizeFallback(t *testing.T) {
 
 func BenchmarkBeaconStateDecodeStreaming(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		state := &deneb.BeaconState{}
 		if err := generic.SSZ.UnmarshalSSZReader(state, bytes.NewReader(testState), len(testState)); err != nil {
 			b.Fatalf("Failed to stream-unmarshal test state: %v", err)
@@ -74,7 +74,7 @@ func BenchmarkBeaconStateDecodeStreaming(b *testing.B) {
 
 func BenchmarkBeaconStateDecodeBuffered(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		state := &deneb.BeaconState{}
 		if err := generic.SSZ.UnmarshalSSZ(state, testState); err != nil {
 			b.Fatalf("Failed to unmarshal test state: %v", err)
@@ -89,7 +89,7 @@ func BenchmarkValidatorProof(b *testing.B) {
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := state.ValidatorProof(555555); err != nil {
 			b.Fatalf("Failed to get validator proof: %v", err)
 		}


### PR DESCRIPTION
Update the SSZ streaming benchmarks to use `testing.B.Loop` instead of manually iterating over `b.N`.

This follows the current Go benchmark API and lets the testing package manage loop timing consistently. Benchmark behavior is otherwise unchanged.

bloop: replace "for i := range b.N" or "for range b.N" in a benchmark with "for b.Loop()", and remove any preceding calls to b.StopTimer, b.StartTimer, and b.ResetTimer.

B.Loop intentionally defeats compiler optimizations such as inlining so that the benchmark is not entirely optimized away. Currently, however, it may cause benchmarks to become slower in some cases due to increased allocation;

More info cab see https://go.dev/issue/73137