### PR TITLE
draft: proof of concept for plan-before-write validator-key recovery (#407, #572)

### DIFF
--- a/rocketpool/api/wallet/recover.go
+++ b/rocketpool/api/wallet/recover.go
@@ -276,8 +276,9 @@ func recoverNodeKeys(c *cli.Command, rp *rocketpool.RocketPool, bc beacon.Client
 		}
 	}
 
+	pubkeys = filteredPubkeys
 	pubkeyMap := map[types.ValidatorPubkey]bool{}
-	for _, pubkey := range pubkeys {
+	for _, pubkey := range filteredPubkeys {
 		pubkeyMap[pubkey] = true
 	}
 

--- a/shared/services/recovery/README.md
+++ b/shared/services/recovery/README.md
@@ -1,0 +1,55 @@
+# Smartnode Safe Recovery Planner
+
+This package implements the **two-phase (Plan-Before-Write) recovery architecture** and per-key diagnosis for Rocket Pool Smartnode validator keys, addressing issues **#407**, **#440**, and **#572**.
+
+---
+
+## The Problem
+
+Previously, Smartnode's key recovery routines (`wallet recover`, `wallet rebuild`, and `wallet test-recovery`) immediately persisted keys to disk as soon as each individual key was discovered. In mixed-key deployments (a combination of mnemonic-derived keys, imported custom EIP-2335 keystores, legacy minipools, and megapool validators), if recovery succeeded for several keys but subsequently failed on a later key (e.g., missing custom keystore, corrupt file, invalid password, or derivation limit exceeded), the node was left in an inconsistent, partially-recovered state.
+
+Additionally, inactive/exited validators on the Beacon chain were filtered into an active list, but the target discovery map was populated from the original unfiltered list, causing exited validators to trigger false recovery failures (Issue #407).
+
+---
+
+## Architectural Principles
+
+### 1. Two-Phase Execution (Plan-Before-Write)
+
+Recovery is strictly separated into two independent phases:
+
+1. **Plan Phase (`PlanValidatorRecovery`)**:
+   - Pure, read-only discovery and diagnosis.
+   - Evaluates all expected minipool and megapool public keys against Beacon chain validator states, installed client keystores, imported custom keys (`custom_keys/`), and mnemonic derivation limits.
+   - Assigns a deterministic `DiscoveryOutcome` to every single public key.
+   - **Zero file mutations, zero keystore modifications.**
+
+2. **Commit Phase (`CommitPlan`)**:
+   - Evaluates the safety invariants of the plan before touching disk.
+   - By default, **any** unresolved or invalid in-scope validator key causes the commit phase to abort immediately before any keystore is touched (`ErrUnresolvedKeysRefusingCommit`).
+   - Only when all in-scope keys are resolved (or when the operator explicitly passes `--allow-partial-recover`), the validated keys are committed to disk via `KeyWriter`.
+
+### 2. Deterministic Per-Key Outcomes
+
+Each public key is assigned a deterministic diagnosis:
+- **`mnemonic_valid`**: Successfully derived from the node mnemonic and verified against the public key.
+- **`custom_valid`**: Loaded from an imported EIP-2335 keystore and decrypted with the provided password.
+- **`installed_valid`**: Key material already exists and is valid in the node's validator client keystores.
+- **`unresolved`**: Not found in custom keys or within the derivation search window (`bucketLimit`).
+- **`invalid_material`**: Corrupt keystore, incorrect password, or pubkey/private key mismatch.
+- **`excluded_inactive`**: Exited or inactive on the Beacon chain; safely excluded from recovery.
+
+Commit status is tracked explicitly:
+- `written`: Successfully written to keystores.
+- `skipped_already_installed`: Key was already installed; avoided redundant overwrite.
+- `skipped_excluded`: Inactive validator; no keys written.
+- `skipped_partial`: Unresolved key omitted during an operator-approved partial recovery.
+- `not_attempted`: Write phase was blocked because plan was invalid or unapproved.
+
+### 3. Partial Recovery Behavior (`--allow-partial-recover`)
+
+When an operator cannot locate a lost custom key or wants to bring online only the validators that could be found, passing `--allow-partial-recover` allows Smartnode to commit all resolved keys while recording which keys were skipped (`skipped_partial`). This prevents operators from being stuck when one obsolete or migrated key cannot be derived.
+
+### 4. Exclusion of Cross-Client Rollback
+
+Smartnode interfaces with diverse external Validator Clients (Lighthouse, Nimbus, Prysm, Teku, Lodestar), each with its own local keystore formats and disk layouts. This architecture provides a **pre-mutation safety guarantee** (ensuring all keys are validated in memory before any writes begin). It does not attempt transactional cross-client atomic rollback in the event of hardware or OS-level disk failures mid-write. Operators can safely re-run recovery idempotently at any time.

--- a/shared/services/recovery/committer.go
+++ b/shared/services/recovery/committer.go
@@ -1,0 +1,111 @@
+package recovery
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
+)
+
+// ErrUnresolvedKeysRefusingCommit is returned when default mode encounters unresolved or invalid keys.
+var ErrUnresolvedKeysRefusingCommit = errors.New("refusing to commit recovery: plan contains unresolved or invalid validator keys")
+
+// CommitPlan applies a pre-calculated RecoveryPlan using the provided KeyWriter.
+// By default, if any in-scope key is unresolved or invalid, zero writes occur and an error is returned.
+// When allowPartial is true, resolved keys are committed while unresolved ones are skipped and recorded.
+func CommitPlan(plan *RecoveryPlan, writer KeyWriter, allowPartial bool) error {
+	if err := validateCommitPreconditions(plan, writer, allowPartial); err != nil {
+		return err
+	}
+
+	for i := range plan.Entries {
+		if err := commitEntry(&plan.Entries[i], writer); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateCommitPreconditions verifies parameters and enforces the fail-fast safety invariant.
+func validateCommitPreconditions(plan *RecoveryPlan, writer KeyWriter, allowPartial bool) error {
+	if plan == nil {
+		return errors.New("nil recovery plan provided")
+	}
+	if writer == nil {
+		return errors.New("nil key writer provided")
+	}
+
+	if !allowPartial && plan.HasUnresolvedOrInvalid() {
+		return fmt.Errorf("%w: %d unresolved, %d invalid (run with --allow-partial-recover to write only resolved keys)",
+			ErrUnresolvedKeysRefusingCommit, plan.TotalUnresolved, plan.TotalInvalid)
+	}
+
+	return nil
+}
+
+// commitEntry routes key persistence or status updates for a single plan entry.
+func commitEntry(entry *ValidatorPlanEntry, writer KeyWriter) error {
+	switch entry.DiscoveryOutcome {
+	case OutcomeExcludedInactive:
+		entry.CommitOutcome = CommitSkippedExcluded
+		return nil
+
+	case OutcomeInstalledValid:
+		entry.CommitOutcome = CommitSkippedAlreadyInstalled
+		return nil
+
+	case OutcomeUnresolved, OutcomeInvalidMaterial:
+		entry.CommitOutcome = CommitSkippedPartial
+		return nil
+
+	case OutcomeMnemonicValid:
+		return commitMnemonicEntry(entry, writer)
+
+	case OutcomeCustomValid:
+		return commitCustomEntry(entry, writer)
+
+	default:
+		entry.CommitOutcome = CommitNotAttempted
+		return nil
+	}
+}
+
+// commitMnemonicEntry validates and persists a mnemonic-derived validator key.
+func commitMnemonicEntry(entry *ValidatorPlanEntry, writer KeyWriter) error {
+	if entry.WalletIndex == nil || entry.PrivateKey == nil {
+		entry.CommitOutcome = CommitFailed
+		return fmt.Errorf("incomplete key material for mnemonic-derived pubkey %s", entry.Pubkey.Hex())
+	}
+
+	vk := wallet.ValidatorKey{
+		PublicKey:      entry.Pubkey,
+		PrivateKey:     entry.PrivateKey,
+		DerivationPath: entry.DerivationPath,
+		WalletIndex:    *entry.WalletIndex,
+	}
+
+	if err := writer.SaveValidatorKey(vk); err != nil {
+		entry.CommitOutcome = CommitFailed
+		return fmt.Errorf("error writing mnemonic validator key %s: %w", entry.Pubkey.Hex(), err)
+	}
+
+	entry.CommitOutcome = CommitWritten
+	return nil
+}
+
+// commitCustomEntry validates and persists an imported custom validator keystore.
+func commitCustomEntry(entry *ValidatorPlanEntry, writer KeyWriter) error {
+	if entry.PrivateKey == nil {
+		entry.CommitOutcome = CommitFailed
+		return fmt.Errorf("incomplete key material for custom pubkey %s", entry.Pubkey.Hex())
+	}
+
+	if err := writer.StoreValidatorKey(entry.PrivateKey, entry.DerivationPath); err != nil {
+		entry.CommitOutcome = CommitFailed
+		return fmt.Errorf("error storing custom validator key %s: %w", entry.Pubkey.Hex(), err)
+	}
+
+	entry.CommitOutcome = CommitWritten
+	return nil
+}

--- a/shared/services/recovery/mock_writer_test.go
+++ b/shared/services/recovery/mock_writer_test.go
@@ -1,0 +1,157 @@
+package recovery
+
+import (
+	"sync"
+
+	eth2types "github.com/wealdtech/go-eth2-types/v2"
+
+	"github.com/rocket-pool/smartnode/bindings/types"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
+)
+
+// StoreCall records a call to StoreValidatorKey.
+type StoreCall struct {
+	Key  *eth2types.BLSPrivateKey
+	Path string
+}
+
+// MockKeyWriter is a thread-safe spy implementation of KeyWriter that records all write attempts.
+type MockKeyWriter struct {
+	mu                     sync.Mutex
+	saveValidatorKeyCalls  []wallet.ValidatorKey
+	storeValidatorKeyCalls []StoreCall
+
+	SaveError  error
+	StoreError error
+}
+
+func NewMockKeyWriter() *MockKeyWriter {
+	return &MockKeyWriter{
+		saveValidatorKeyCalls:  make([]wallet.ValidatorKey, 0),
+		storeValidatorKeyCalls: make([]StoreCall, 0),
+	}
+}
+
+func (m *MockKeyWriter) SaveValidatorKey(key wallet.ValidatorKey) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.SaveError != nil {
+		return m.SaveError
+	}
+	m.saveValidatorKeyCalls = append(m.saveValidatorKeyCalls, key)
+	return nil
+}
+
+func (m *MockKeyWriter) StoreValidatorKey(key *eth2types.BLSPrivateKey, path string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.StoreError != nil {
+		return m.StoreError
+	}
+	m.storeValidatorKeyCalls = append(m.storeValidatorKeyCalls, StoreCall{Key: key, Path: path})
+	return nil
+}
+
+func (m *MockKeyWriter) TotalWrites() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.saveValidatorKeyCalls) + len(m.storeValidatorKeyCalls)
+}
+
+func (m *MockKeyWriter) SaveCalls() []wallet.ValidatorKey {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copied := make([]wallet.ValidatorKey, len(m.saveValidatorKeyCalls))
+	copy(copied, m.saveValidatorKeyCalls)
+	return copied
+}
+
+func (m *MockKeyWriter) StoreCalls() []StoreCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copied := make([]StoreCall, len(m.storeValidatorKeyCalls))
+	copy(copied, m.storeValidatorKeyCalls)
+	return copied
+}
+
+func (m *MockKeyWriter) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saveValidatorKeyCalls = m.saveValidatorKeyCalls[:0]
+	m.storeValidatorKeyCalls = m.storeValidatorKeyCalls[:0]
+	m.SaveError = nil
+	m.StoreError = nil
+}
+
+// MockKeyDeriver provides in-memory mock validator keys for derivation testing.
+type MockKeyDeriver struct {
+	mu          sync.RWMutex
+	keysByIndex map[uint]wallet.ValidatorKey
+}
+
+func NewMockKeyDeriver() *MockKeyDeriver {
+	return &MockKeyDeriver{
+		keysByIndex: make(map[uint]wallet.ValidatorKey),
+	}
+}
+
+func (m *MockKeyDeriver) AddKey(index uint, key wallet.ValidatorKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.keysByIndex[index] = key
+}
+
+func (m *MockKeyDeriver) GetValidatorKeys(startIndex uint, length uint) ([]wallet.ValidatorKey, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	res := make([]wallet.ValidatorKey, 0, length)
+	for i := startIndex; i < startIndex+length; i++ {
+		if k, ok := m.keysByIndex[i]; ok {
+			res = append(res, k)
+		}
+	}
+	return res, nil
+}
+
+// MockCustomKeyProvider provides custom keys for testing.
+type MockCustomKeyProvider struct {
+	mu   sync.RWMutex
+	keys []CustomKey
+	err  error
+}
+
+func NewMockCustomKeyProvider(keys []CustomKey, err error) *MockCustomKeyProvider {
+	return &MockCustomKeyProvider{keys: keys, err: err}
+}
+
+func (m *MockCustomKeyProvider) GetCustomKeys() ([]CustomKey, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.keys, nil
+}
+
+// MockInstalledKeyChecker checks installed keys for testing.
+type MockInstalledKeyChecker struct {
+	mu        sync.RWMutex
+	installed map[types.ValidatorPubkey]bool
+}
+
+func NewMockInstalledKeyChecker(installedPubkeys ...types.ValidatorPubkey) *MockInstalledKeyChecker {
+	m := &MockInstalledKeyChecker{installed: make(map[types.ValidatorPubkey]bool, len(installedPubkeys))}
+	for _, pk := range installedPubkeys {
+		m.installed[pk] = true
+	}
+	return m
+}
+
+func (m *MockInstalledKeyChecker) IsKeyInstalled(pubkey types.ValidatorPubkey) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.installed[pubkey], nil
+}

