### PR TITLE
feat(node): add pending transaction inspection and cancellation commands (#351)

### DIFF
--- a/RESEARCH_ISSUE_351.md
+++ b/RESEARCH_ISSUE_351.md
@@ -1,0 +1,171 @@
+# Research & Design Specification: Pending Transaction Management (Issue #351)
+
+**Issue**: [rocket-pool/smartnode#351: [FEATURE REQUEST] Command to check/cancel the node's pending txs](https://github.com/rocket-pool/smartnode/issues/351)  
+**Target Project Directory**: `/mnt/data/Projects/smartnode`
+
+---
+
+## 1. Problem Statement & Motivation
+
+Rocket Pool node operators frequently encounter stuck transactions in the mempool due to sudden network base fee or priority fee spikes after submitting on-chain operations (such as minipool staking, RPL rewards claiming, fee distributor distribution, or setting withdrawal addresses).
+
+### 1.1 Root Causes
+1. **Ethereum Nonce Serialization**: Ethereum strictly processes transactions from a given address in strictly increasing nonce order ($0, 1, 2, \dots$). If transaction $N$ has a gas price below the miner/validator inclusion threshold, all subsequent transactions $N+1, N+2, \dots$ are queued behind it and will never execute until transaction $N$ is mined or cancelled.
+2. **Current Workaround Friction**: Node operators must currently:
+   - Open Etherscan or another block explorer to locate their node wallet address.
+   - Inspect the pending transaction to identify the stuck nonce and gas parameters.
+   - Manually formulate a replacement transaction using CLI flags (`--nonce <N>`, `--maxPrioFee <higher_fee>`).
+   - Calculate replacement fees (Ethereum clients enforce a $\ge 10\%$ increase in priority fee and max fee over the pending transaction).
+   - Repeat sequentially if multiple transactions are backed up.
+3. **Error Risks**: Node operators can easily miscalculate replacement fees leading to `replacement transaction underpriced` RPC errors, or accidentally send invalid transactions.
+
+---
+
+## 2. Functional Requirements
+
+### 2.1 Feature 1: Check Pending Transactions
+* **CLI Command**: `rocketpool node pending-transactions` (aliases: `pending-txs`, `pending`, `txs`)
+* **Functionality**:
+  - Compares the on-chain mined nonce (`latest`) against the mempool pending nonce (`pending`).
+  - Lists the count of pending transactions.
+  - Formats a table displaying the stuck nonces, estimated gas parameters, and action suggestions.
+
+### 2.2 Feature 2: Cancel / Overwrite Pending Transactions
+* **CLI Command**: `rocketpool node cancel-transaction` (aliases: `cancel-tx`, `cancel`)
+* **Flags**:
+  - `--nonce, -n <uint>`: Specific nonce to cancel (defaults to the lowest pending nonce, which is the primary blocker).
+  - `--all, -a`: Batch cancels all pending nonces in sequential ascending order.
+  - `--yes, -y`: Automatically confirm prompts.
+* **Mechanism**:
+  - Submits a 0-ETH self-transfer (`from == to == nodeAddress`, empty `data = []`, gas limit `21,000`).
+  - Applies a calculated gas bump ($\ge 15\%$ above previous priority fee or current network base fee + priority fee, whichever is higher).
+  - Waits for confirmation and reports status to the user.
+
+---
+
+## 3. System Architecture & Components
+
+```mermaid
+flowchart TD
+    subgraph CLI ["rocketpool-cli"]
+        CLI_Cmd["rocketpool-cli/node/commands.go"]
+        CLI_Pending["rocketpool-cli/node/pending-transactions.go"]
+        CLI_Cancel["rocketpool-cli/node/cancel-transaction.go"]
+    end
+
+    subgraph Service ["shared/services/rocketpool"]
+        RP_Client["shared/services/rocketpool/node.go"]
+    end
+
+    subgraph Daemon ["rocketpool (daemon) / api"]
+        API_Routes["rocketpool/api/node/routes.go"]
+        API_Pending["rocketpool/api/node/pending-transactions.go"]
+        API_Cancel["rocketpool/api/node/cancel-transaction.go"]
+    end
+
+    subgraph Types ["shared/types/api"]
+        API_Types["shared/types/api/node.go"]
+    end
+
+    subgraph EC ["Ethereum Execution Client"]
+        EthClient["ecManager / go-ethereum ethclient"]
+    end
+
+    CLI_Cmd --> CLI_Pending
+    CLI_Cmd --> CLI_Cancel
+    CLI_Pending --> RP_Client
+    CLI_Cancel --> RP_Client
+    RP_Client --> API_Routes
+    API_Routes --> API_Pending
+    API_Routes --> API_Cancel
+    API_Pending --> EthClient
+    API_Cancel --> EthClient
+    API_Pending --> API_Types
+    API_Cancel --> API_Types
+```
+
+---
+
+## 4. Implementation Details by Component
+
+### 4.1 Data Models (`shared/types/api/node.go`)
+```go
+// NodePendingTransactionsResponse contains the pending status of the node
+type NodePendingTransactionsResponse struct {
+	APIResponse
+	NodeAddress         common.Address     `json:"nodeAddress"`
+	LatestNonce         uint64             `json:"latestNonce"`
+	PendingNonce        uint64             `json:"pendingNonce"`
+	PendingCount        uint64             `json:"pendingCount"`
+	PendingTransactions []PendingTxDetails `json:"pendingTransactions"`
+}
+
+type PendingTxDetails struct {
+	Nonce          uint64          `json:"nonce"`
+	Hash           *common.Hash    `json:"hash,omitempty"`
+	To             *common.Address `json:"to,omitempty"`
+	Value          *big.Int        `json:"value,omitempty"`
+	GasLimit       uint64          `json:"gasLimit"`
+	MaxFeePerGas   *big.Int        `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFee *big.Int        `json:"maxPriorityFeePerGas,omitempty"`
+	IsStuck        bool            `json:"isStuck"`
+}
+
+type CanCancelNodeTransactionResponse struct {
+	APIResponse
+	CanCancel           bool    `json:"canCancel"`
+	Nonce               uint64  `json:"nonce"`
+	GasLimit            uint64  `json:"gasLimit"`
+	MinPriorityFeeGwei  float64 `json:"minPriorityFeeGwei"`
+	SuggestedMaxFeeGwei float64 `json:"suggestedMaxFeeGwei"`
+}
+
+type CancelNodeTransactionResponse struct {
+	APIResponse
+	TxHash common.Hash `json:"txHash"`
+}
+```
+
+### 4.2 Daemon API Routes & Handlers (`rocketpool/api/node/`)
+
+1. **`rocketpool/api/node/routes.go`**:
+   Register endpoints via `snroute`:
+   - `snroute.Read("/api/node/pending-transactions", pendingTransactionsHandler).RegisterTo(router)`
+   - `snroute.Read("/api/node/can-cancel-transaction", canCancelTransactionHandler).RegisterTo(router)`
+   - `snroute.Write("/api/node/cancel-transaction", cancelTransactionHandler).RegisterTo(router)`
+
+2. **`rocketpool/api/node/pending-transactions.go`**:
+   - Query `latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)`
+   - Query `pendingNonce, err := ec.PendingNonceAt(ctx, nodeAddress)`
+   - If `pendingNonce > latestNonce`, assemble the range $[\text{latestNonce}, \text{pendingNonce}-1]$.
+   - Tiered enrichment: Query `txpool_contentFrom` on EC; if supported, extract transaction hashes, destinations, and gas prices.
+
+3. **`rocketpool/api/node/cancel-transaction.go`**:
+   - Preflight: verify `nonce >= latestNonce` (supporting evicted txs where `pendingNonce == latestNonce`), verify wallet is loaded and not in observe mode, and verify ETH balance covers gas.
+   - Prepare a 0-ETH transaction to `nodeAddress` with empty data payload and fixed 21,000 gas limit.
+   - Calculate replacement fees: $\ge 15\%$ bump over previous fee if known, or market-based $2 \times \text{BaseFee} + \text{Tip}$ buffer.
+   - Sign with `opts.Signer` and broadcast via `ec.SendTransaction()`.
+
+### 4.3 Client Methods (`shared/services/rocketpool/node.go`)
+- `(c *Client) NodePendingTransactions() (api.NodePendingTransactionsResponse, error)`
+- `(c *Client) CanCancelNodeTransaction(nonce uint64) (api.CanCancelNodeTransactionResponse, error)`
+- `(c *Client) CancelNodeTransaction(nonce uint64) (api.CancelNodeTransactionResponse, error)`
+
+### 4.4 CLI Subcommands (`rocketpool-cli/node/`)
+- `rocketpool-cli/node/commands.go`: Register `pending-transactions` (aliases: `pending-txs`, `pending`, `txs`) and `cancel-transaction` (aliases: `cancel-tx`, `cancel`).
+- `rocketpool-cli/node/pending-transactions.go`: Tabulated display of stuck nonces, fees, hashes, and actionable cancel guidance.
+- `rocketpool-cli/node/cancel-transaction.go`: Interactive confirmation, gas summary, single / batch execution, and transaction tracking with `rp.WaitForTransaction()`.
+
+---
+
+## 5. Edge Cases & Safety Matrix
+
+| Scenario | Behavior |
+| :--- | :--- |
+| **No pending transactions in pool (`pendingNonce == latestNonce`)** | Inform the user; allow explicit `--nonce <N>` override if $N \ge \text{latestNonce}$ to cancel an evicted transaction. |
+| **Evicted / Dropped transaction** | If an underpriced transaction was dropped from the local EC mempool, operator can specify `--nonce <N>` to overwrite it on network/relays. |
+| **Insufficient ETH for gas** | `can-cancel-transaction` verifies node ETH balance $\ge 21,000 \times \text{suggestedMaxFee}$ and warns operator before submitting. |
+| **Cancelling out-of-order nonce** | Warn user if cancelling nonce $> \text{latestNonce}$ while lower nonces remain stuck; prioritize the lowest nonce first. |
+| **Replacement Underpricing** | Calculate minimum 15% priority fee bump over known tx or default $2 \times \text{BaseFee} + \text{Tip}$. |
+| **Observe Mode (Cold / HW Wallet)** | Fail early with clean error: observe mode cannot sign or submit transactions. |
+| **Multiple Pending Transactions (`--all`)** | Execute sequentially: cancel $N$, wait for block inclusion, then proceed to $N+1$ to prevent nonce collisions. |

--- a/rocketpool-cli/node/cancel-transaction.go
+++ b/rocketpool-cli/node/cancel-transaction.go
@@ -7,8 +7,10 @@ import (
 	"github.com/rocket-pool/smartnode/rocketpool-cli/cli/color"
 	"github.com/rocket-pool/smartnode/rocketpool-cli/cli/prompt"
 	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
+	"github.com/rocket-pool/smartnode/shared/types/api"
 )
 
+// cancelTransaction orchestrates transaction cancellation for single or all pending transactions.
 func cancelTransaction(nonce uint64, nonceSet bool, cancelAll bool, yes bool) error {
 	rp := rocketpool.NewClient()
 	defer rp.Close()
@@ -17,23 +19,34 @@ func cancelTransaction(nonce uint64, nonceSet bool, cancelAll bool, yes bool) er
 		return cancelAllTransactions(rp, yes)
 	}
 
-	// If nonce was not explicitly specified via flag, detect lowest pending nonce
-	if !nonceSet {
-		pendingResp, err := rp.NodePendingTransactions()
-		if err != nil {
-			return fmt.Errorf("error detecting pending transactions: %w", err)
-		}
-		if pendingResp.PendingCount == 0 {
-			nonce = pendingResp.LatestNonce
-			color.YellowPrintf("No pending transactions reported by local mempool; defaulting to current on-chain nonce %d.\n", nonce)
-		} else {
-			nonce = pendingResp.PendingTransactions[0].Nonce
-		}
+	targetNonce, err := resolveTargetNonce(rp, nonce, nonceSet)
+	if err != nil {
+		return err
 	}
 
-	return cancelSingleTransaction(rp, nonce, yes)
+	return cancelSingleTransaction(rp, targetNonce, yes)
 }
 
+// resolveTargetNonce determines the target nonce to cancel when not explicitly set by flag.
+func resolveTargetNonce(rp *rocketpool.Client, nonce uint64, nonceSet bool) (uint64, error) {
+	if nonceSet {
+		return nonce, nil
+	}
+
+	pendingResp, err := rp.NodePendingTransactions()
+	if err != nil {
+		return 0, fmt.Errorf("error detecting pending transactions: %w", err)
+	}
+
+	if pendingResp.PendingCount == 0 {
+		color.YellowPrintf("No pending transactions reported by local mempool; defaulting to current on-chain nonce %d.\n", pendingResp.LatestNonce)
+		return pendingResp.LatestNonce, nil
+	}
+
+	return pendingResp.PendingTransactions[0].Nonce, nil
+}
+
+// cancelSingleTransaction performs the preflight check, confirmation prompt, submission, and confirmation tracking.
 func cancelSingleTransaction(rp *rocketpool.Client, nonce uint64, yes bool) error {
 	canCancel, err := rp.CanCancelNodeTransaction(nonce)
 	if err != nil {
@@ -43,12 +56,7 @@ func cancelSingleTransaction(rp *rocketpool.Client, nonce uint64, yes bool) erro
 		return errors.New("cannot cancel transaction at this nonce")
 	}
 
-	color.YellowPrintf("Preparing to cancel transaction at nonce %d with a 0-ETH replacement.\n", nonce)
-	fmt.Printf("  Gas Limit:          %d\n", canCancel.GasLimit)
-	fmt.Printf("  Max Priority Fee:   %.2f gwei\n", canCancel.MinPriorityFeeGwei)
-	fmt.Printf("  Suggested Max Fee:  %.2f gwei\n", canCancel.SuggestedMaxFeeGwei)
-	maxCostEth := (canCancel.SuggestedMaxFeeGwei / 1e9) * float64(canCancel.GasLimit)
-	fmt.Printf("  Estimated Max Cost: %.6f ETH\n", maxCostEth)
+	printCancelPreflightSummary(&canCancel)
 
 	if !yes {
 		if !prompt.Confirm("Are you sure you want to cancel the pending transaction at nonce %d?", nonce) {
@@ -57,6 +65,21 @@ func cancelSingleTransaction(rp *rocketpool.Client, nonce uint64, yes bool) erro
 		}
 	}
 
+	return submitAndTrackCancellation(rp, nonce)
+}
+
+// printCancelPreflightSummary prints the fee and gas parameters of the proposed cancellation transaction.
+func printCancelPreflightSummary(canCancel *api.CanCancelNodeTransactionResponse) {
+	color.YellowPrintf("Preparing to cancel transaction at nonce %d with a 0-ETH replacement.\n", canCancel.Nonce)
+	fmt.Printf("  Gas Limit:          %d\n", canCancel.GasLimit)
+	fmt.Printf("  Max Priority Fee:   %.2f gwei\n", canCancel.MinPriorityFeeGwei)
+	fmt.Printf("  Suggested Max Fee:  %.2f gwei\n", canCancel.SuggestedMaxFeeGwei)
+	maxCostEth := (canCancel.SuggestedMaxFeeGwei / 1e9) * float64(canCancel.GasLimit)
+	fmt.Printf("  Estimated Max Cost: %.6f ETH\n", maxCostEth)
+}
+
+// submitAndTrackCancellation transmits the replacement tx and waits for block inclusion.
+func submitAndTrackCancellation(rp *rocketpool.Client, nonce uint64) error {
 	resp, err := rp.CancelNodeTransaction(nonce)
 	if err != nil {
 		return fmt.Errorf("error submitting cancel transaction: %w", err)
@@ -73,6 +96,7 @@ func cancelSingleTransaction(rp *rocketpool.Client, nonce uint64, yes bool) erro
 	return nil
 }
 
+// cancelAllTransactions loops through all pending transactions in order, cancelling each sequentially.
 func cancelAllTransactions(rp *rocketpool.Client, yes bool) error {
 	pendingResp, err := rp.NodePendingTransactions()
 	if err != nil {

--- a/rocketpool-cli/node/cancel-transaction.go
+++ b/rocketpool-cli/node/cancel-transaction.go
@@ -1,0 +1,105 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rocket-pool/smartnode/rocketpool-cli/cli/color"
+	"github.com/rocket-pool/smartnode/rocketpool-cli/cli/prompt"
+	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
+)
+
+func cancelTransaction(nonce uint64, nonceSet bool, cancelAll bool, yes bool) error {
+	rp := rocketpool.NewClient()
+	defer rp.Close()
+
+	if cancelAll {
+		return cancelAllTransactions(rp, yes)
+	}
+
+	// If nonce was not explicitly specified via flag, detect lowest pending nonce
+	if !nonceSet {
+		pendingResp, err := rp.NodePendingTransactions()
+		if err != nil {
+			return fmt.Errorf("error detecting pending transactions: %w", err)
+		}
+		if pendingResp.PendingCount == 0 {
+			nonce = pendingResp.LatestNonce
+			color.YellowPrintf("No pending transactions reported by local mempool; defaulting to current on-chain nonce %d.\n", nonce)
+		} else {
+			nonce = pendingResp.PendingTransactions[0].Nonce
+		}
+	}
+
+	return cancelSingleTransaction(rp, nonce, yes)
+}
+
+func cancelSingleTransaction(rp *rocketpool.Client, nonce uint64, yes bool) error {
+	canCancel, err := rp.CanCancelNodeTransaction(nonce)
+	if err != nil {
+		return err
+	}
+	if !canCancel.CanCancel {
+		return errors.New("cannot cancel transaction at this nonce")
+	}
+
+	color.YellowPrintf("Preparing to cancel transaction at nonce %d with a 0-ETH replacement.\n", nonce)
+	fmt.Printf("  Gas Limit:          %d\n", canCancel.GasLimit)
+	fmt.Printf("  Max Priority Fee:   %.2f gwei\n", canCancel.MinPriorityFeeGwei)
+	fmt.Printf("  Suggested Max Fee:  %.2f gwei\n", canCancel.SuggestedMaxFeeGwei)
+	maxCostEth := (canCancel.SuggestedMaxFeeGwei / 1e9) * float64(canCancel.GasLimit)
+	fmt.Printf("  Estimated Max Cost: %.6f ETH\n", maxCostEth)
+
+	if !yes {
+		if !prompt.Confirm("Are you sure you want to cancel the pending transaction at nonce %d?", nonce) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	resp, err := rp.CancelNodeTransaction(nonce)
+	if err != nil {
+		return fmt.Errorf("error submitting cancel transaction: %w", err)
+	}
+
+	color.GreenPrintf("Cancellation transaction submitted with hash %s\n", resp.TxHash.Hex())
+	fmt.Println("Waiting for the transaction to be included in a block...")
+
+	if _, err := rp.WaitForTransaction(resp.TxHash); err != nil {
+		return fmt.Errorf("error waiting for cancellation transaction: %w", err)
+	}
+
+	color.GreenPrintf("Transaction successfully mined! Nonce %d is now unblocked.\n", nonce)
+	return nil
+}
+
+func cancelAllTransactions(rp *rocketpool.Client, yes bool) error {
+	pendingResp, err := rp.NodePendingTransactions()
+	if err != nil {
+		return fmt.Errorf("error querying pending transactions: %w", err)
+	}
+
+	if pendingResp.PendingCount == 0 {
+		color.GreenPrintln("No pending transactions to cancel in the local mempool.")
+		return nil
+	}
+
+	color.YellowPrintf("Found %d pending transaction(s) to cancel sequentially.\n", pendingResp.PendingCount)
+
+	if !yes {
+		if !prompt.Confirm("Are you sure you want to cancel all %d pending transactions?", pendingResp.PendingCount) {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	for _, tx := range pendingResp.PendingTransactions {
+		color.YellowPrintf("\n--- Cancelling transaction at nonce %d ---\n", tx.Nonce)
+		if err := cancelSingleTransaction(rp, tx.Nonce, true); err != nil {
+			return fmt.Errorf("error cancelling nonce %d: %w", tx.Nonce, err)
+		}
+	}
+
+	color.GreenPrintln("\nAll pending transactions have been cancelled successfully.")
+	return nil
+}

--- a/rocketpool-cli/node/commands.go
+++ b/rocketpool-cli/node/commands.go
@@ -792,6 +792,59 @@ func RegisterCommands(app *cli.Command, name string, aliases []string) {
 					},
 				},
 			},
+
+			{
+				Name:      "pending-transactions",
+				Aliases:   []string{"pending-txs", "pending", "txs"},
+				Usage:     "View the node's pending transactions in the mempool",
+				UsageText: "rocketpool node pending-transactions",
+				Action: func(ctx context.Context, c *cli.Command) error {
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run
+					return getPendingTransactions()
+
+				},
+			},
+
+			{
+				Name:      "cancel-transaction",
+				Aliases:   []string{"cancel-tx", "cancel"},
+				Usage:     "Cancel or unblock a pending transaction by sending a 0-ETH replacement transaction with higher fees",
+				UsageText: "rocketpool node cancel-transaction [options]",
+				Flags: []cli.Flag{
+					&cli.Uint64Flag{
+						Name:    "nonce",
+						Aliases: []string{"n"},
+						Usage:   "The specific nonce to cancel (defaults to the lowest pending nonce)",
+					},
+					&cli.BoolFlag{
+						Name:    "all",
+						Aliases: []string{"a"},
+						Usage:   "Cancel all pending transactions sequentially",
+					},
+					&cli.BoolFlag{
+						Name:    "yes",
+						Aliases: []string{"y"},
+						Usage:   "Automatically confirm cancellation without interactive prompts",
+					},
+				},
+				Action: func(ctx context.Context, c *cli.Command) error {
+
+					// Validate args
+					if err := cliutils.ValidateArgCount(c, 0); err != nil {
+						return err
+					}
+
+					// Run
+					return cancelTransaction(c.Uint64("nonce"), c.IsSet("nonce"), c.Bool("all"), c.Bool("yes"))
+
+				},
+			},
 		},
 	})
 }

--- a/rocketpool-cli/node/commands_test.go
+++ b/rocketpool-cli/node/commands_test.go
@@ -1,0 +1,72 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func TestPendingAndCancelCommandsRegistered(t *testing.T) {
+	app := &cli.Command{}
+	RegisterCommands(app, "node", []string{"n"})
+
+	if len(app.Commands) != 1 {
+		t.Fatalf("expected 1 command group, got %d", len(app.Commands))
+	}
+
+	nodeCmd := app.Commands[0]
+	if nodeCmd.Name != "node" {
+		t.Fatalf("expected command group 'node', got '%s'", nodeCmd.Name)
+	}
+
+	foundPending := false
+	foundCancel := false
+
+	for _, subcmd := range nodeCmd.Commands {
+		if subcmd.Name == "pending-transactions" {
+			foundPending = true
+			expectedAliases := map[string]bool{"pending-txs": true, "pending": true, "txs": true}
+			for _, alias := range subcmd.Aliases {
+				delete(expectedAliases, alias)
+			}
+			if len(expectedAliases) != 0 {
+				t.Errorf("missing expected aliases for pending-transactions: %v", expectedAliases)
+			}
+		}
+
+		if subcmd.Name == "cancel-transaction" {
+			foundCancel = true
+			expectedAliases := map[string]bool{"cancel-tx": true, "cancel": true}
+			for _, alias := range subcmd.Aliases {
+				delete(expectedAliases, alias)
+			}
+			if len(expectedAliases) != 0 {
+				t.Errorf("missing expected aliases for cancel-transaction: %v", expectedAliases)
+			}
+
+			// Verify flags: nonce, all, yes
+			flagsFound := map[string]bool{}
+			for _, flag := range subcmd.Flags {
+				for _, name := range flag.Names() {
+					flagsFound[name] = true
+				}
+			}
+			if !flagsFound["nonce"] || !flagsFound["n"] {
+				t.Error("cancel-transaction missing nonce flag")
+			}
+			if !flagsFound["all"] || !flagsFound["a"] {
+				t.Error("cancel-transaction missing all flag")
+			}
+			if !flagsFound["yes"] || !flagsFound["y"] {
+				t.Error("cancel-transaction missing yes flag")
+			}
+		}
+	}
+
+	if !foundPending {
+		t.Error("pending-transactions command not registered under node")
+	}
+	if !foundCancel {
+		t.Error("cancel-transaction command not registered under node")
+	}
+}

--- a/rocketpool-cli/node/pending-transactions.go
+++ b/rocketpool-cli/node/pending-transactions.go
@@ -2,14 +2,17 @@ package node
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"text/tabwriter"
 
 	"github.com/rocket-pool/smartnode/rocketpool-cli/cli/color"
 	"github.com/rocket-pool/smartnode/shared/math"
 	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
+	"github.com/rocket-pool/smartnode/shared/types/api"
 )
 
+// getPendingTransactions coordinates fetching and displaying pending transactions.
 func getPendingTransactions() error {
 	rp := rocketpool.NewClient()
 	defer rp.Close()
@@ -19,81 +22,104 @@ func getPendingTransactions() error {
 		return err
 	}
 
+	renderPendingTransactionsHeader(&resp)
+
+	if resp.PendingCount == 0 {
+		renderNoPendingNotice(resp.LatestNonce)
+		return nil
+	}
+
+	color.YellowPrintf("Found %d pending transaction(s) blocking the node queue:\n\n", resp.PendingCount)
+	renderPendingTransactionsTable(os.Stdout, resp.PendingTransactions)
+
+	fmt.Println()
+	renderActionSuggestions(resp.PendingTransactions[0].Nonce, resp.PendingCount)
+	return nil
+}
+
+// renderPendingTransactionsHeader outputs the summary status block for the node account.
+func renderPendingTransactionsHeader(resp *api.NodePendingTransactionsResponse) {
 	color.GreenPrintln("=== Node Pending Transactions ===")
 	fmt.Printf("Node Account:            %s\n", color.LightBlue(resp.NodeAddress.Hex()))
 	fmt.Printf("Mined Nonce (latest):    %s\n", color.Yellow(fmt.Sprintf("%d", resp.LatestNonce)))
 	fmt.Printf("Mempool Nonce (pending): %s\n", color.Yellow(fmt.Sprintf("%d", resp.PendingNonce)))
 	fmt.Println()
+}
 
-	if resp.PendingCount == 0 {
-		color.GreenPrintln("No pending transactions found in the node's mempool.")
-		fmt.Println("Note: If a transaction was recently dropped due to low fees or a node restart, you can still cancel it with:")
-		fmt.Printf("  %s\n", color.LightBlue(fmt.Sprintf("rocketpool node cancel-transaction --nonce %d", resp.LatestNonce)))
-		return nil
-	}
+// renderNoPendingNotice displays the empty queue status and helpful troubleshooting tip.
+func renderNoPendingNotice(latestNonce uint64) {
+	color.GreenPrintln("No pending transactions found in the node's mempool.")
+	fmt.Println("Note: If a transaction was recently dropped due to low fees or a node restart, you can still cancel it with:")
+	fmt.Printf("  %s\n", color.LightBlue(fmt.Sprintf("rocketpool node cancel-transaction --nonce %d", latestNonce)))
+}
 
-	color.YellowPrintf("Found %d pending transaction(s) blocking the node queue:\n\n", resp.PendingCount)
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+// renderPendingTransactionsTable writes a formatted table of pending transactions to the provided writer.
+func renderPendingTransactionsTable(out io.Writer, txs []api.PendingTxDetails) {
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "NONCE\tHASH\tTO\tVALUE (ETH)\tMAX FEE (GWEI)\tPRIO FEE (GWEI)\tSTATUS")
 	fmt.Fprintln(w, "-----\t----\t--\t-----------\t--------------\t---------------\t------")
 
-	for _, tx := range resp.PendingTransactions {
-		hashStr := "<unknown>"
-		if tx.Hash != nil {
-			hashStr = tx.Hash.Hex()
-			if len(hashStr) > 12 {
-				hashStr = hashStr[:6] + "..." + hashStr[len(hashStr)-4:]
-			}
-		}
-
-		toStr := "<unknown>"
-		if tx.To != nil {
-			toStr = tx.To.Hex()
-			if len(toStr) > 12 {
-				toStr = toStr[:6] + "..." + toStr[len(toStr)-4:]
-			}
-		}
-
-		valEth := "0.0000"
-		if tx.Value != nil {
-			valEth = fmt.Sprintf("%.4f", math.WeiToEth(tx.Value))
-		}
-
-		maxFeeGwei := "-"
-		if tx.MaxFeePerGas != nil {
-			maxFeeGwei = fmt.Sprintf("%.2f", math.WeiToGwei(tx.MaxFeePerGas))
-		}
-
-		prioFeeGwei := "-"
-		if tx.MaxPriorityFee != nil {
-			prioFeeGwei = fmt.Sprintf("%.2f", math.WeiToGwei(tx.MaxPriorityFee))
-		}
-
-		status := "Pending"
-		if tx.IsStuck {
-			status = "Stuck"
-		}
-
+	for _, tx := range txs {
+		nonce, hashStr, toStr, valEth, maxFeeGwei, prioFeeGwei, status := formatPendingTxRow(tx)
 		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			tx.Nonce,
-			hashStr,
-			toStr,
-			valEth,
-			maxFeeGwei,
-			prioFeeGwei,
-			status,
+			nonce, hashStr, toStr, valEth, maxFeeGwei, prioFeeGwei, status,
 		)
 	}
 	_ = w.Flush()
+}
 
-	fmt.Println()
+// formatPendingTxRow formats a single pending transaction into table column strings.
+func formatPendingTxRow(tx api.PendingTxDetails) (nonce uint64, hashStr, toStr, valEth, maxFeeGwei, prioFeeGwei, status string) {
+	nonce = tx.Nonce
+
+	hashStr = "<unknown>"
+	if tx.Hash != nil {
+		hashStr = truncateHex(tx.Hash.Hex(), 6, 4)
+	}
+
+	toStr = "<unknown>"
+	if tx.To != nil {
+		toStr = truncateHex(tx.To.Hex(), 6, 4)
+	}
+
+	valEth = "0.0000"
+	if tx.Value != nil {
+		valEth = fmt.Sprintf("%.4f", math.WeiToEth(tx.Value))
+	}
+
+	maxFeeGwei = "-"
+	if tx.MaxFeePerGas != nil {
+		maxFeeGwei = fmt.Sprintf("%.2f", math.WeiToGwei(tx.MaxFeePerGas))
+	}
+
+	prioFeeGwei = "-"
+	if tx.MaxPriorityFee != nil {
+		prioFeeGwei = fmt.Sprintf("%.2f", math.WeiToGwei(tx.MaxPriorityFee))
+	}
+
+	status = "Pending"
+	if tx.IsStuck {
+		status = "Stuck"
+	}
+
+	return nonce, hashStr, toStr, valEth, maxFeeGwei, prioFeeGwei, status
+}
+
+// truncateHex abbreviates a long hex string with ellipses (e.g. 0x1234...abcd).
+func truncateHex(s string, headLen, tailLen int) string {
+	if len(s) > headLen+tailLen+2 {
+		return s[:headLen] + "..." + s[len(s)-tailLen:]
+	}
+	return s
+}
+
+// renderActionSuggestions displays suggested CLI commands based on pending transaction count.
+func renderActionSuggestions(lowestNonce uint64, pendingCount uint64) {
 	color.YellowPrintln("Action Suggestions:")
-	fmt.Printf("  • Cancel the lowest blocking transaction (nonce %d):\n", resp.PendingTransactions[0].Nonce)
-	fmt.Printf("      %s\n", color.LightBlue(fmt.Sprintf("rocketpool node cancel-transaction --nonce %d", resp.PendingTransactions[0].Nonce)))
-	if resp.PendingCount > 1 {
-		fmt.Printf("  • Cancel ALL %d pending transactions sequentially:\n", resp.PendingCount)
+	fmt.Printf("  • Cancel the lowest blocking transaction (nonce %d):\n", lowestNonce)
+	fmt.Printf("      %s\n", color.LightBlue(fmt.Sprintf("rocketpool node cancel-transaction --nonce %d", lowestNonce)))
+	if pendingCount > 1 {
+		fmt.Printf("  • Cancel ALL %d pending transactions sequentially:\n", pendingCount)
 		fmt.Printf("      %s\n", color.LightBlue("rocketpool node cancel-transaction --all"))
 	}
-	return nil
 }

--- a/rocketpool-cli/node/pending-transactions.go
+++ b/rocketpool-cli/node/pending-transactions.go
@@ -1,0 +1,99 @@
+package node
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/rocket-pool/smartnode/rocketpool-cli/cli/color"
+	"github.com/rocket-pool/smartnode/shared/math"
+	"github.com/rocket-pool/smartnode/shared/services/rocketpool"
+)
+
+func getPendingTransactions() error {
+	rp := rocketpool.NewClient()
+	defer rp.Close()
+
+	resp, err := rp.NodePendingTransactions()
+	if err != nil {
+		return err
+	}
+
+	color.GreenPrintln("=== Node Pending Transactions ===")
+	fmt.Printf("Node Account:            %s\n", color.LightBlue(resp.NodeAddress.Hex()))
+	fmt.Printf("Mined Nonce (latest):    %s\n", color.Yellow(fmt.Sprintf("%d", resp.LatestNonce)))
+	fmt.Printf("Mempool Nonce (pending): %s\n", color.Yellow(fmt.Sprintf("%d", resp.PendingNonce)))
+	fmt.Println()
+
+	if resp.PendingCount == 0 {
+		color.GreenPrintln("No pending transactions found in the node's mempool.")
+		fmt.Println("Note: If a transaction was recently dropped due to low fees or a node restart, you can still cancel it with:")
+		fmt.Printf("  %s\n", color.LightBlue(fmt.Sprintf("rocketpool node cancel-transaction --nonce %d", resp.LatestNonce)))
+		return nil
+	}
+
+	color.YellowPrintf("Found %d pending transaction(s) blocking the node queue:\n\n", resp.PendingCount)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NONCE\tHASH\tTO\tVALUE (ETH)\tMAX FEE (GWEI)\tPRIO FEE (GWEI)\tSTATUS")
+	fmt.Fprintln(w, "-----\t----\t--\t-----------\t--------------\t---------------\t------")
+
+	for _, tx := range resp.PendingTransactions {
+		hashStr := "<unknown>"
+		if tx.Hash != nil {
+			hashStr = tx.Hash.Hex()
+			if len(hashStr) > 12 {
+				hashStr = hashStr[:6] + "..." + hashStr[len(hashStr)-4:]
+			}
+		}
+
+		toStr := "<unknown>"
+		if tx.To != nil {
+			toStr = tx.To.Hex()
+			if len(toStr) > 12 {
+				toStr = toStr[:6] + "..." + toStr[len(toStr)-4:]
+			}
+		}
+
+		valEth := "0.0000"
+		if tx.Value != nil {
+			valEth = fmt.Sprintf("%.4f", math.WeiToEth(tx.Value))
+		}
+
+		maxFeeGwei := "-"
+		if tx.MaxFeePerGas != nil {
+			maxFeeGwei = fmt.Sprintf("%.2f", math.WeiToGwei(tx.MaxFeePerGas))
+		}
+
+		prioFeeGwei := "-"
+		if tx.MaxPriorityFee != nil {
+			prioFeeGwei = fmt.Sprintf("%.2f", math.WeiToGwei(tx.MaxPriorityFee))
+		}
+
+		status := "Pending"
+		if tx.IsStuck {
+			status = "Stuck"
+		}
+
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			tx.Nonce,
+			hashStr,
+			toStr,
+			valEth,
+			maxFeeGwei,
+			prioFeeGwei,
+			status,
+		)
+	}
+	_ = w.Flush()
+
+	fmt.Println()
+	color.YellowPrintln("Action Suggestions:")
+	fmt.Printf("  • Cancel the lowest blocking transaction (nonce %d):\n", resp.PendingTransactions[0].Nonce)
+	fmt.Printf("      %s\n", color.LightBlue(fmt.Sprintf("rocketpool node cancel-transaction --nonce %d", resp.PendingTransactions[0].Nonce)))
+	if resp.PendingCount > 1 {
+		fmt.Printf("  • Cancel ALL %d pending transactions sequentially:\n", resp.PendingCount)
+		fmt.Printf("      %s\n", color.LightBlue("rocketpool node cancel-transaction --all"))
+	}
+	return nil
+}

--- a/rocketpool-cli/node/pending_tx_cli_test.go
+++ b/rocketpool-cli/node/pending_tx_cli_test.go
@@ -1,0 +1,108 @@
+package node
+
+import (
+	"bytes"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+func TestTruncateHex(t *testing.T) {
+	fullHash := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	truncated := truncateHex(fullHash, 6, 4)
+	if truncated != "0x1234...cdef" {
+		t.Fatalf("expected 0x1234...cdef, got %s", truncated)
+	}
+
+	short := "0x1234"
+	if truncateHex(short, 6, 4) != short {
+		t.Fatalf("expected %s to not be truncated", short)
+	}
+}
+
+func TestFormatPendingTxRow(t *testing.T) {
+	// Test sparse tx
+	sparseTx := api.PendingTxDetails{
+		Nonce:   5,
+		IsStuck: false,
+	}
+	nonce, hashStr, toStr, valEth, maxFeeGwei, prioFeeGwei, status := formatPendingTxRow(sparseTx)
+	if nonce != 5 {
+		t.Errorf("expected nonce 5, got %d", nonce)
+	}
+	if hashStr != "<unknown>" {
+		t.Errorf("expected <unknown>, got %s", hashStr)
+	}
+	if toStr != "<unknown>" {
+		t.Errorf("expected <unknown>, got %s", toStr)
+	}
+	if valEth != "0.0000" {
+		t.Errorf("expected 0.0000, got %s", valEth)
+	}
+	if maxFeeGwei != "-" {
+		t.Errorf("expected '-', got %s", maxFeeGwei)
+	}
+	if prioFeeGwei != "-" {
+		t.Errorf("expected '-', got %s", prioFeeGwei)
+	}
+	if status != "Pending" {
+		t.Errorf("expected 'Pending', got %s", status)
+	}
+
+	// Test fully enriched tx
+	h := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	to := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	enrichedTx := api.PendingTxDetails{
+		Nonce:          12,
+		Hash:           &h,
+		To:             &to,
+		Value:          big.NewInt(1500000000000000000), // 1.5 ETH
+		MaxFeePerGas:   big.NewInt(30000000000),         // 30 Gwei
+		MaxPriorityFee: big.NewInt(2000000000),          // 2 Gwei
+		IsStuck:        true,
+	}
+	nonce, hashStr, toStr, valEth, maxFeeGwei, prioFeeGwei, status = formatPendingTxRow(enrichedTx)
+	if nonce != 12 {
+		t.Errorf("expected nonce 12, got %d", nonce)
+	}
+	if hashStr != "0x1234...cdef" {
+		t.Errorf("expected 0x1234...cdef, got %s", hashStr)
+	}
+	if toStr != truncateHex(to.Hex(), 6, 4) {
+		t.Errorf("expected %s, got %s", truncateHex(to.Hex(), 6, 4), toStr)
+	}
+	if valEth != "1.5000" {
+		t.Errorf("expected 1.5000, got %s", valEth)
+	}
+	if maxFeeGwei != "30.00" {
+		t.Errorf("expected 30.00, got %s", maxFeeGwei)
+	}
+	if prioFeeGwei != "2.00" {
+		t.Errorf("expected 2.00, got %s", prioFeeGwei)
+	}
+	if status != "Stuck" {
+		t.Errorf("expected 'Stuck', got %s", status)
+	}
+}
+
+func TestRenderPendingTransactionsTable(t *testing.T) {
+	buf := new(bytes.Buffer)
+	txs := []api.PendingTxDetails{
+		{Nonce: 1, IsStuck: true},
+		{Nonce: 2, IsStuck: true},
+	}
+
+	renderPendingTransactionsTable(buf, txs)
+	output := buf.String()
+
+	if !strings.Contains(output, "NONCE") || !strings.Contains(output, "HASH") {
+		t.Errorf("table missing header: %s", output)
+	}
+	if !strings.Contains(output, "1") || !strings.Contains(output, "2") {
+		t.Errorf("table missing rows: %s", output)
+	}
+}

--- a/rocketpool/api/node/cancel-transaction.go
+++ b/rocketpool/api/node/cancel-transaction.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/urfave/cli/v3"
@@ -15,47 +16,20 @@ import (
 	"github.com/rocket-pool/smartnode/rocketpool/api/snroute"
 	"github.com/rocket-pool/smartnode/shared/math"
 	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/services/wallet"
 	"github.com/rocket-pool/smartnode/shared/types/api"
 )
 
 const cancelTxGasLimit uint64 = 21000
 
 func canCancelNodeTransaction(c *cli.Command, nonce uint64) (*api.CanCancelNodeTransactionResponse, error) {
-	// Require node wallet
-	if err := services.RequireNodeWallet(c); err != nil {
-		return nil, err
-	}
-	w, err := services.GetWallet(c)
+	_, ec, nodeAddress, err := validateCancelPreflight(c, nonce)
 	if err != nil {
 		return nil, err
 	}
-	ec, err := services.GetEthClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	// Verify not in observe/masquerade mode
-	if _, err := w.GetNodePrivateKeyBytes(); err != nil {
-		return nil, fmt.Errorf("node is in observe mode; cannot sign transactions: %w", err)
-	}
-
-	nodeAccount, err := w.GetNodeAccount()
-	if err != nil {
-		return nil, err
-	}
-	nodeAddress := nodeAccount.Address
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-
-	// Verify nonce >= latestNonce
-	latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error getting latest on-chain nonce: %w", err)
-	}
-	if nonce < latestNonce {
-		return nil, fmt.Errorf("nonce %d has already been mined (latest on-chain nonce is %d)", nonce, latestNonce)
-	}
 
 	// Calculate suggested gas fees
 	minPriorityFee, suggestedMaxFee := calculateReplacementFees(ctx, ec, nodeAddress, nonce)
@@ -87,40 +61,13 @@ func canCancelNodeTransaction(c *cli.Command, nonce uint64) (*api.CanCancelNodeT
 }
 
 func cancelNodeTransaction(c *cli.Command, nonce uint64, t *snroute.TransactOpts) (*api.CancelNodeTransactionResponse, error) {
-	// Require node wallet
-	if err := services.RequireNodeWallet(c); err != nil {
-		return nil, err
-	}
-	w, err := services.GetWallet(c)
+	w, ec, nodeAddress, err := validateCancelPreflight(c, nonce)
 	if err != nil {
 		return nil, err
 	}
-	ec, err := services.GetEthClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := w.GetNodePrivateKeyBytes(); err != nil {
-		return nil, fmt.Errorf("node is in observe mode; cannot sign transactions: %w", err)
-	}
-
-	nodeAccount, err := w.GetNodeAccount()
-	if err != nil {
-		return nil, err
-	}
-	nodeAddress := nodeAccount.Address
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-
-	// Verify nonce is still valid
-	latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error getting latest on-chain nonce: %w", err)
-	}
-	if nonce < latestNonce {
-		return nil, fmt.Errorf("nonce %d has already been mined (latest on-chain nonce is %d)", nonce, latestNonce)
-	}
 
 	opts := t.Opts()
 	// Fall back to suggested replacement fees if none provided
@@ -134,46 +81,95 @@ func cancelNodeTransaction(c *cli.Command, nonce uint64, t *snroute.TransactOpts
 		}
 	}
 
-	// Prepare a 0-ETH dynamic fee self-transfer
-	chainID := w.GetChainID()
-	tx := types.NewTx(&types.DynamicFeeTx{
+	tx := buildCancelDynamicFeeTx(w.GetChainID(), nonce, nodeAddress, opts.GasTipCap, opts.GasFeeCap)
+
+	txHash, err := broadcastCancelTx(ctx, ec, opts, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.CancelNodeTransactionResponse{
+		TxHash: txHash,
+	}, nil
+}
+
+// validateCancelPreflight ensures the wallet is unlocked, not observing, and the target nonce is valid.
+func validateCancelPreflight(c *cli.Command, nonce uint64) (wallet.Wallet, *services.ExecutionClientManager, common.Address, error) {
+	if err := services.RequireNodeWallet(c); err != nil {
+		return nil, nil, common.Address{}, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, nil, common.Address{}, err
+	}
+	ec, err := services.GetEthClient(c)
+	if err != nil {
+		return nil, nil, common.Address{}, err
+	}
+
+	if _, err := w.GetNodePrivateKeyBytes(); err != nil {
+		return nil, nil, common.Address{}, fmt.Errorf("node is in observe mode; cannot sign transactions: %w", err)
+	}
+
+	nodeAccount, err := w.GetNodeAccount()
+	if err != nil {
+		return nil, nil, common.Address{}, err
+	}
+	nodeAddress := nodeAccount.Address
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)
+	if err != nil {
+		return nil, nil, common.Address{}, fmt.Errorf("error getting latest on-chain nonce: %w", err)
+	}
+	if nonce < latestNonce {
+		return nil, nil, common.Address{}, fmt.Errorf("nonce %d has already been mined (latest on-chain nonce is %d)", nonce, latestNonce)
+	}
+
+	return w, ec, nodeAddress, nil
+}
+
+// buildCancelDynamicFeeTx constructs a 0-ETH dynamic fee transaction to self.
+func buildCancelDynamicFeeTx(chainID *big.Int, nonce uint64, nodeAddress common.Address, gasTipCap, gasFeeCap *big.Int) *types.Transaction {
+	return types.NewTx(&types.DynamicFeeTx{
 		ChainID:    chainID,
 		Nonce:      nonce,
-		GasTipCap:  opts.GasTipCap,
-		GasFeeCap:  opts.GasFeeCap,
+		GasTipCap:  gasTipCap,
+		GasFeeCap:  gasFeeCap,
 		Gas:        cancelTxGasLimit,
 		To:         &nodeAddress,
 		Value:      big.NewInt(0),
 		Data:       []byte{},
 		AccessList: []types.AccessTuple{},
 	})
+}
 
+// broadcastCancelTx signs and transmits the cancellation transaction via the execution client.
+func broadcastCancelTx(ctx context.Context, ec *services.ExecutionClientManager, opts *bind.TransactOpts, tx *types.Transaction) (common.Hash, error) {
 	if opts.Signer == nil {
-		return nil, fmt.Errorf("transactor signer is not configured")
+		return common.Hash{}, fmt.Errorf("transactor signer is not configured")
 	}
 
 	signedTx, err := opts.Signer(opts.From, tx)
 	if err != nil {
-		return nil, fmt.Errorf("error signing cancellation transaction: %w", err)
+		return common.Hash{}, fmt.Errorf("error signing cancellation transaction: %w", err)
 	}
 
 	if err := ec.SendTransaction(ctx, signedTx); err != nil {
-		return nil, fmt.Errorf("error broadcasting cancellation transaction: %w", err)
+		return common.Hash{}, fmt.Errorf("error broadcasting cancellation transaction: %w", err)
 	}
 
-	return &api.CancelNodeTransactionResponse{
-		TxHash: signedTx.Hash(),
-	}, nil
+	return signedTx.Hash(), nil
 }
 
 // calculateReplacementFees calculates appropriate tip and max fee for a replacement tx
 func calculateReplacementFees(ctx context.Context, ec *services.ExecutionClientManager, nodeAddress common.Address, nonce uint64) (*big.Int, *big.Int) {
-	// Base values from current network
 	suggestedTip, err := ec.SuggestGasTipCap(ctx)
 	if err != nil || suggestedTip == nil {
 		suggestedTip = math.GweiToWei(2.0)
 	}
-	// Default minimum 2 gwei tip
 	minTip := math.GweiToWei(2.0)
 	if suggestedTip.Cmp(minTip) < 0 {
 		suggestedTip = minTip
@@ -189,46 +185,22 @@ func calculateReplacementFees(ctx context.Context, ec *services.ExecutionClientM
 	marketMaxFee.Add(marketMaxFee, suggestedTip)
 
 	// Attempt txpool enrichment
-	var poolContent txPoolContentFromResponse
-	_ = ec.RawCallContext(ctx, &poolContent, "txpool_contentFrom", nodeAddress.Hex())
+	poolContent := fetchNodeMempool(ctx, ec, nodeAddress)
+	oldTip, oldFee := poolContent.getTxGasFees(nonce)
 
-	nonceStr := strconv.FormatUint(nonce, 10)
-	var existingTx map[string]interface{}
-	if txMap, ok := poolContent.Pending[nonceStr]; ok {
-		existingTx = txMap
-	} else if txMap, ok := poolContent.Queued[nonceStr]; ok {
-		existingTx = txMap
+	if oldTip != nil {
+		bumpedTip := new(big.Int).Mul(oldTip, big.NewInt(115))
+		bumpedTip.Div(bumpedTip, big.NewInt(100))
+		if bumpedTip.Cmp(suggestedTip) > 0 {
+			suggestedTip = bumpedTip
+		}
 	}
 
-	if existingTx != nil {
-		var oldTip *big.Int
-		var oldFee *big.Int
-
-		if p := parseHexBigInt(existingTx["maxPriorityFeePerGas"]); p != nil {
-			oldTip = p
-		}
-		if f := parseHexBigInt(existingTx["maxFeePerGas"]); f != nil {
-			oldFee = f
-		} else if gp := parseHexBigInt(existingTx["gasPrice"]); gp != nil {
-			oldFee = gp
-		}
-
-		if oldTip != nil {
-			// Apply 15% bump over old tip
-			bumpedTip := new(big.Int).Mul(oldTip, big.NewInt(115))
-			bumpedTip.Div(bumpedTip, big.NewInt(100))
-			if bumpedTip.Cmp(suggestedTip) > 0 {
-				suggestedTip = bumpedTip
-			}
-		}
-
-		if oldFee != nil {
-			// Apply 15% bump over old fee
-			bumpedFee := new(big.Int).Mul(oldFee, big.NewInt(115))
-			bumpedFee.Div(bumpedFee, big.NewInt(100))
-			if bumpedFee.Cmp(marketMaxFee) > 0 {
-				marketMaxFee = bumpedFee
-			}
+	if oldFee != nil {
+		bumpedFee := new(big.Int).Mul(oldFee, big.NewInt(115))
+		bumpedFee.Div(bumpedFee, big.NewInt(100))
+		if bumpedFee.Cmp(marketMaxFee) > 0 {
+			marketMaxFee = bumpedFee
 		}
 	}
 

--- a/rocketpool/api/node/cancel-transaction.go
+++ b/rocketpool/api/node/cancel-transaction.go
@@ -1,0 +1,268 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/urfave/cli/v3"
+
+	"github.com/rocket-pool/smartnode/rocketpool/api/response"
+	"github.com/rocket-pool/smartnode/rocketpool/api/snroute"
+	"github.com/rocket-pool/smartnode/shared/math"
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+const cancelTxGasLimit uint64 = 21000
+
+func canCancelNodeTransaction(c *cli.Command, nonce uint64) (*api.CanCancelNodeTransactionResponse, error) {
+	// Require node wallet
+	if err := services.RequireNodeWallet(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+	ec, err := services.GetEthClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify not in observe/masquerade mode
+	if _, err := w.GetNodePrivateKeyBytes(); err != nil {
+		return nil, fmt.Errorf("node is in observe mode; cannot sign transactions: %w", err)
+	}
+
+	nodeAccount, err := w.GetNodeAccount()
+	if err != nil {
+		return nil, err
+	}
+	nodeAddress := nodeAccount.Address
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Verify nonce >= latestNonce
+	latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error getting latest on-chain nonce: %w", err)
+	}
+	if nonce < latestNonce {
+		return nil, fmt.Errorf("nonce %d has already been mined (latest on-chain nonce is %d)", nonce, latestNonce)
+	}
+
+	// Calculate suggested gas fees
+	minPriorityFee, suggestedMaxFee := calculateReplacementFees(ctx, ec, nodeAddress, nonce)
+
+	// Check ETH balance
+	balance, err := ec.BalanceAt(ctx, nodeAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error getting node account balance: %w", err)
+	}
+
+	requiredBalance := new(big.Int).Mul(suggestedMaxFee, big.NewInt(int64(cancelTxGasLimit)))
+	if balance.Cmp(requiredBalance) < 0 {
+		return &api.CanCancelNodeTransactionResponse{
+			CanCancel:           false,
+			Nonce:               nonce,
+			GasLimit:            cancelTxGasLimit,
+			MinPriorityFeeGwei:  math.WeiToGwei(minPriorityFee),
+			SuggestedMaxFeeGwei: math.WeiToGwei(suggestedMaxFee),
+		}, fmt.Errorf("insufficient ETH balance: have %.6f ETH, need at least %.6f ETH for gas", math.WeiToEth(balance), math.WeiToEth(requiredBalance))
+	}
+
+	return &api.CanCancelNodeTransactionResponse{
+		CanCancel:           true,
+		Nonce:               nonce,
+		GasLimit:            cancelTxGasLimit,
+		MinPriorityFeeGwei:  math.WeiToGwei(minPriorityFee),
+		SuggestedMaxFeeGwei: math.WeiToGwei(suggestedMaxFee),
+	}, nil
+}
+
+func cancelNodeTransaction(c *cli.Command, nonce uint64, t *snroute.TransactOpts) (*api.CancelNodeTransactionResponse, error) {
+	// Require node wallet
+	if err := services.RequireNodeWallet(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+	ec, err := services.GetEthClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := w.GetNodePrivateKeyBytes(); err != nil {
+		return nil, fmt.Errorf("node is in observe mode; cannot sign transactions: %w", err)
+	}
+
+	nodeAccount, err := w.GetNodeAccount()
+	if err != nil {
+		return nil, err
+	}
+	nodeAddress := nodeAccount.Address
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Verify nonce is still valid
+	latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error getting latest on-chain nonce: %w", err)
+	}
+	if nonce < latestNonce {
+		return nil, fmt.Errorf("nonce %d has already been mined (latest on-chain nonce is %d)", nonce, latestNonce)
+	}
+
+	opts := t.Opts()
+	// Fall back to suggested replacement fees if none provided
+	if opts.GasTipCap == nil || opts.GasFeeCap == nil {
+		suggTip, suggFee := calculateReplacementFees(ctx, ec, nodeAddress, nonce)
+		if opts.GasTipCap == nil {
+			opts.GasTipCap = suggTip
+		}
+		if opts.GasFeeCap == nil {
+			opts.GasFeeCap = suggFee
+		}
+	}
+
+	// Prepare a 0-ETH dynamic fee self-transfer
+	chainID := w.GetChainID()
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:    chainID,
+		Nonce:      nonce,
+		GasTipCap:  opts.GasTipCap,
+		GasFeeCap:  opts.GasFeeCap,
+		Gas:        cancelTxGasLimit,
+		To:         &nodeAddress,
+		Value:      big.NewInt(0),
+		Data:       []byte{},
+		AccessList: []types.AccessTuple{},
+	})
+
+	if opts.Signer == nil {
+		return nil, fmt.Errorf("transactor signer is not configured")
+	}
+
+	signedTx, err := opts.Signer(opts.From, tx)
+	if err != nil {
+		return nil, fmt.Errorf("error signing cancellation transaction: %w", err)
+	}
+
+	if err := ec.SendTransaction(ctx, signedTx); err != nil {
+		return nil, fmt.Errorf("error broadcasting cancellation transaction: %w", err)
+	}
+
+	return &api.CancelNodeTransactionResponse{
+		TxHash: signedTx.Hash(),
+	}, nil
+}
+
+// calculateReplacementFees calculates appropriate tip and max fee for a replacement tx
+func calculateReplacementFees(ctx context.Context, ec *services.ExecutionClientManager, nodeAddress common.Address, nonce uint64) (*big.Int, *big.Int) {
+	// Base values from current network
+	suggestedTip, err := ec.SuggestGasTipCap(ctx)
+	if err != nil || suggestedTip == nil {
+		suggestedTip = math.GweiToWei(2.0)
+	}
+	// Default minimum 2 gwei tip
+	minTip := math.GweiToWei(2.0)
+	if suggestedTip.Cmp(minTip) < 0 {
+		suggestedTip = minTip
+	}
+
+	baseFee := big.NewInt(0)
+	if header, err := ec.HeaderByNumber(ctx, nil); err == nil && header != nil && header.BaseFee != nil {
+		baseFee = header.BaseFee
+	}
+
+	// Market max fee = 2 * BaseFee + Tip
+	marketMaxFee := new(big.Int).Mul(baseFee, big.NewInt(2))
+	marketMaxFee.Add(marketMaxFee, suggestedTip)
+
+	// Attempt txpool enrichment
+	var poolContent txPoolContentFromResponse
+	_ = ec.RawCallContext(ctx, &poolContent, "txpool_contentFrom", nodeAddress.Hex())
+
+	nonceStr := strconv.FormatUint(nonce, 10)
+	var existingTx map[string]interface{}
+	if txMap, ok := poolContent.Pending[nonceStr]; ok {
+		existingTx = txMap
+	} else if txMap, ok := poolContent.Queued[nonceStr]; ok {
+		existingTx = txMap
+	}
+
+	if existingTx != nil {
+		var oldTip *big.Int
+		var oldFee *big.Int
+
+		if p := parseHexBigInt(existingTx["maxPriorityFeePerGas"]); p != nil {
+			oldTip = p
+		}
+		if f := parseHexBigInt(existingTx["maxFeePerGas"]); f != nil {
+			oldFee = f
+		} else if gp := parseHexBigInt(existingTx["gasPrice"]); gp != nil {
+			oldFee = gp
+		}
+
+		if oldTip != nil {
+			// Apply 15% bump over old tip
+			bumpedTip := new(big.Int).Mul(oldTip, big.NewInt(115))
+			bumpedTip.Div(bumpedTip, big.NewInt(100))
+			if bumpedTip.Cmp(suggestedTip) > 0 {
+				suggestedTip = bumpedTip
+			}
+		}
+
+		if oldFee != nil {
+			// Apply 15% bump over old fee
+			bumpedFee := new(big.Int).Mul(oldFee, big.NewInt(115))
+			bumpedFee.Div(bumpedFee, big.NewInt(100))
+			if bumpedFee.Cmp(marketMaxFee) > 0 {
+				marketMaxFee = bumpedFee
+			}
+		}
+	}
+
+	// Ensure maxFee >= suggestedTip
+	if marketMaxFee.Cmp(suggestedTip) < 0 {
+		marketMaxFee = new(big.Int).Add(suggestedTip, math.GweiToWei(1.0))
+	}
+
+	return suggestedTip, marketMaxFee
+}
+
+func canCancelTransactionHandler(ctx snroute.Context) {
+	nonceStr := ctx.Request.URL.Query().Get("nonce")
+	nonce, err := strconv.ParseUint(nonceStr, 10, 64)
+	if err != nil {
+		response.WriteErrorResponse(ctx.Writer, fmt.Errorf("invalid nonce: %w", err))
+		return
+	}
+	resp, err := canCancelNodeTransaction(ctx.Command(), nonce)
+	response.WriteResponse(ctx.Writer, resp, err)
+}
+
+func cancelTransactionHandler(ctx snroute.WriteContext) {
+	nonceStr := ctx.Request.FormValue("nonce")
+	nonce, err := strconv.ParseUint(nonceStr, 10, 64)
+	if err != nil {
+		response.WriteErrorResponse(ctx.Writer, fmt.Errorf("invalid nonce: %w", err))
+		return
+	}
+	opts, err := ctx.Transactor()
+	if err != nil {
+		response.WriteErrorResponse(ctx.Writer, err)
+		return
+	}
+	resp, err := cancelNodeTransaction(ctx.Command(), nonce, opts)
+	response.WriteResponse(ctx.Writer, resp, err)
+}

--- a/rocketpool/api/node/mempool.go
+++ b/rocketpool/api/node/mempool.go
@@ -1,0 +1,107 @@
+package node
+
+import (
+	"context"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+// txPoolContentResponse represents the payload returned by txpool_contentFrom
+type txPoolContentResponse struct {
+	Pending map[string]map[string]interface{} `json:"pending"`
+	Queued  map[string]map[string]interface{} `json:"queued"`
+}
+
+// fetchNodeMempool performs a best-effort txpool_contentFrom query against the execution client.
+func fetchNodeMempool(ctx context.Context, ec *services.ExecutionClientManager, nodeAddress common.Address) *txPoolContentResponse {
+	var poolContent txPoolContentResponse
+	_ = ec.RawCallContext(ctx, &poolContent, "txpool_contentFrom", nodeAddress.Hex())
+	return &poolContent
+}
+
+// findTxByNonce looks for a transaction at the given nonce in pending or queued sets.
+func (p *txPoolContentResponse) findTxByNonce(nonce uint64) map[string]interface{} {
+	if p == nil {
+		return nil
+	}
+	nonceStr := strconv.FormatUint(nonce, 10)
+	if txMap, ok := p.Pending[nonceStr]; ok {
+		return txMap
+	}
+	if txMap, ok := p.Queued[nonceStr]; ok {
+		return txMap
+	}
+	return nil
+}
+
+// getTxGasFees extracts the max priority fee and max fee (or gasPrice) for the given nonce if known.
+func (p *txPoolContentResponse) getTxGasFees(nonce uint64) (oldTip *big.Int, oldFee *big.Int) {
+	txMap := p.findTxByNonce(nonce)
+	if txMap == nil {
+		return nil, nil
+	}
+	if tip := parseHexBigInt(txMap["maxPriorityFeePerGas"]); tip != nil {
+		oldTip = tip
+	}
+	if fee := parseHexBigInt(txMap["maxFeePerGas"]); fee != nil {
+		oldFee = fee
+	} else if gp := parseHexBigInt(txMap["gasPrice"]); gp != nil {
+		oldFee = gp
+	}
+	return oldTip, oldFee
+}
+
+// populatePendingTxDetails fills in item fields from txMap if available.
+func populatePendingTxDetails(item *api.PendingTxDetails, txMap map[string]interface{}) {
+	if txMap == nil {
+		return
+	}
+	if hStr, ok := txMap["hash"].(string); ok && hStr != "" {
+		h := common.HexToHash(hStr)
+		item.Hash = &h
+	}
+	if toStr, ok := txMap["to"].(string); ok && toStr != "" {
+		to := common.HexToAddress(toStr)
+		item.To = &to
+	}
+	if val := parseHexBigInt(txMap["value"]); val != nil {
+		item.Value = val
+	}
+	if gas := parseHexUint64(txMap["gas"]); gas > 0 {
+		item.GasLimit = gas
+	}
+	if maxFee := parseHexBigInt(txMap["maxFeePerGas"]); maxFee != nil {
+		item.MaxFeePerGas = maxFee
+	} else if gasPrice := parseHexBigInt(txMap["gasPrice"]); gasPrice != nil {
+		item.MaxFeePerGas = gasPrice
+	}
+	if maxPrio := parseHexBigInt(txMap["maxPriorityFeePerGas"]); maxPrio != nil {
+		item.MaxPriorityFee = maxPrio
+	}
+}
+
+// parseHexUint64 parses a hex string like "0x5208" or scalar to uint64.
+func parseHexUint64(v interface{}) uint64 {
+	if s, ok := v.(string); ok {
+		s = strings.TrimPrefix(s, "0x")
+		n, _ := strconv.ParseUint(s, 16, 64)
+		return n
+	}
+	return 0
+}
+
+// parseHexBigInt parses a hex string like "0x123" to *big.Int.
+func parseHexBigInt(v interface{}) *big.Int {
+	if s, ok := v.(string); ok {
+		s = strings.TrimPrefix(s, "0x")
+		b, _ := new(big.Int).SetString(s, 16)
+		return b
+	}
+	return nil
+}

--- a/rocketpool/api/node/mempool_test.go
+++ b/rocketpool/api/node/mempool_test.go
@@ -1,0 +1,143 @@
+package node
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+func TestParseHexUint64(t *testing.T) {
+	if val := parseHexUint64("0x5208"); val != 21000 {
+		t.Fatalf("expected 21000, got %d", val)
+	}
+	if val := parseHexUint64(nil); val != 0 {
+		t.Fatalf("expected 0 for nil, got %d", val)
+	}
+	if val := parseHexUint64("invalid"); val != 0 {
+		t.Fatalf("expected 0 for invalid, got %d", val)
+	}
+	if val := parseHexUint64("a"); val != 10 {
+		t.Fatalf("expected 10, got %d", val)
+	}
+}
+
+func TestParseHexBigInt(t *testing.T) {
+	b := parseHexBigInt("0x10")
+	if b == nil || b.Cmp(big.NewInt(16)) != 0 {
+		t.Fatalf("expected 16, got %v", b)
+	}
+
+	if parseHexBigInt(nil) != nil {
+		t.Fatalf("expected nil for nil input")
+	}
+	if parseHexBigInt("invalid_hex_string") != nil {
+		t.Fatalf("expected nil for invalid string")
+	}
+}
+
+func TestTxPoolContentResponse_FindTxByNonce(t *testing.T) {
+	var nilResp *txPoolContentResponse
+	if nilResp.findTxByNonce(5) != nil {
+		t.Fatalf("expected nil for nil receiver")
+	}
+
+	pool := &txPoolContentResponse{
+		Pending: map[string]map[string]interface{}{
+			"10": {"hash": "0x1111111111111111111111111111111111111111111111111111111111111111"},
+		},
+		Queued: map[string]map[string]interface{}{
+			"11": {"hash": "0x2222222222222222222222222222222222222222222222222222222222222222"},
+		},
+	}
+
+	if pool.findTxByNonce(10) == nil {
+		t.Fatalf("expected tx at nonce 10")
+	}
+	if pool.findTxByNonce(11) == nil {
+		t.Fatalf("expected tx at nonce 11")
+	}
+	if pool.findTxByNonce(12) != nil {
+		t.Fatalf("expected nil at nonce 12")
+	}
+}
+
+func TestTxPoolContentResponse_GetTxGasFees(t *testing.T) {
+	pool := &txPoolContentResponse{
+		Pending: map[string]map[string]interface{}{
+			"10": {
+				"maxPriorityFeePerGas": "0x77359400", // 2 Gwei
+				"maxFeePerGas":         "0xba43b7400", // 50 Gwei
+			},
+			"11": {
+				"gasPrice": "0x4a817c800", // 20 Gwei legacy
+			},
+		},
+		Queued: map[string]map[string]interface{}{},
+	}
+
+	tip, fee := pool.getTxGasFees(10)
+	if tip == nil || tip.Cmp(big.NewInt(2000000000)) != 0 {
+		t.Fatalf("expected tip 2000000000, got %v", tip)
+	}
+	if fee == nil || fee.Cmp(big.NewInt(50000000000)) != 0 {
+		t.Fatalf("expected fee 50000000000, got %v", fee)
+	}
+
+	tipLegacy, feeLegacy := pool.getTxGasFees(11)
+	if tipLegacy != nil {
+		t.Fatalf("expected nil tip for legacy tx, got %v", tipLegacy)
+	}
+	if feeLegacy == nil || feeLegacy.Cmp(big.NewInt(20000000000)) != 0 {
+		t.Fatalf("expected fee 20000000000, got %v", feeLegacy)
+	}
+
+	tipMissing, feeMissing := pool.getTxGasFees(999)
+	if tipMissing != nil || feeMissing != nil {
+		t.Fatalf("expected nil for missing nonce")
+	}
+}
+
+func TestPopulatePendingTxDetails(t *testing.T) {
+	item := &api.PendingTxDetails{Nonce: 42}
+	populatePendingTxDetails(item, nil)
+	if item.Hash != nil {
+		t.Fatalf("expected nil hash when txMap is nil")
+	}
+
+	targetTo := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	txMap := map[string]interface{}{
+		"hash":                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"to":                   targetTo.Hex(),
+		"value":                "0xde0b6b3a7640000", // 1 ETH
+		"gas":                  "0x5208",            // 21000
+		"maxFeePerGas":         "0x2540be400",       // 10 Gwei
+		"maxPriorityFeePerGas": "0x77359400",        // 2 Gwei
+	}
+
+	populatePendingTxDetails(item, txMap)
+
+	if item.Hash == nil || item.Hash.Hex() != "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("unexpected hash: %v", item.Hash)
+	}
+	if item.To == nil || *item.To != targetTo {
+		t.Fatalf("unexpected to: %v", item.To)
+	}
+	if item.Value == nil || item.Value.Cmp(big.NewInt(1000000000000000000)) != 0 {
+		t.Fatalf("unexpected value: %v", item.Value)
+	}
+	if item.GasLimit != 21000 {
+		t.Fatalf("expected gas 21000, got %d", item.GasLimit)
+	}
+	if item.MaxFeePerGas == nil || item.MaxFeePerGas.Cmp(big.NewInt(10000000000)) != 0 {
+		t.Fatalf("unexpected max fee: %v", item.MaxFeePerGas)
+	}
+	if item.MaxPriorityFee == nil || item.MaxPriorityFee.Cmp(big.NewInt(2000000000)) != 0 {
+		t.Fatalf("unexpected max priority fee: %v", item.MaxPriorityFee)
+	}
+	if !item.IsEnriched() {
+		t.Fatalf("expected item.IsEnriched() to be true")
+	}
+}

--- a/rocketpool/api/node/pending-transactions.go
+++ b/rocketpool/api/node/pending-transactions.go
@@ -1,0 +1,140 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/urfave/cli/v3"
+
+	"github.com/rocket-pool/smartnode/rocketpool/api/response"
+	"github.com/rocket-pool/smartnode/rocketpool/api/snroute"
+	"github.com/rocket-pool/smartnode/shared/services"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+type txPoolContentFromResponse struct {
+	Pending map[string]map[string]interface{} `json:"pending"`
+	Queued  map[string]map[string]interface{} `json:"queued"`
+}
+
+func nodePendingTransactions(c *cli.Command) (*api.NodePendingTransactionsResponse, error) {
+	// Require node wallet
+	if err := services.RequireNodeWallet(c); err != nil {
+		return nil, err
+	}
+	w, err := services.GetWallet(c)
+	if err != nil {
+		return nil, err
+	}
+	ec, err := services.GetEthClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeAccount, err := w.GetNodeAccount()
+	if err != nil {
+		return nil, err
+	}
+	nodeAddress := nodeAccount.Address
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// 1. Get latest mined nonce and pending mempool nonce
+	latestNonce, err := ec.NonceAt(ctx, nodeAddress, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error getting latest on-chain nonce: %w", err)
+	}
+
+	pendingNonce, err := ec.PendingNonceAt(ctx, nodeAddress)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pending nonce: %w", err)
+	}
+
+	resp := api.NodePendingTransactionsResponse{
+		NodeAddress:         nodeAddress,
+		LatestNonce:         latestNonce,
+		PendingNonce:        pendingNonce,
+		PendingTransactions: make([]api.PendingTxDetails, 0),
+	}
+
+	if pendingNonce > latestNonce {
+		resp.PendingCount = pendingNonce - latestNonce
+
+		// 2. Best-effort mempool query via txpool_contentFrom
+		var poolContent txPoolContentFromResponse
+		_ = ec.RawCallContext(ctx, &poolContent, "txpool_contentFrom", nodeAddress.Hex())
+
+		for nonce := latestNonce; nonce < pendingNonce; nonce++ {
+			nonceStr := strconv.FormatUint(nonce, 10)
+			item := api.PendingTxDetails{
+				Nonce:   nonce,
+				IsStuck: true,
+			}
+
+			// Check if enriched details exist in txpool output
+			if txMap, ok := poolContent.Pending[nonceStr]; ok {
+				enrichPendingTxDetails(&item, txMap)
+			} else if txMap, ok := poolContent.Queued[nonceStr]; ok {
+				enrichPendingTxDetails(&item, txMap)
+			}
+
+			resp.PendingTransactions = append(resp.PendingTransactions, item)
+		}
+	}
+
+	return &resp, nil
+}
+
+func enrichPendingTxDetails(item *api.PendingTxDetails, txMap map[string]interface{}) {
+	if hStr, ok := txMap["hash"].(string); ok && hStr != "" {
+		h := common.HexToHash(hStr)
+		item.Hash = &h
+	}
+	if toStr, ok := txMap["to"].(string); ok && toStr != "" {
+		to := common.HexToAddress(toStr)
+		item.To = &to
+	}
+	if val := parseHexBigInt(txMap["value"]); val != nil {
+		item.Value = val
+	}
+	if gas := parseHexUint64(txMap["gas"]); gas > 0 {
+		item.GasLimit = gas
+	}
+	if maxFee := parseHexBigInt(txMap["maxFeePerGas"]); maxFee != nil {
+		item.MaxFeePerGas = maxFee
+	} else if gasPrice := parseHexBigInt(txMap["gasPrice"]); gasPrice != nil {
+		item.MaxFeePerGas = gasPrice
+	}
+	if maxPrio := parseHexBigInt(txMap["maxPriorityFeePerGas"]); maxPrio != nil {
+		item.MaxPriorityFee = maxPrio
+	}
+}
+
+func parseHexUint64(v interface{}) uint64 {
+	if s, ok := v.(string); ok {
+		s = strings.TrimPrefix(s, "0x")
+		n, _ := strconv.ParseUint(s, 16, 64)
+		return n
+	}
+	return 0
+}
+
+func parseHexBigInt(v interface{}) *big.Int {
+	if s, ok := v.(string); ok {
+		s = strings.TrimPrefix(s, "0x")
+		b, _ := new(big.Int).SetString(s, 16)
+		return b
+	}
+	return nil
+}
+
+func pendingTransactionsHandler(ctx snroute.Context) {
+	resp, err := nodePendingTransactions(ctx.Command())
+	response.WriteResponse(ctx.Writer, resp, err)
+}

--- a/rocketpool/api/node/pending-transactions.go
+++ b/rocketpool/api/node/pending-transactions.go
@@ -3,12 +3,8 @@ package node
 import (
 	"context"
 	"fmt"
-	"math/big"
-	"strconv"
-	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v3"
 
 	"github.com/rocket-pool/smartnode/rocketpool/api/response"
@@ -16,11 +12,6 @@ import (
 	"github.com/rocket-pool/smartnode/shared/services"
 	"github.com/rocket-pool/smartnode/shared/types/api"
 )
-
-type txPoolContentFromResponse struct {
-	Pending map[string]map[string]interface{} `json:"pending"`
-	Queued  map[string]map[string]interface{} `json:"queued"`
-}
 
 func nodePendingTransactions(c *cli.Command) (*api.NodePendingTransactionsResponse, error) {
 	// Require node wallet
@@ -67,71 +58,19 @@ func nodePendingTransactions(c *cli.Command) (*api.NodePendingTransactionsRespon
 		resp.PendingCount = pendingNonce - latestNonce
 
 		// 2. Best-effort mempool query via txpool_contentFrom
-		var poolContent txPoolContentFromResponse
-		_ = ec.RawCallContext(ctx, &poolContent, "txpool_contentFrom", nodeAddress.Hex())
+		poolContent := fetchNodeMempool(ctx, ec, nodeAddress)
 
 		for nonce := latestNonce; nonce < pendingNonce; nonce++ {
-			nonceStr := strconv.FormatUint(nonce, 10)
 			item := api.PendingTxDetails{
 				Nonce:   nonce,
 				IsStuck: true,
 			}
-
-			// Check if enriched details exist in txpool output
-			if txMap, ok := poolContent.Pending[nonceStr]; ok {
-				enrichPendingTxDetails(&item, txMap)
-			} else if txMap, ok := poolContent.Queued[nonceStr]; ok {
-				enrichPendingTxDetails(&item, txMap)
-			}
-
+			populatePendingTxDetails(&item, poolContent.findTxByNonce(nonce))
 			resp.PendingTransactions = append(resp.PendingTransactions, item)
 		}
 	}
 
 	return &resp, nil
-}
-
-func enrichPendingTxDetails(item *api.PendingTxDetails, txMap map[string]interface{}) {
-	if hStr, ok := txMap["hash"].(string); ok && hStr != "" {
-		h := common.HexToHash(hStr)
-		item.Hash = &h
-	}
-	if toStr, ok := txMap["to"].(string); ok && toStr != "" {
-		to := common.HexToAddress(toStr)
-		item.To = &to
-	}
-	if val := parseHexBigInt(txMap["value"]); val != nil {
-		item.Value = val
-	}
-	if gas := parseHexUint64(txMap["gas"]); gas > 0 {
-		item.GasLimit = gas
-	}
-	if maxFee := parseHexBigInt(txMap["maxFeePerGas"]); maxFee != nil {
-		item.MaxFeePerGas = maxFee
-	} else if gasPrice := parseHexBigInt(txMap["gasPrice"]); gasPrice != nil {
-		item.MaxFeePerGas = gasPrice
-	}
-	if maxPrio := parseHexBigInt(txMap["maxPriorityFeePerGas"]); maxPrio != nil {
-		item.MaxPriorityFee = maxPrio
-	}
-}
-
-func parseHexUint64(v interface{}) uint64 {
-	if s, ok := v.(string); ok {
-		s = strings.TrimPrefix(s, "0x")
-		n, _ := strconv.ParseUint(s, 16, 64)
-		return n
-	}
-	return 0
-}
-
-func parseHexBigInt(v interface{}) *big.Int {
-	if s, ok := v.(string); ok {
-		s = strings.TrimPrefix(s, "0x")
-		b, _ := new(big.Int).SetString(s, 16)
-		return b
-	}
-	return nil
 }
 
 func pendingTransactionsHandler(ctx snroute.Context) {

--- a/rocketpool/api/node/pending-transactions_test.go
+++ b/rocketpool/api/node/pending-transactions_test.go
@@ -1,0 +1,77 @@
+package node
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rocket-pool/smartnode/shared/types/api"
+)
+
+func TestParseHexHelpers(t *testing.T) {
+	// parseHexUint64 tests
+	if got := parseHexUint64("0x1a"); got != 26 {
+		t.Errorf("expected 26, got %d", got)
+	}
+	if got := parseHexUint64("0x5208"); got != 21000 {
+		t.Errorf("expected 21000, got %d", got)
+	}
+	if got := parseHexUint64("0x0"); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+	if got := parseHexUint64(123); got != 0 {
+		t.Errorf("expected 0 for non-string, got %d", got)
+	}
+
+	// parseHexBigInt tests
+	val := parseHexBigInt("0xde0b6b3a7640000") // 1 ETH in wei
+	expectedVal, _ := new(big.Int).SetString("1000000000000000000", 10)
+	if val == nil || val.Cmp(expectedVal) != 0 {
+		t.Errorf("expected 1 ETH (10^18 wei), got %v", val)
+	}
+
+	zeroVal := parseHexBigInt("0x0")
+	if zeroVal == nil || zeroVal.Cmp(big.NewInt(0)) != 0 {
+		t.Errorf("expected 0, got %v", zeroVal)
+	}
+
+	if got := parseHexBigInt(123); got != nil {
+		t.Errorf("expected nil for non-string, got %v", got)
+	}
+}
+
+func TestEnrichPendingTxDetails(t *testing.T) {
+	item := api.PendingTxDetails{
+		Nonce:   10,
+		IsStuck: true,
+	}
+
+	expectedHash := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	expectedTo := "0x1111111111111111111111111111111111111111"
+	txMap := map[string]interface{}{
+		"hash":                  expectedHash,
+		"to":                    expectedTo,
+		"value":                 "0xde0b6b3a7640000", // 1 ETH
+		"gas":                   "0x5208",            // 21000
+		"maxFeePerGas":          "0x4a817c800",       // 20 Gwei
+		"maxPriorityFeePerGas":  "0x77359400",        // 2 Gwei
+	}
+
+	enrichPendingTxDetails(&item, txMap)
+
+	if item.Hash == nil || item.Hash.Hex() != common.HexToHash(expectedHash).Hex() {
+		t.Errorf("hash mismatch: expected %s, got %v", expectedHash, item.Hash)
+	}
+	if item.To == nil || item.To.Hex() != common.HexToAddress(expectedTo).Hex() {
+		t.Errorf("to address mismatch: expected %s, got %v", expectedTo, item.To)
+	}
+	if item.GasLimit != 21000 {
+		t.Errorf("expected gas limit 21000, got %d", item.GasLimit)
+	}
+	if item.MaxFeePerGas == nil || item.MaxFeePerGas.Cmp(big.NewInt(20000000000)) != 0 {
+		t.Errorf("maxFeePerGas mismatch: expected 20 Gwei, got %v", item.MaxFeePerGas)
+	}
+	if item.MaxPriorityFee == nil || item.MaxPriorityFee.Cmp(big.NewInt(2000000000)) != 0 {
+		t.Errorf("maxPriorityFee mismatch: expected 2 Gwei, got %v", item.MaxPriorityFee)
+	}
+}

--- a/rocketpool/api/node/pending-transactions_test.go
+++ b/rocketpool/api/node/pending-transactions_test.go
@@ -57,7 +57,7 @@ func TestEnrichPendingTxDetails(t *testing.T) {
 		"maxPriorityFeePerGas":  "0x77359400",        // 2 Gwei
 	}
 
-	enrichPendingTxDetails(&item, txMap)
+	populatePendingTxDetails(&item, txMap)
 
 	if item.Hash == nil || item.Hash.Hex() != common.HexToHash(expectedHash).Hex() {
 		t.Errorf("hash mismatch: expected %s, got %v", expectedHash, item.Hash)

--- a/rocketpool/api/node/routes.go
+++ b/rocketpool/api/node/routes.go
@@ -166,6 +166,12 @@ func RegisterRoutes(router *snroute.Router) {
 	// --- Bond requirement ---
 
 	snroute.Read("/api/node/get-bond-requirement", getBondRequirementHandler).RegisterTo(router)
+
+	// --- Pending transactions ---
+
+	snroute.Read("/api/node/pending-transactions", pendingTransactionsHandler).RegisterTo(router)
+	snroute.Read("/api/node/can-cancel-transaction", canCancelTransactionHandler).RegisterTo(router)
+	snroute.Write("/api/node/cancel-transaction", cancelTransactionHandler).RegisterTo(router)
 }
 
 // --- Helper types and functions ---

--- a/shared/services/ec-manager.go
+++ b/shared/services/ec-manager.go
@@ -231,6 +231,17 @@ func (p *ExecutionClientManager) PendingNonceAt(ctx context.Context, account com
 	return result.(uint64), err
 }
 
+// RawCallContext executes a raw JSON-RPC call against the active execution client.
+func (p *ExecutionClientManager) RawCallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	if p.static != nil {
+		return fmt.Errorf("raw RPC call %s not supported in static mode", method)
+	}
+	_, err := p.runFunction(func(client *EthClient) (interface{}, error) {
+		return nil, client.Client.Client().CallContext(ctx, result, method, args...)
+	})
+	return err
+}
+
 // SuggestGasPrice retrieves the currently suggested gas price to allow a timely
 // execution of a transaction.
 func (p *ExecutionClientManager) SuggestGasPrice(ctx context.Context) (*big.Int, error) {

--- a/shared/services/rocketpool/node.go
+++ b/shared/services/rocketpool/node.go
@@ -538,3 +538,22 @@ func (c *Client) ClaimUnclaimedRewards(nodeAddress common.Address) (api.ClaimUnc
 func (c *Client) GetBondRequirement(numValidators uint64) (api.GetBondRequirementResponse, error) {
 	return c.callAPI[api.GetBondRequirementResponse]("GET", "/api/node/get-bond-requirement", url.Values{"numValidators": {strconv.FormatUint(numValidators, 10)}}, "Could not get get-bond-requirement response")
 }
+
+// Get pending transactions for the node
+func (c *Client) NodePendingTransactions() (api.NodePendingTransactionsResponse, error) {
+	return c.callAPI[api.NodePendingTransactionsResponse]("GET", "/api/node/pending-transactions", nil, "Could not get pending transactions")
+}
+
+// Check if a pending transaction can be cancelled
+func (c *Client) CanCancelNodeTransaction(nonce uint64) (api.CanCancelNodeTransactionResponse, error) {
+	return c.callAPI[api.CanCancelNodeTransactionResponse]("GET", "/api/node/can-cancel-transaction", url.Values{
+		"nonce": {strconv.FormatUint(nonce, 10)},
+	}, "Could not get can-cancel-transaction response")
+}
+
+// Cancel a pending transaction by sending a replacement 0-ETH transaction
+func (c *Client) CancelNodeTransaction(nonce uint64) (api.CancelNodeTransactionResponse, error) {
+	return c.callAPI[api.CancelNodeTransactionResponse]("POST", "/api/node/cancel-transaction", url.Values{
+		"nonce": {strconv.FormatUint(nonce, 10)},
+	}, "Could not cancel transaction")
+}

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -792,3 +792,37 @@ type ClaimUnclaimedRewardsResponse struct {
 	APIResponse
 	TxHash common.Hash `json:"txHash"`
 }
+
+type NodePendingTransactionsResponse struct {
+	APIResponse
+	NodeAddress         common.Address     `json:"nodeAddress"`
+	LatestNonce         uint64             `json:"latestNonce"`
+	PendingNonce        uint64             `json:"pendingNonce"`
+	PendingCount        uint64             `json:"pendingCount"`
+	PendingTransactions []PendingTxDetails `json:"pendingTransactions"`
+}
+
+type PendingTxDetails struct {
+	Nonce          uint64          `json:"nonce"`
+	Hash           *common.Hash    `json:"hash,omitempty"`
+	To             *common.Address `json:"to,omitempty"`
+	Value          *big.Int        `json:"value,omitempty"`
+	GasLimit       uint64          `json:"gasLimit"`
+	MaxFeePerGas   *big.Int        `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFee *big.Int        `json:"maxPriorityFeePerGas,omitempty"`
+	IsStuck        bool            `json:"isStuck"`
+}
+
+type CanCancelNodeTransactionResponse struct {
+	APIResponse
+	CanCancel           bool    `json:"canCancel"`
+	Nonce               uint64  `json:"nonce"`
+	GasLimit            uint64  `json:"gasLimit"`
+	MinPriorityFeeGwei  float64 `json:"minPriorityFeeGwei"`
+	SuggestedMaxFeeGwei float64 `json:"suggestedMaxFeeGwei"`
+}
+
+type CancelNodeTransactionResponse struct {
+	APIResponse
+	TxHash common.Hash `json:"txHash"`
+}

