### PR TITLE
fix: improve relay and fixture diagnostics

### DIFF
--- a/shared/services/flashbots/bundle.go
+++ b/shared/services/flashbots/bundle.go
@@ -126,7 +126,7 @@ func (b *Bundle) SetRevertingTxHashes(revertingTxHashes []string) {
 // SetReplacementUuid sets the replacement UUID for this bundle that can be used to cancel/replace this bundle
 func (b *Bundle) SetReplacementUuid(replacementUuid string) error {
 	if b.uuidAlreadySend {
-		return errors.New("bundle already send to relay, cant change uuid")
+		return errors.New("bundle already sent to relay, can't change uuid")
 	}
 
 	b.replacementUuid = replacementUuid

--- a/shared/services/rewards/mock_v11_test.go
+++ b/shared/services/rewards/mock_v11_test.go
@@ -847,7 +847,7 @@ func TestInsufficientEthForBonusesesV11(tt *testing.T) {
 	odaoNodes := history.GetDefaultMockODAONodes()
 	history.Nodes = append(history.Nodes, odaoNodes...)
 
-	// Ovewrite the SP balance to a value under the bonus commission
+	// Overwrite the SP balance to a value under the bonus commission
 	history.NetworkDetails.SmoothingPoolBalance = big.NewInt(1100)
 	// Set the SP voter share to 0
 	history.NetworkDetails.PendingVoterShareEth = big.NewInt(100)

--- a/shared/services/rewards/test/rocketpool.go
+++ b/shared/services/rewards/test/rocketpool.go
@@ -26,7 +26,7 @@ import (
 // The latter is useful to probe specific behaviors such as opt-in/opt-out eligibility timing,
 // node weight, smoothing pool status, etc.
 //
-// Because recording responses ties the test to a specific version of the contracts and therefor
+// Because recording responses ties the test to a specific version of the contracts and therefore
 // the client-side code, the interface we need to mock should be as minimized as possible, and the
 // recorded data should tightly match that interface. That is, no recorded response should encode
 // something like the contract address data are being requested from, but instead the high-level

--- a/shared/types/api/wallet.go
+++ b/shared/types/api/wallet.go
@@ -27,7 +27,7 @@ type WalletStatusResponse struct {
 	// When masquerading, AccountAddress represents the masqueraded address.
 	// When using a normal wallet, AccountAddress represents the address derived from the wallet stored on disk
 	AccountAddress common.Address `json:"accountAddress"`
-	// NodeAddress always represents the address drived from the wallet stored on disk
+	// NodeAddress always represents the address derived from the wallet stored on disk
 	NodeAddress    common.Address `json:"nodeAddress"`
 	IsMasquerading bool           `json:"isMasquerading"`
 	IsObserve      bool           `json:"isObserve"`


### PR DESCRIPTION
Update the Flashbots relay diagnostic wording and rewards fixture/API comments so `sent`, `can't`, `therefore`, `Overwrite`, and `derived` describe the actual state and grammar. 