--- a/shared/services/recovery/planner.go
+++ b/shared/services/recovery/planner.go
@@ -1,0 +1,244 @@
+package recovery
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/rocket-pool/smartnode/bindings/types"
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
+)
+
+// Default limits matching Smartnode recovery constants.
+const (
+	DefaultBucketSize  uint = 20
+	DefaultBucketLimit uint = 2000
+)
+
+// PlannerOptions controls configuration for key discovery.
+type PlannerOptions struct {
+	BucketSize  uint
+	BucketLimit uint
+}
+
+// DefaultPlannerOptions returns sensible default planner settings.
+func DefaultPlannerOptions() PlannerOptions {
+	return PlannerOptions{
+		BucketSize:  DefaultBucketSize,
+		BucketLimit: DefaultBucketLimit,
+	}
+}
+
+// PlanValidatorRecovery builds a complete, deterministic RecoveryPlan without mutating any files.
+func PlanValidatorRecovery(
+	pubkeys []types.ValidatorPubkey,
+	statuses map[types.ValidatorPubkey]beacon.ValidatorStatus,
+	deriver KeyDeriver,
+	installedChecker InstalledKeyChecker,
+	customProvider CustomKeyProvider,
+	opts PlannerOptions,
+) (*RecoveryPlan, error) {
+	opts = normalizePlannerOptions(opts)
+
+	validPubkeys := filterAndDeduplicatePubkeys(pubkeys)
+	entryMap, unresolvedMap := initializePlanEntries(validPubkeys, statuses)
+
+	checkInstalledKeys(installedChecker, unresolvedMap)
+
+	if err := inspectCustomKeys(customProvider, unresolvedMap); err != nil {
+		return nil, err
+	}
+
+	if err := searchMnemonicKeys(deriver, unresolvedMap, opts); err != nil {
+		return nil, err
+	}
+
+	return buildRecoveryPlan(validPubkeys, entryMap, unresolvedMap, opts.BucketLimit), nil
+}
+
+// normalizePlannerOptions ensures option fields have safe non-zero defaults.
+func normalizePlannerOptions(opts PlannerOptions) PlannerOptions {
+	if opts.BucketSize == 0 {
+		opts.BucketSize = DefaultBucketSize
+	}
+	if opts.BucketLimit == 0 {
+		opts.BucketLimit = DefaultBucketLimit
+	}
+	return opts
+}
+
+// filterAndDeduplicatePubkeys strips out empty/zero pubkeys and duplicate entries, preserving order.
+func filterAndDeduplicatePubkeys(pubkeys []types.ValidatorPubkey) []types.ValidatorPubkey {
+	zeroPubkey := types.ValidatorPubkey{}
+	seen := make(map[types.ValidatorPubkey]bool, len(pubkeys))
+	valid := make([]types.ValidatorPubkey, 0, len(pubkeys))
+
+	for _, pk := range pubkeys {
+		if bytes.Equal(pk[:], zeroPubkey[:]) || seen[pk] {
+			continue
+		}
+		seen[pk] = true
+		valid = append(valid, pk)
+	}
+	return valid
+}
+
+// initializePlanEntries creates entries for all pubkeys and identifies inactive beacon validators.
+// Fixes Issue #407: inactive validators are categorized as OutcomeExcludedInactive.
+func initializePlanEntries(
+	validPubkeys []types.ValidatorPubkey,
+	statuses map[types.ValidatorPubkey]beacon.ValidatorStatus,
+) (map[types.ValidatorPubkey]*ValidatorPlanEntry, map[types.ValidatorPubkey]*ValidatorPlanEntry) {
+	entryMap := make(map[types.ValidatorPubkey]*ValidatorPlanEntry, len(validPubkeys))
+	unresolvedMap := make(map[types.ValidatorPubkey]*ValidatorPlanEntry)
+
+	for _, pk := range validPubkeys {
+		entry := &ValidatorPlanEntry{
+			Pubkey:        pk,
+			Source:        SourceNone,
+			CommitOutcome: CommitNotAttempted,
+		}
+		entryMap[pk] = entry
+
+		if statuses != nil {
+			if status, hasStatus := statuses[pk]; hasStatus && !isActiveValidatorState(status.Status) {
+				entry.DiscoveryOutcome = OutcomeExcludedInactive
+				entry.CommitOutcome = CommitSkippedExcluded
+				entry.Details = fmt.Sprintf("beacon validator state: %s", status.Status)
+				continue
+			}
+		}
+
+		entry.DiscoveryOutcome = OutcomeUnresolved
+		unresolvedMap[pk] = entry
+	}
+
+	return entryMap, unresolvedMap
+}
+
+// checkInstalledKeys identifies validator keys that are already installed in validator clients.
+func checkInstalledKeys(
+	installedChecker InstalledKeyChecker,
+	unresolvedMap map[types.ValidatorPubkey]*ValidatorPlanEntry,
+) {
+	if installedChecker == nil || len(unresolvedMap) == 0 {
+		return
+	}
+
+	for pk, entry := range unresolvedMap {
+		installed, err := installedChecker.IsKeyInstalled(pk)
+		if err == nil && installed {
+			entry.Source = SourceInstalled
+			entry.DiscoveryOutcome = OutcomeInstalledValid
+			entry.CommitOutcome = CommitSkippedAlreadyInstalled
+			entry.Details = "key material already present in validator client keystores"
+			delete(unresolvedMap, pk)
+		}
+	}
+}
+
+// inspectCustomKeys processes imported EIP-2335 custom keystores without writing anything to disk.
+func inspectCustomKeys(
+	customProvider CustomKeyProvider,
+	unresolvedMap map[types.ValidatorPubkey]*ValidatorPlanEntry,
+) error {
+	if customProvider == nil || len(unresolvedMap) == 0 {
+		return nil
+	}
+
+	customKeys, err := customProvider.GetCustomKeys()
+	if err != nil {
+		return fmt.Errorf("error loading custom keys: %w", err)
+	}
+
+	for _, ck := range customKeys {
+		entry, exists := unresolvedMap[ck.Pubkey]
+		if !exists {
+			continue
+		}
+
+		entry.Source = SourceCustomKeystore
+		if ck.Error != nil {
+			entry.DiscoveryOutcome = OutcomeInvalidMaterial
+			entry.CommitOutcome = CommitNotAttempted
+			entry.Details = ck.Error.Error()
+		} else {
+			entry.DiscoveryOutcome = OutcomeCustomValid
+			entry.CommitOutcome = CommitNotAttempted
+			entry.PrivateKey = ck.PrivateKey
+			entry.DerivationPath = ck.DerivationPath
+			entry.Details = fmt.Sprintf("loaded from custom keystore: %s", ck.FileName)
+		}
+		delete(unresolvedMap, ck.Pubkey)
+	}
+
+	return nil
+}
+
+// searchMnemonicKeys derives keys from the wallet mnemonic seed within the configured bucket limits.
+func searchMnemonicKeys(
+	deriver KeyDeriver,
+	unresolvedMap map[types.ValidatorPubkey]*ValidatorPlanEntry,
+	opts PlannerOptions,
+) error {
+	if deriver == nil || len(unresolvedMap) == 0 {
+		return nil
+	}
+
+	bucketStart := uint(0)
+	for bucketStart < opts.BucketLimit && len(unresolvedMap) > 0 {
+		bucketEnd := bucketStart + opts.BucketSize
+		if bucketEnd > opts.BucketLimit {
+			bucketEnd = opts.BucketLimit
+		}
+
+		keys, err := deriver.GetValidatorKeys(bucketStart, bucketEnd-bucketStart)
+		if err != nil {
+			return fmt.Errorf("error deriving validator keys at index %d: %w", bucketStart, err)
+		}
+
+		for _, vk := range keys {
+			entry, exists := unresolvedMap[vk.PublicKey]
+			if exists {
+				wIndex := vk.WalletIndex
+				entry.Source = SourceMnemonic
+				entry.DiscoveryOutcome = OutcomeMnemonicValid
+				entry.CommitOutcome = CommitNotAttempted
+				entry.PrivateKey = vk.PrivateKey
+				entry.DerivationPath = vk.DerivationPath
+				entry.WalletIndex = &wIndex
+				entry.Details = fmt.Sprintf("derived at index %d (%s)", vk.WalletIndex, vk.DerivationPath)
+				delete(unresolvedMap, vk.PublicKey)
+			}
+		}
+
+		bucketStart = bucketEnd
+	}
+
+	return nil
+}
+
+// buildRecoveryPlan sets final details for remaining unresolved keys and packages the plan.
+func buildRecoveryPlan(
+	validPubkeys []types.ValidatorPubkey,
+	entryMap map[types.ValidatorPubkey]*ValidatorPlanEntry,
+	unresolvedMap map[types.ValidatorPubkey]*ValidatorPlanEntry,
+	bucketLimit uint,
+) *RecoveryPlan {
+	for _, entry := range unresolvedMap {
+		entry.Details = fmt.Sprintf("not resolved within derivation limit (%d attempts)", bucketLimit)
+	}
+
+	plan := NewRecoveryPlan()
+	for _, pk := range validPubkeys {
+		plan.AddEntry(*entryMap[pk])
+	}
+	return plan
+}
+
+// isActiveValidatorState checks if a beacon validator status is in an active or pending state.
+func isActiveValidatorState(state beacon.ValidatorState) bool {
+	return state == beacon.ValidatorState_ActiveOngoing ||
+		state == beacon.ValidatorState_ActiveExiting ||
+		state == beacon.ValidatorState_PendingInitialized ||
+		state == beacon.ValidatorState_PendingQueued
+}

