### PR TITLE
refactor: append EIP-712 signature bytes directly

### DIFF
--- a/rocketpool/eip712/eip712.go
+++ b/rocketpool/eip712/eip712.go
@@ -56,5 +56,5 @@ func (c *Components) UnmarshalText(text []byte) error {
 }
 
 func (c *Components) MarshalText() ([]byte, error) {
-	return []byte(fmt.Sprintf("0x%x%x%x", c.R, c.S, c.V)), nil
+	return fmt.Appendf(nil, "0x%x%x%x", c.R, c.S, c.V), nil
 }


### PR DESCRIPTION
MarshalText currently formats an intermediate string and then converts it to []byte. 

Use `fmt.Appendf` with a nil destination to produce the same 0x-prefixed EIP-712 representation directly. 

TestRoundTrip continues to cover the encoding.