--- a/shared/types/api/node.go
+++ b/shared/types/api/node.go
@@ -793,6 +793,7 @@ type ClaimUnclaimedRewardsResponse struct {
 	TxHash common.Hash `json:"txHash"`
 }
 
+// NodePendingTransactionsResponse contains the pending transaction state of the node account.
 type NodePendingTransactionsResponse struct {
 	APIResponse
 	NodeAddress         common.Address     `json:"nodeAddress"`
@@ -802,6 +803,7 @@ type NodePendingTransactionsResponse struct {
 	PendingTransactions []PendingTxDetails `json:"pendingTransactions"`
 }
 
+// PendingTxDetails describes a single pending or stuck transaction in the node account's queue.
 type PendingTxDetails struct {
 	Nonce          uint64          `json:"nonce"`
 	Hash           *common.Hash    `json:"hash,omitempty"`
@@ -813,6 +815,17 @@ type PendingTxDetails struct {
 	IsStuck        bool            `json:"isStuck"`
 }
 
+// HasHash returns true if the transaction hash was resolved from the mempool.
+func (p PendingTxDetails) HasHash() bool {
+	return p.Hash != nil
+}
+
+// IsEnriched returns true if detailed mempool metadata (hash or gas parameters) was resolved.
+func (p PendingTxDetails) IsEnriched() bool {
+	return p.Hash != nil || p.MaxFeePerGas != nil
+}
+
+// CanCancelNodeTransactionResponse contains preflight verification and suggested gas parameters for cancelling a transaction.
 type CanCancelNodeTransactionResponse struct {
 	APIResponse
 	CanCancel           bool    `json:"canCancel"`
@@ -822,6 +835,7 @@ type CanCancelNodeTransactionResponse struct {
 	SuggestedMaxFeeGwei float64 `json:"suggestedMaxFeeGwei"`
 }
 
+// CancelNodeTransactionResponse contains the transaction hash of a broadcasted cancellation transaction.
 type CancelNodeTransactionResponse struct {
 	APIResponse
 	TxHash common.Hash `json:"txHash"`

--- a/shared/types/api/pending_tx_test.go
+++ b/shared/types/api/pending_tx_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestPendingTxDetailsMethods(t *testing.T) {
+	empty := PendingTxDetails{Nonce: 1}
+	if empty.HasHash() {
+		t.Error("expected empty.HasHash() to be false")
+	}
+	if empty.IsEnriched() {
+		t.Error("expected empty.IsEnriched() to be false")
+	}
+
+	h := common.HexToHash("0x123")
+	withHash := PendingTxDetails{Nonce: 2, Hash: &h}
+	if !withHash.HasHash() {
+		t.Error("expected withHash.HasHash() to be true")
+	}
+	if !withHash.IsEnriched() {
+		t.Error("expected withHash.IsEnriched() to be true")
+	}
+
+	withFee := PendingTxDetails{Nonce: 3, MaxFeePerGas: big.NewInt(100)}
+	if withFee.HasHash() {
+		t.Error("expected withFee.HasHash() to be false")
+	}
+	if !withFee.IsEnriched() {
+		t.Error("expected withFee.IsEnriched() to be true")
+	}
+}


### PR DESCRIPTION
### Summary
Resolves #351

Implements native CLI commands and daemon endpoints to inspect and unblock/cancel stuck transactions in the Rocket Pool node account's queue.

Node operators who experience base fee or priority fee spikes after submitting on-chain operations previously had to manually look up nonces and calculate replacement gas fees on block explorers. This change provides automated queue inspection and safe EIP-1559 0-ETH replacement transaction submission with appropriate fee bumps.

---

### Key Changes

#### 1. CLI Commands (`rocketpool-cli/node/`)
- `rocketpool node pending-transactions` (aliases: `pending-txs`, `pending`, `txs`):
  - Displays on-chain mined nonce vs. mempool pending nonce.
  - Formats an aligned table of pending transactions with hash, recipient, value, and fee parameters.
  - Provides actionable command suggestions to unblock the queue.
- `rocketpool node cancel-transaction` (aliases: `cancel-tx`, `cancel`):
  - `--nonce, -n <uint>`: cancels a specific stuck nonce (defaults to lowest blocking nonce).
  - `--all, -a`: batch cancels all pending nonces in sequential ascending order.
  - `--yes, -y`: bypasses interactive confirmation prompts.

#### 2. Daemon API Layer (`rocketpool/api/node/`)
- Registered routes via `snroute`:
  - `GET /api/node/pending-transactions` (`snroute.Read`)
  - `GET /api/node/can-cancel-transaction` (`snroute.Read`)
  - `POST /api/node/cancel-transaction` (`snroute.Write`)
- `mempool.go`: Centralized helper querying `txpool_contentFrom` JSON-RPC with safe hex decoding and txpool enrichment.
- `cancel-transaction.go`: Preflight validation, EIP-1559 replacement fee calculation (enforcing $\ge 15\%$ bump over previous fee or market rate), and 0-ETH dynamic fee self-transfer broadcasting.

#### 3. Shared Services & Types (`shared/`)
- `shared/types/api/node.go`: API response models (`NodePendingTransactionsResponse`, `PendingTxDetails`, `CanCancelNodeTransactionResponse`, `CancelNodeTransactionResponse`).
- `shared/services/ec-manager.go`: Added `RawCallContext` for raw execution client JSON-RPC calls.
- `shared/services/rocketpool/node.go`: Added client SDK wrapper methods.

---

### Verification & Tests

| Test Suite | Command / Target | Status |
| :--- | :--- | :--- |
| **Full Repo Unit Tests** | `go test $(go list ./... \| grep -v bindings)` | ✅ Passed (0 failures) |
| **Node API Tests** | `go test -v ./rocketpool/api/node/...` | ✅ Passed |
| **CLI Formatting & Commands** | `go test -v ./rocketpool-cli/node/...` | ✅ Passed |
| **Route Classification Tests** | `go test -v ./rocketpool/node/routes/...` | ✅ Passed |
| **Workspace Compilation** | `go build ./...` | ✅ Passed (Exit 0) |
| **Go Vet** | `go vet ./...` | ✅ Passed (0 warnings) |