--- a/shared/services/recovery/planner_test.go
+++ b/shared/services/recovery/planner_test.go
@@ -1,0 +1,345 @@
+package recovery
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/tyler-smith/go-bip39"
+	eth2types "github.com/wealdtech/go-eth2-types/v2"
+	eth2util "github.com/wealdtech/go-eth2-util"
+
+	"github.com/rocket-pool/smartnode/bindings/types"
+	"github.com/rocket-pool/smartnode/shared/services/beacon"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
+)
+
+const testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+func init() {
+	_ = eth2types.InitBLS()
+}
+
+// createTestBLSKey derives a deterministic BLS key for tests using the test mnemonic and index.
+func createTestBLSKey(t *testing.T, index uint) (*eth2types.BLSPrivateKey, types.ValidatorPubkey, string) {
+	t.Helper()
+	seed := bip39.NewSeed(testMnemonic, "")
+	derivationPath := fmt.Sprintf("m/12381/3600/%d/0/0", index)
+	privKey, err := eth2util.PrivateKeyFromSeedAndPath(seed, derivationPath)
+	if err != nil {
+		t.Fatalf("failed to derive test BLS key at index %d: %v", index, err)
+	}
+	pubkeyBytes := privKey.PublicKey().Marshal()
+	return privKey, types.BytesToValidatorPubkey(pubkeyBytes), derivationPath
+}
+
+// assertZeroWrites ensures no keystore modifications were attempted.
+func assertZeroWrites(t *testing.T, writerSpy *MockKeyWriter) {
+	t.Helper()
+	if writerSpy.TotalWrites() != 0 {
+		t.Fatalf("FATAL SAFETY VIOLATION: expected 0 writes on failure, but writer recorded %d writes!", writerSpy.TotalWrites())
+	}
+	if len(writerSpy.SaveCalls()) != 0 {
+		t.Errorf("expected 0 SaveValidatorKey calls, got %d", len(writerSpy.SaveCalls()))
+	}
+	if len(writerSpy.StoreCalls()) != 0 {
+		t.Errorf("expected 0 StoreValidatorKey calls, got %d", len(writerSpy.StoreCalls()))
+	}
+}
+
+// assertOutcome checks the discovery and commit outcomes for a plan entry.
+func assertOutcome(t *testing.T, entry *ValidatorPlanEntry, expectedDiscovery DiscoveryOutcome, expectedCommit CommitOutcome) {
+	t.Helper()
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if entry.DiscoveryOutcome != expectedDiscovery {
+		t.Errorf("expected DiscoveryOutcome %s for %s, got %s", expectedDiscovery, entry.Pubkey.Hex(), entry.DiscoveryOutcome)
+	}
+	if entry.CommitOutcome != expectedCommit {
+		t.Errorf("expected CommitOutcome %s for %s, got %s", expectedCommit, entry.Pubkey.Hex(), entry.CommitOutcome)
+	}
+}
+
+// TestMnemonicOnlyRecoverySuccess verifies that a purely mnemonic-derived validator set
+// plans cleanly and commits all keys.
+func TestMnemonicOnlyRecoverySuccess(t *testing.T) {
+	priv0, pk0, path0 := createTestBLSKey(t, 0)
+	priv1, pk1, path1 := createTestBLSKey(t, 1)
+	priv2, pk2, path2 := createTestBLSKey(t, 2)
+
+	deriver := NewMockKeyDeriver()
+	deriver.AddKey(0, wallet.ValidatorKey{PublicKey: pk0, PrivateKey: priv0, DerivationPath: path0, WalletIndex: 0})
+	deriver.AddKey(1, wallet.ValidatorKey{PublicKey: pk1, PrivateKey: priv1, DerivationPath: path1, WalletIndex: 1})
+	deriver.AddKey(2, wallet.ValidatorKey{PublicKey: pk2, PrivateKey: priv2, DerivationPath: path2, WalletIndex: 2})
+
+	pubkeys := []types.ValidatorPubkey{pk0, pk1, pk2}
+
+	// Step 1: Plan recovery
+	plan, err := PlanValidatorRecovery(pubkeys, nil, deriver, nil, nil, DefaultPlannerOptions())
+	if err != nil {
+		t.Fatalf("unexpected planning error: %v", err)
+	}
+
+	if plan.TotalInScope != 3 {
+		t.Errorf("expected 3 in-scope keys, got %d", plan.TotalInScope)
+	}
+	if plan.TotalResolved != 3 {
+		t.Errorf("expected 3 resolved keys, got %d", plan.TotalResolved)
+	}
+	if !plan.CanCommitByDefault() {
+		t.Error("plan should allow default commit")
+	}
+
+	// Step 2: Commit recovery
+	writer := NewMockKeyWriter()
+	if err := CommitPlan(plan, writer, false); err != nil {
+		t.Fatalf("commit failed: %v", err)
+	}
+
+	if writer.TotalWrites() != 3 {
+		t.Errorf("expected 3 writes, got %d", writer.TotalWrites())
+	}
+	for _, entry := range plan.Entries {
+		assertOutcome(t, &entry, OutcomeMnemonicValid, CommitWritten)
+	}
+}
+
+// TestMixedRecoveryWithOneUnresolvedKey_DefaultFlowZeroWrites is the core MVP architectural proof:
+// proves that encountering ONE unresolved key halts default recovery and makes ZERO disk writes.
+func TestMixedRecoveryWithOneUnresolvedKey_DefaultFlowZeroWrites(t *testing.T) {
+	priv0, pk0, path0 := createTestBLSKey(t, 0)
+	priv1, pk1, path1 := createTestBLSKey(t, 1)
+	privCustom, pkCustom, _ := createTestBLSKey(t, 50)
+	_, pkUnresolved, _ := createTestBLSKey(t, 999) // Will not be provided
+
+	deriver := NewMockKeyDeriver()
+	deriver.AddKey(0, wallet.ValidatorKey{PublicKey: pk0, PrivateKey: priv0, DerivationPath: path0, WalletIndex: 0})
+	deriver.AddKey(1, wallet.ValidatorKey{PublicKey: pk1, PrivateKey: priv1, DerivationPath: path1, WalletIndex: 1})
+
+	customProvider := NewMockCustomKeyProvider([]CustomKey{
+		{
+			Pubkey:         pkCustom,
+			PrivateKey:     privCustom,
+			DerivationPath: "custom/keystore-1",
+			FileName:       "custom-validator-1.json",
+		},
+	}, nil)
+
+	pubkeys := []types.ValidatorPubkey{pk0, pk1, pkCustom, pkUnresolved}
+
+	// Step 1: Run read-only plan
+	plan, err := PlanValidatorRecovery(pubkeys, nil, deriver, nil, customProvider, DefaultPlannerOptions())
+	if err != nil {
+		t.Fatalf("unexpected plan error: %v", err)
+	}
+
+	if plan.TotalInScope != 4 {
+		t.Fatalf("expected 4 in-scope keys, got %d", plan.TotalInScope)
+	}
+	if plan.TotalResolved != 3 {
+		t.Errorf("expected 3 resolved keys, got %d", plan.TotalResolved)
+	}
+	if plan.TotalUnresolved != 1 {
+		t.Errorf("expected 1 unresolved key, got %d", plan.TotalUnresolved)
+	}
+	if plan.CanCommitByDefault() {
+		t.Error("plan with unresolved keys must NOT allow default commit")
+	}
+
+	unresolvedEntry := plan.GetEntry(pkUnresolved)
+	if unresolvedEntry == nil || unresolvedEntry.DiscoveryOutcome != OutcomeUnresolved {
+		t.Fatalf("expected pkUnresolved to have OutcomeUnresolved")
+	}
+
+	// Step 2: Attempt commit under DEFAULT mode (allowPartial = false)
+	writerSpy := NewMockKeyWriter()
+	commitErr := CommitPlan(plan, writerSpy, false)
+
+	if commitErr == nil {
+		t.Fatal("expected commit to fail under default mode due to unresolved key, but got nil")
+	}
+	if !errors.Is(commitErr, ErrUnresolvedKeysRefusingCommit) {
+		t.Errorf("expected ErrUnresolvedKeysRefusingCommit, got: %v", commitErr)
+	}
+
+	// CRITICAL ARCHITECTURAL GUARANTEE: Zero writes must have been made!
+	assertZeroWrites(t, writerSpy)
+}
+
+// TestMixedRecoveryWithOneUnresolvedKey_PartialRecoveryAllowsValidKeys verifies that
+// operators opting in with allowPartial = true can commit resolved keys while tracking the skipped key.
+func TestMixedRecoveryWithOneUnresolvedKey_PartialRecoveryAllowsValidKeys(t *testing.T) {
+	priv0, pk0, path0 := createTestBLSKey(t, 0)
+	priv1, pk1, path1 := createTestBLSKey(t, 1)
+	privCustom, pkCustom, _ := createTestBLSKey(t, 50)
+	_, pkUnresolved, _ := createTestBLSKey(t, 999)
+
+	deriver := NewMockKeyDeriver()
+	deriver.AddKey(0, wallet.ValidatorKey{PublicKey: pk0, PrivateKey: priv0, DerivationPath: path0, WalletIndex: 0})
+	deriver.AddKey(1, wallet.ValidatorKey{PublicKey: pk1, PrivateKey: priv1, DerivationPath: path1, WalletIndex: 1})
+
+	customProvider := NewMockCustomKeyProvider([]CustomKey{
+		{
+			Pubkey:         pkCustom,
+			PrivateKey:     privCustom,
+			DerivationPath: "custom/keystore-1",
+			FileName:       "custom-validator-1.json",
+		},
+	}, nil)
+
+	pubkeys := []types.ValidatorPubkey{pk0, pk1, pkCustom, pkUnresolved}
+
+	plan, err := PlanValidatorRecovery(pubkeys, nil, deriver, nil, customProvider, DefaultPlannerOptions())
+	if err != nil {
+		t.Fatalf("unexpected plan error: %v", err)
+	}
+
+	writerSpy := NewMockKeyWriter()
+	// Commit with allowPartial = true
+	if err := CommitPlan(plan, writerSpy, true); err != nil {
+		t.Fatalf("unexpected commit error with partial recovery allowed: %v", err)
+	}
+
+	// Should have written the 3 resolved keys (2 mnemonic + 1 custom)
+	if writerSpy.TotalWrites() != 3 {
+		t.Errorf("expected 3 writes, got %d", writerSpy.TotalWrites())
+	}
+	if len(writerSpy.SaveCalls()) != 2 {
+		t.Errorf("expected 2 SaveValidatorKey calls, got %d", len(writerSpy.SaveCalls()))
+	}
+	if len(writerSpy.StoreCalls()) != 1 {
+		t.Errorf("expected 1 StoreValidatorKey calls, got %d", len(writerSpy.StoreCalls()))
+	}
+
+	unresolvedEntry := plan.GetEntry(pkUnresolved)
+	if unresolvedEntry.CommitOutcome != CommitSkippedPartial {
+		t.Errorf("expected unresolved entry to have CommitSkippedPartial, got %s", unresolvedEntry.CommitOutcome)
+	}
+}
+
+// TestInactiveValidatorFiltering_FixIssue407 verifies that inactive and exited validators
+// are excluded cleanly during planning and do not block recovery or generate missing-key errors.
+func TestInactiveValidatorFiltering_FixIssue407(t *testing.T) {
+	privActive, pkActive, pathActive := createTestBLSKey(t, 0)
+	privPending, pkPending, pathPending := createTestBLSKey(t, 1)
+	_, pkExited, _ := createTestBLSKey(t, 2)
+	_, pkSlashed, _ := createTestBLSKey(t, 3)
+
+	deriver := NewMockKeyDeriver()
+	deriver.AddKey(0, wallet.ValidatorKey{PublicKey: pkActive, PrivateKey: privActive, DerivationPath: pathActive, WalletIndex: 0})
+	deriver.AddKey(1, wallet.ValidatorKey{PublicKey: pkPending, PrivateKey: privPending, DerivationPath: pathPending, WalletIndex: 1})
+
+	statuses := map[types.ValidatorPubkey]beacon.ValidatorStatus{
+		pkActive:  {Status: beacon.ValidatorState_ActiveOngoing},
+		pkPending: {Status: beacon.ValidatorState_PendingQueued},
+		pkExited:  {Status: beacon.ValidatorState_ExitedUnslashed},
+		pkSlashed: {Status: beacon.ValidatorState_ExitedSlashed},
+	}
+
+	pubkeys := []types.ValidatorPubkey{pkActive, pkPending, pkExited, pkSlashed}
+
+	plan, err := PlanValidatorRecovery(pubkeys, statuses, deriver, nil, nil, DefaultPlannerOptions())
+	if err != nil {
+		t.Fatalf("unexpected plan error: %v", err)
+	}
+
+	if plan.TotalExcluded != 2 {
+		t.Errorf("expected 2 excluded inactive validators, got %d", plan.TotalExcluded)
+	}
+	if plan.TotalInScope != 2 {
+		t.Errorf("expected 2 in-scope validators, got %d", plan.TotalInScope)
+	}
+	if plan.TotalResolved != 2 {
+		t.Errorf("expected 2 resolved validators, got %d", plan.TotalResolved)
+	}
+	if plan.TotalUnresolved != 0 {
+		t.Errorf("expected 0 unresolved validators, got %d", plan.TotalUnresolved)
+	}
+	if !plan.CanCommitByDefault() {
+		t.Error("plan with excluded inactive validators should be committable by default")
+	}
+
+	exitedEntry := plan.GetEntry(pkExited)
+	assertOutcome(t, exitedEntry, OutcomeExcludedInactive, CommitSkippedExcluded)
+
+	writer := NewMockKeyWriter()
+	if err := CommitPlan(plan, writer, false); err != nil {
+		t.Fatalf("unexpected commit error: %v", err)
+	}
+
+	if writer.TotalWrites() != 2 {
+		t.Errorf("expected exactly 2 writes for the 2 active validators, got %d", writer.TotalWrites())
+	}
+}
+
+// TestCustomKeyInvalidMaterial_FailsFast verifies that corrupt keystores or password mismatches
+// are captured as OutcomeInvalidMaterial and prevent default writes.
+func TestCustomKeyInvalidMaterial_FailsFast(t *testing.T) {
+	_, pkBad, _ := createTestBLSKey(t, 0)
+
+	customProvider := NewMockCustomKeyProvider([]CustomKey{
+		{
+			Pubkey:   pkBad,
+			Error:    errors.New("could not decrypt keystore: invalid password"),
+			FileName: "bad-keystore.json",
+		},
+	}, nil)
+
+	pubkeys := []types.ValidatorPubkey{pkBad}
+
+	plan, err := PlanValidatorRecovery(pubkeys, nil, nil, nil, customProvider, DefaultPlannerOptions())
+	if err != nil {
+		t.Fatalf("unexpected planning error: %v", err)
+	}
+
+	if plan.TotalInvalid != 1 {
+		t.Errorf("expected 1 invalid key, got %d", plan.TotalInvalid)
+	}
+	if plan.CanCommitByDefault() {
+		t.Error("plan with invalid custom key material must NOT allow default commit")
+	}
+
+	writer := NewMockKeyWriter()
+	err = CommitPlan(plan, writer, false)
+	if err == nil {
+		t.Fatal("expected commit to fail on invalid custom key, got nil")
+	}
+	assertZeroWrites(t, writer)
+}
+
+// TestAlreadyInstalledKey_SkippedDuringCommit verifies that keys already present in the validator client
+// are diagnosed as installed and skipped during commit without error.
+func TestAlreadyInstalledKey_SkippedDuringCommit(t *testing.T) {
+	_, pkInstalled, _ := createTestBLSKey(t, 0)
+	privNew, pkNew, pathNew := createTestBLSKey(t, 1)
+
+	deriver := NewMockKeyDeriver()
+	deriver.AddKey(1, wallet.ValidatorKey{PublicKey: pkNew, PrivateKey: privNew, DerivationPath: pathNew, WalletIndex: 1})
+
+	installedChecker := NewMockInstalledKeyChecker(pkInstalled)
+
+	pubkeys := []types.ValidatorPubkey{pkInstalled, pkNew}
+
+	plan, err := PlanValidatorRecovery(pubkeys, nil, deriver, installedChecker, nil, DefaultPlannerOptions())
+	if err != nil {
+		t.Fatalf("unexpected plan error: %v", err)
+	}
+
+	installedEntry := plan.GetEntry(pkInstalled)
+	assertOutcome(t, installedEntry, OutcomeInstalledValid, CommitSkippedAlreadyInstalled)
+
+	writer := NewMockKeyWriter()
+	if err := CommitPlan(plan, writer, false); err != nil {
+		t.Fatalf("unexpected commit error: %v", err)
+	}
+
+	// Only the new key pkNew should have been written!
+	if writer.TotalWrites() != 1 {
+		t.Errorf("expected 1 write, got %d", writer.TotalWrites())
+	}
+	saveCalls := writer.SaveCalls()
+	if len(saveCalls) != 1 || saveCalls[0].PublicKey != pkNew {
+		t.Errorf("expected SaveValidatorKey call for pkNew, got %+v", saveCalls)
+	}
+}

