### PR TITLE
Fix executeUpgradeHandler ID parsing and error response

### DIFF
--- a/rocketpool/api/upgrade/execute-upgrade.go
+++ b/rocketpool/api/upgrade/execute-upgrade.go
@@ -127,9 +127,9 @@ func executeUpgrade(c *cli.Command, upgradeProposalId uint64, t *snroute.Transac
 }
 
 func canExecuteUpgradeHandler(ctx snroute.Context) {
-	id, err := cliutils.ValidatePositiveUint("upgrade proposal ID", ctx.Request.URL.Query().Get("id"))
+	id, err := cliutils.ValidatePositiveUint("upgrade proposal ID", ctx.Request.FormValue("id"))
 	if err != nil {
-		response.WriteResponse(ctx.Writer, nil, err)
+		response.WriteErrorResponse(ctx.Writer, err)
 		return
 	}
 	resp, err := canExecuteUpgrade(ctx.Command(), id)
@@ -137,9 +137,9 @@ func canExecuteUpgradeHandler(ctx snroute.Context) {
 }
 
 func executeUpgradeHandler(ctx snroute.WriteContext) {
-	id, err := strconv.ParseUint(ctx.Request.URL.Query().Get("id"), 10, 64)
+	id, err := strconv.ParseUint(ctx.Request.FormValue("id"), 10, 64)
 	if err != nil {
-		response.WriteResponse(ctx.Writer, nil, err)
+		response.WriteErrorResponse(ctx.Writer, err)
 		return
 	}
 	opts, err := ctx.Transactor()


### PR DESCRIPTION
Resolves the following issue: 
```
tpan@tpan-meerkat:~$ rp4 o u eu
Please select a proposal to execute:
1: All available proposals
2: proposal 2 (name: 'rocketDAOProtocolVerifier', type: 'UpgradeContract', upgrade address: '0xc4D85aA3e318c38005F6D73cC53E5A2b4223723a', upgrade ABI: 'eJzlWE2P2jAQ/SurnFEPW7VacevuXjh0haDqBaHISQawmtiRPYZGq/3vHUNInE1IUgm6gd5wPB7Pm4/nGRavHhepQe2NF/YnghIs/pGl4I29UApULMS7mQx/Ac5RKraGiRVasRC8kSdYYgV95Qp8iyIFWtM2HvSw/MPbcuRpZAjfDbKAxxwz2hVSpCxjQQzlCbpZozIhKfTeRq8eI6EskYbMXLFYw6hqdQS/IfLGdGK/UwFhaH3/5WtpbKpkKjWLJ8/lfUche1e7OlaAy9WFGxbHINagGgC76grD283by3dY1lMV8gTI30naoG5ZSD0dAcxNkHBEuqAQhy0IHHoEDurO5X9GIAnzPwzANHfHoxTRo1Hi/wvA5/tSWRATl7yYJHD15UJnrqdQJqkU5OBG9qtp0iY55a7KwSBD0C6kDdOb8uRx22ZAB5gDB97Zlf70IiOHcpWUTpKiSYk+rxPTYukUjAKw3/Q7aCRzufqbkStbue/0C1m70W8trfLOgOrcrXsSlgbza3o/kysjQuRSnNfKevTzLTdSPsWCh26gSiEHZxgznliAT+4zedtQpyUdDh9oFeaQmbIvM/risBwkNfanQn/HUVTa6IIJnZxTQDlV1NatZFwJMIIVITwy5ZDwlTauAYsI1Li8+5pm3XVoWw67jwE1BcXlNcM6Ty66LplbHO0eAWGSvLZrxxp99DCUwD/vi26SO+Sjgv7OpBQ3lIczGs4ulYmpUVfCiuSQ/M1z/TD8960pJvn7PIzMP9mSXzvf1WZ2v2tobx3S/a4pffi5WOm12ubOpWOlHRKPOTI7TOCDaUhuvsWvREz0jNbFo1SvrK3EvyiraoAsrEnbP8CXzhAynov1VO7eF/aV5kmfKWpL/e0q+ym7OrpAyriJ8Pffz9HokCHabne+PA/n6iGXfwDUK8OH')
2

+============== Suggested Gas Prices ===============+
|   Speed   |    Max Fee   |      Total Gas Cost     |
| Fast      | 1.05662 gwei | 0.000000 to 0.000000 ETH |
| Standard  | 1.05147 gwei | 0.000000 to 0.000000 ETH |
| Slow      | 1.05135 gwei | 0.000000 to 0.000000 ETH |
+====================================================+

These prices include a maximum priority fee of 1.0000 gwei.
Please enter your max fee (including the priority fee) or leave blank for the default of 1.05662 gwei:


Using a max fee of 1.057 gwei and a priority fee of 1.000 gwei.
Are you sure you want to execute 1 proposals? [y/n]
y

Could not execute proposal 2: Could not execute upgrade proposal: invalid API response.
```

- We need `.FormValue("id")` instead of `.URL.Query().Get("id")` to properly parse the ID.
- `WriteErrorResponse()` returns the actual error instead of a generic `invalid API response`

Verification: 

Before:
```
$ curl -s -X POST http://123.4.5.6:7890/api/upgrade/execute-upgrade \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -H "Authorization: Bearer <api-token>" \
  -d "id=999"
{"status":"error","error":"invalid API response"}
```
After:
```
$ curl -s -X POST http://123.4.5.6:7890/api/upgrade/execute-upgrade \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -H "Authorization: Bearer <api-token>" \
  -d "id=999"
{"status":"error","error":"error executing trusted node DAO upgrade 999: error estimating gas needed: execution reverted: Invalid trusted node","txHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}
```