--- a/shared/services/recovery/types.go
+++ b/shared/services/recovery/types.go
@@ -1,0 +1,188 @@
+package recovery
+
+import (
+	"encoding/json"
+	"fmt"
+
+	eth2types "github.com/wealdtech/go-eth2-types/v2"
+
+	"github.com/rocket-pool/smartnode/bindings/types"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
+)
+
+// KeyDiscoverySource identifies how key material for a validator was obtained.
+type KeyDiscoverySource string
+
+const (
+	SourceNone           KeyDiscoverySource = "none"
+	SourceMnemonic       KeyDiscoverySource = "mnemonic"
+	SourceCustomKeystore KeyDiscoverySource = "custom_keystore"
+	SourceInstalled      KeyDiscoverySource = "installed"
+)
+
+// DiscoveryOutcome represents the deterministic diagnosis of a validator pubkey during planning.
+type DiscoveryOutcome string
+
+const (
+	OutcomeMnemonicValid    DiscoveryOutcome = "mnemonic_valid"
+	OutcomeCustomValid      DiscoveryOutcome = "custom_valid"
+	OutcomeInstalledValid   DiscoveryOutcome = "installed_valid"
+	OutcomeUnresolved       DiscoveryOutcome = "unresolved"
+	OutcomeInvalidMaterial  DiscoveryOutcome = "invalid_material"
+	OutcomeExcludedInactive DiscoveryOutcome = "excluded_inactive"
+)
+
+// CommitOutcome represents the result of attempting to write key material to disk.
+type CommitOutcome string
+
+const (
+	CommitNotAttempted            CommitOutcome = "not_attempted"
+	CommitWritten                 CommitOutcome = "written"
+	CommitSkippedAlreadyInstalled CommitOutcome = "skipped_already_installed"
+	CommitSkippedExcluded         CommitOutcome = "skipped_excluded"
+	CommitSkippedPartial          CommitOutcome = "skipped_partial"
+	CommitFailed                  CommitOutcome = "failed"
+)
+
+// ValidatorPlanEntry contains the discovery diagnosis and commit result for a single validator.
+type ValidatorPlanEntry struct {
+	Pubkey           types.ValidatorPubkey `json:"pubkey"`
+	Source           KeyDiscoverySource    `json:"source"`
+	DiscoveryOutcome DiscoveryOutcome      `json:"discoveryOutcome"`
+	CommitOutcome    CommitOutcome         `json:"commitOutcome"`
+	Details          string                `json:"details,omitempty"`
+	DerivationPath   string                `json:"derivationPath,omitempty"`
+	WalletIndex      *uint                 `json:"walletIndex,omitempty"`
+
+	// In-memory key material kept only during planning/committing and never serialized.
+	PrivateKey *eth2types.BLSPrivateKey `json:"-"`
+}
+
+// IsResolved returns true if the entry was successfully discovered and has valid key material.
+func (e *ValidatorPlanEntry) IsResolved() bool {
+	return e.DiscoveryOutcome == OutcomeMnemonicValid ||
+		e.DiscoveryOutcome == OutcomeCustomValid ||
+		e.DiscoveryOutcome == OutcomeInstalledValid
+}
+
+// IsExcluded returns true if the validator was excluded due to inactive beacon chain state.
+func (e *ValidatorPlanEntry) IsExcluded() bool {
+	return e.DiscoveryOutcome == OutcomeExcludedInactive
+}
+
+// RecoveryPlan encapsulates the entire recovery state across all in-scope validators.
+type RecoveryPlan struct {
+	Entries         []ValidatorPlanEntry `json:"entries"`
+	TotalInScope    int                  `json:"totalInScope"`
+	TotalResolved   int                  `json:"totalResolved"`
+	TotalUnresolved int                  `json:"totalUnresolved"`
+	TotalInvalid    int                  `json:"totalInvalid"`
+	TotalExcluded   int                  `json:"totalExcluded"`
+}
+
+// NewRecoveryPlan constructs an initialized RecoveryPlan.
+func NewRecoveryPlan() *RecoveryPlan {
+	return &RecoveryPlan{
+		Entries: []ValidatorPlanEntry{},
+	}
+}
+
+// AddEntry appends an entry to the plan and updates summary counts.
+func (p *RecoveryPlan) AddEntry(entry ValidatorPlanEntry) {
+	p.Entries = append(p.Entries, entry)
+	p.recalculateTotals()
+}
+
+func (p *RecoveryPlan) recalculateTotals() {
+	p.TotalInScope = 0
+	p.TotalResolved = 0
+	p.TotalUnresolved = 0
+	p.TotalInvalid = 0
+	p.TotalExcluded = 0
+
+	for _, e := range p.Entries {
+		switch e.DiscoveryOutcome {
+		case OutcomeExcludedInactive:
+			p.TotalExcluded++
+		case OutcomeMnemonicValid, OutcomeCustomValid, OutcomeInstalledValid:
+			p.TotalInScope++
+			p.TotalResolved++
+		case OutcomeUnresolved:
+			p.TotalInScope++
+			p.TotalUnresolved++
+		case OutcomeInvalidMaterial:
+			p.TotalInScope++
+			p.TotalInvalid++
+		}
+	}
+}
+
+// HasUnresolvedOrInvalid returns true if any in-scope validator lacks valid key material.
+func (p *RecoveryPlan) HasUnresolvedOrInvalid() bool {
+	return p.TotalUnresolved > 0 || p.TotalInvalid > 0
+}
+
+// CanCommitByDefault returns true if all in-scope validators were resolved and valid.
+func (p *RecoveryPlan) CanCommitByDefault() bool {
+	return !p.HasUnresolvedOrInvalid()
+}
+
+// GetEntry returns a pointer to the entry for the given pubkey, or nil if not found.
+func (p *RecoveryPlan) GetEntry(pubkey types.ValidatorPubkey) *ValidatorPlanEntry {
+	for i := range p.Entries {
+		if p.Entries[i].Pubkey == pubkey {
+			return &p.Entries[i]
+		}
+	}
+	return nil
+}
+
+// SummaryString returns a human-readable summary of the plan.
+func (p *RecoveryPlan) SummaryString() string {
+	return fmt.Sprintf(
+		"In-scope: %d (Resolved: %d, Unresolved: %d, Invalid: %d), Excluded: %d",
+		p.TotalInScope, p.TotalResolved, p.TotalUnresolved, p.TotalInvalid, p.TotalExcluded,
+	)
+}
+
+// KeyDeriver provides derived validator keys from the wallet mnemonic.
+type KeyDeriver interface {
+	GetValidatorKeys(startIndex uint, length uint) ([]wallet.ValidatorKey, error)
+}
+
+// InstalledKeyChecker checks if a validator key is already installed in the node.
+type InstalledKeyChecker interface {
+	IsKeyInstalled(pubkey types.ValidatorPubkey) (bool, error)
+}
+
+// CustomKey represents a custom key file that has been parsed.
+type CustomKey struct {
+	Pubkey         types.ValidatorPubkey
+	PrivateKey     *eth2types.BLSPrivateKey
+	DerivationPath string
+	Error          error
+	FileName       string
+}
+
+// CustomKeyProvider provides custom validator keys from disk or mocks.
+type CustomKeyProvider interface {
+	GetCustomKeys() ([]CustomKey, error)
+}
+
+// KeyWriter performs actual persistent writes of validator keys.
+type KeyWriter interface {
+	SaveValidatorKey(key wallet.ValidatorKey) error
+	StoreValidatorKey(key *eth2types.BLSPrivateKey, path string) error
+}
+
+// Ensure json serialization excludes sensitive fields
+var _ json.Marshaler = (*ValidatorPlanEntry)(nil)
+
+func (e ValidatorPlanEntry) MarshalJSON() ([]byte, error) {
+	type Alias ValidatorPlanEntry
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias: (Alias)(e),
+	})
+}


### PR DESCRIPTION
**Status**: This is an unfunded feasibility prototype for a Round 40 grant application, not a production-complete or merge-ready implementation. It demonstrates the recovery-plan model, plan/commit separation, inactive-validator filtering fix, and zero-write safety test. Remaining work includes integration into `recover`, `rebuild`, and `test-recovery`; CLI/API behavior; production writer adapters; broader failure-path tests; documentation; and maintainer-requested revisions.

---

### Description
This PR introduces the **Safe Recovery Planner & Per-Key Diagnosis** architecture for validator key recovery, prototyping a solution for #407 and #572; #440 provides operator-impact context.

Previously, Smartnode persisted validator keys to disk immediately as each individual key was discovered. In mixed-key setups (mnemonic-derived, custom EIP-2335 keystores, megapools), encountering an error on a later key left the operator in a partially-written, inconsistent state. Additionally, inactive/exited validators on the Beacon chain were filtered into `filteredPubkeys`, but the target map was populated from the unfiltered list, causing recovery to fail on exited validators (#407).

### Key Architectural Changes
1. **Two-Stage Plan-Before-Write Execution (`shared/services/recovery`)**:
   - **Plan Phase (`PlanValidatorRecovery`)**: Pure, read-only discovery that assesses minipool/megapool keys, checks Beacon statuses, inspects custom keys, tests mnemonic derivation, and checks installed keystores. **Zero disk writes**.
   - **Commit Phase (`CommitPlan`)**: Enforces the safety invariant: in default mode, if any in-scope key is unresolved or invalid, recovery halts before touching disk (`ErrUnresolvedKeysRefusingCommit`). An explicit `--allow-partial-recover` option allows committing only validated keys while recording skipped keys.
2. **Deterministic Per-Key Diagnosis (`types.ValidatorPlanEntry`)**:
   - Explicit outcomes: `mnemonic_valid`, `custom_valid`, `installed_valid`, `unresolved`, `invalid_material`, and `excluded_inactive`.
3. **Issue #407 Bug Fix**:
   - Fixed `recoverNodeKeys` in `rocketpool/api/wallet/recover.go` so `pubkeyMap` correctly iterates over `filteredPubkeys`.
4. **Spy-Writer Test Suite**:
   - Comprehensive tests including `TestMixedRecoveryWithOneUnresolvedKey_DefaultFlowZeroWrites` asserting through a writer-spy test that `writerSpy.TotalWrites() == 0` on unresolved key failure under default mode.

### Testing Done
- `go test -v -count=1 ./shared/services/recovery/...` (All 6 test suites passing)
- `go test -v -count=1 ./rocketpool/api/wallet/...` (All wallet tests passing)
- Passed `golangci-lint/v2@v2.13.1` with 0 issues.

---
*Note for maintainers: As this is a contribution from a new fork, the GitHub Actions workflows are awaiting approval to run (`action_required`). Could a maintainer please approve the workflow runs? Thank you!*
